### PR TITLE
feat!: enable readline keybinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support lowercased action and fix overwrite for actions in custom key bindings.
 - Added `ReceiveChar` action for custom key bindings.
+- New default key bindings for Linux and Windows so that conflicts with readline key bindings are removed
 
 ## 0.0.16
 

--- a/docs/docs/key-bindings.md
+++ b/docs/docs/key-bindings.md
@@ -45,13 +45,13 @@ Close tab or quit: <span class="keyword">Command + W</span>
 
 ### Windows
 
-Copy: <span class="keyword">Control + C</span>
+Copy: <span class="keyword">Control + Shift + C</span>
 
-Paste: <span class="keyword">Control + V</span>
+Paste: <span class="keyword">Control + Shift + V</span>
 
-Create new window: <span class="keyword">Control + N</span>
+Create new window: <span class="keyword">Control + Shift + N</span>
 
-Create new tab: <span class="keyword">Control + T</span>
+Create new tab: <span class="keyword">Control + Shift + T</span>
 
 Move to next tab: <span class="keyword">Control + Shift + RightBracket (])</span>
 
@@ -65,17 +65,17 @@ Decrease font size: <span class="keyword">Control + Minus (-)</span>
 
 Reset font size: <span class="keyword">Control + 0</span>
 
-Close tab or quit: <span class="keyword">Control + W</span>
+Close tab or quit: <span class="keyword">Control + Shift + W</span>
 
 ### Linux and BSD
 
-Copy: <span class="keyword">Control + C</span>
+Copy: <span class="keyword">Control + Shift + C</span>
 
-Paste: <span class="keyword">Control + V</span>
+Paste: <span class="keyword">Control + Shift + V</span>
 
-Create new window: <span class="keyword">Control + N</span>
+Create new window: <span class="keyword">Control + Shift + N</span>
 
-Create new tab: <span class="keyword">Control + T</span>
+Create new tab: <span class="keyword">Control + Shift + T</span>
 
 Move to next tab: <span class="keyword">Control + Shift + RightBracket (])</span>
 
@@ -89,7 +89,7 @@ Decrease font size: <span class="keyword">Control + Minus (-)</span>
 
 Reset font size: <span class="keyword">Control + 0</span>
 
-Close tab or quit: <span class="keyword">Control + W</span>
+Close tab or quit: <span class="keyword">Control + Shift + W</span>
 
 ### Custom key bindings
 

--- a/rio/src/screen/bindings/mod.rs
+++ b/rio/src/screen/bindings/mod.rs
@@ -871,12 +871,12 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         "+",      ModifiersState::CONTROL;  Action::IncreaseFontSize;
         "-",          ModifiersState::CONTROL;  Action::DecreaseFontSize;
         "-", ModifiersState::CONTROL;  Action::DecreaseFontSize;
-        "n", ModifiersState::CONTROL; Action::WindowCreateNew;
-        "t", ModifiersState::CONTROL; Action::TabCreateNew;
+        "n", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::WindowCreateNew;
+        "t", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabCreateNew;
         Tab, ModifiersState::CONTROL; Action::TabSwitchNext;
         "[", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabSwitchNext;
         "]", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabSwitchPrev;
-        "w", ModifiersState::CONTROL; Action::TabCloseCurrent;
+        "w", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabCloseCurrent;
     )
 }
 
@@ -897,10 +897,10 @@ pub fn platform_key_bindings() -> Vec<KeyBinding> {
         "-",          ModifiersState::CONTROL;  Action::DecreaseFontSize;
         "-", ModifiersState::CONTROL;  Action::DecreaseFontSize;
         Enter, ModifiersState::ALT; Action::ToggleFullscreen;
-        "t", ModifiersState::CONTROL; Action::TabCreateNew;
+        "t", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabCreateNew;
         Tab, ModifiersState::CONTROL; Action::TabSwitchNext;
-        "w", ModifiersState::CONTROL; Action::TabCloseCurrent;
-        "n", ModifiersState::CONTROL; Action::WindowCreateNew;
+        "w", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabCloseCurrent;
+        "n", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::WindowCreateNew;
         "[", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabSwitchNext;
         "]", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabSwitchPrev;
     )


### PR DESCRIPTION
Some of the original rio default keybinds for Linux & Windows were
conflicting with the default keybinds of the readline library, thereby
prohibiting the use of those readline keybinds in programs that make use
of readline (most shells, most REPLs, most editors)

This change updates the default modifiers in rio from just `CONTROL`
to `CONTROL` + `SHIFT` for those keybinds that would otherwise conflict
with the readline ones.

Also, the documentation for default Copy & Paste keybinds on Windows and
Linux has been corrected.
