### PR TITLE
feat(config): add window-height and window-width parameters to config

### DIFF
--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -71,3 +71,11 @@ pub fn default_theme() -> String {
 pub fn default_font_size() -> f32 {
     16.
 }
+
+pub fn default_window_width() -> i32 {
+    600
+}
+
+pub fn default_window_height() -> i32 {
+    400
+}

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -39,6 +39,10 @@ impl Default for Developer {
 pub struct Config {
     #[serde(rename = "window-opacity", default = "default_window_opacity")]
     pub window_opacity: f32,
+    #[serde(rename = "window-width", default = "default_window_width")]
+    pub window_width: i32,
+    #[serde(rename = "window-height", default = "default_window_height")]
+    pub window_height: i32,
     #[serde(default = "Performance::default")]
     pub performance: Performance,
     #[serde(default = "default_shell")]
@@ -193,6 +197,8 @@ impl Default for Config {
             use_fork: default_use_fork(),
             env_vars: default_env_vars(),
             window_opacity: default_window_opacity(),
+            window_width: default_window_width(),
+            window_height: default_window_height(),
             performance: Performance::default(),
             padding_x: default_padding_x(),
             font_size: default_font_size(),

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -39,7 +39,7 @@ performance = "High"
 # It makes Rio look for the specified theme in the themes folder
 # (macos and linux: ~/.config/rio/themes/dracula.toml)
 # (windows: C:\Users\USER\AppData\Local\rio\themes\dracula.toml)
-# 
+#
 # Dracula theme code is available in:
 # https://github.com/dracula/rio-terminal
 theme = "dracula"
@@ -61,6 +61,18 @@ option_as_alt = 'both'
 # Only works for Windows / X11 / WebAssembly
 window-opacity = 0.5
 
+# Window Width
+#
+# window-width changes the intial window width.
+# Default: 600
+window-width = 1200
+
+# Window Height
+#
+# window-height changes the inital window height.
+# Default: 400
+window-height = 800
+
 # Shell
 #
 # You can set `shell.program` to the path of your favorite shell, e.g. `/bin/fish`.
@@ -70,7 +82,7 @@ window-opacity = 0.5
 #   - (macOS) user login shell
 #   - (Linux/BSD) user login shell
 #   - (Windows) powershell
-# 
+#
 shell = { program = "/bin/zsh", args = ["--login"] }
 
 # Startup directory

--- a/rio/src/screen/window/mod.rs
+++ b/rio/src/screen/window/mod.rs
@@ -8,10 +8,7 @@ pub const LOGO_ICON: &[u8; 119202] =
 pub const DEFAULT_MINIMUM_WINDOW_HEIGHT: i32 = 150;
 pub const DEFAULT_MINIMUM_WINDOW_WIDTH: i32 = 300;
 
-pub const DEFAULT_HEIGHT: i32 = 400;
-pub const DEFAULT_WIDTH: i32 = 600;
-
-pub fn create_window_builder(title: &str) -> WindowBuilder {
+pub fn create_window_builder(title: &str, config: &Rc<Config>) -> WindowBuilder {
     let image_icon = image::load_from_memory(LOGO_ICON).unwrap();
     let icon = Icon::from_rgba(
         image_icon.to_rgba8().into_raw(),
@@ -24,8 +21,8 @@ pub fn create_window_builder(title: &str) -> WindowBuilder {
     let mut window_builder = WindowBuilder::new()
         .with_title(title)
         .with_inner_size(winit::dpi::LogicalSize {
-            width: DEFAULT_WIDTH,
-            height: DEFAULT_HEIGHT,
+            width: config.window_width,
+            height: config.window_height,
         })
         .with_min_inner_size(winit::dpi::LogicalSize {
             width: DEFAULT_MINIMUM_WINDOW_WIDTH,

--- a/rio/src/sequencer.rs
+++ b/rio/src/sequencer.rs
@@ -42,7 +42,7 @@ impl SequencerWindow {
     ) -> Result<Self, Box<dyn Error>> {
         let proxy = event_loop.create_proxy();
         let event_proxy = EventProxy::new(proxy.clone());
-        let window_builder = create_window_builder("Rio");
+        let window_builder = create_window_builder("Rio", config);
         let winit_window = window_builder.build(event_loop).unwrap();
         let winit_window = configure_window(winit_window, config);
 
@@ -71,7 +71,7 @@ impl SequencerWindow {
         config: &Rc<config::Config>,
         window_name: &str,
     ) -> Self {
-        let window_builder = create_window_builder(window_name);
+        let window_builder = create_window_builder(window_name, config);
         let winit_window = window_builder.build(event_loop).unwrap();
         let winit_window = configure_window(winit_window, config);
 


### PR DESCRIPTION
This PR is an attempt to solve #143 


Allow setting the window height and width in the configuration file instead of hardcoded values. Fallback to 600x400 when not set. Tested in macos and KDE.

