### PR TITLE
change .deb package name to avoid conflicts

### DIFF
--- a/rio/Cargo.toml
+++ b/rio/Cargo.toml
@@ -68,14 +68,14 @@ wayland = [
 ]
 
 [package.metadata.deb]
-name = "rio"
+name = "rio-term"
 maintainer = "Raphael Amorim <rapha850@gmail.com>"
 copyright = "2023, Raphael Amorim <rapha850@gmail.com>"
 depends = "$auto"
 section = "admin"
 priority = "optional"
 assets = [
-    ["../target/release/rio", "usr/local/bin/", "755"],
+    ["../target/release/rio-term", "usr/local/bin/", "755"],
     ["../misc/rio.desktop", "usr/share/applications/", "644"],
     ["../misc/rio.terminfo", "usr/share/info/", "644"],
     ["../misc/logo.svg", "usr/share/icons/hicolor/scalable/apps/rio.svg", "644"],


### PR DESCRIPTION
I don't know if I'm changing the right place, but looks like a good start!

Fix #173 