### PR TITLE
add application id to window on x11/wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix unconditional query of xdg-portal settings on Wayland
 - Fix `Maximized` startup mode not filling the screen properly on GNOME Wayland.
 - Fix Default Vi key bindings for `Last`/`First` actions not working on X11/Wayland.
+- Set `app_id`/`WM_CLASS` property on Wayland/X11
 
 ## 0.0.12
 

--- a/rio/src/screen/constants.rs
+++ b/rio/src/screen/constants.rs
@@ -24,3 +24,9 @@ pub const DEADZONE_END_Y: f64 = -2.0;
 
 #[cfg(target_os = "macos")]
 pub const DEADZONE_START_X: f64 = 80.;
+
+#[cfg(all(
+    any(feature = "wayland", feature = "x11"),
+    not(any(target_os = "macos", windows))
+))]
+pub const APPLICATION_ID: &str = "rio";

--- a/rio/src/screen/window/mod.rs
+++ b/rio/src/screen/window/mod.rs
@@ -32,6 +32,20 @@ pub fn create_window_builder(title: &str, config: &Rc<Config>) -> WindowBuilder 
         .with_decorations(true)
         .with_window_icon(Some(icon));
 
+    #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
+    {
+        use crate::screen::constants::APPLICATION_ID;
+        use winit::platform::x11::WindowBuilderExtX11;
+        window_builder = window_builder.with_name(APPLICATION_ID, "");
+    }
+
+    #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
+    {
+        use crate::screen::constants::APPLICATION_ID;
+        use winit::platform::wayland::WindowBuilderExtWayland;
+        window_builder = window_builder.with_name(APPLICATION_ID, "");
+    }
+
     #[cfg(target_os = "macos")]
     {
         use winit::platform::macos::WindowBuilderExtMacOS;


### PR DESCRIPTION
Not sure how many apps integrate with this change, but at least tested that it enables Waybar on wayland to detect rio's desktop file and icon.