### PR TITLE
feat: option for ignoring theme foreground selection color

### DIFF
--- a/docs/docs/configuration-file.md
+++ b/docs/docs/configuration-file.md
@@ -49,6 +49,12 @@ performance = "High"
 #
 theme = "dracula"
 
+# Ignore theme selection foreground color
+#
+# Default is false
+#
+ignore_theme_selection_fg_color = false
+
 # Adaptive Theme
 #
 # Changes theme based on the system theme (light and dark)

--- a/rio-config/src/defaults.rs
+++ b/rio-config/src/defaults.rs
@@ -95,6 +95,12 @@ cursor = '▇'
 #
 blinking_cursor = true
 
+# Ignore theme selection foreground color
+#
+# Default is false
+#
+ignore_theme_selection_fg_color = false
+
 # Performance
 #
 # Set WGPU rendering performance

--- a/rio-config/src/lib.rs
+++ b/rio-config/src/lib.rs
@@ -357,7 +357,7 @@ impl Default for Config {
             use_fork: default_use_fork(),
             window: Window::default(),
             working_dir: default_working_dir(),
-            ignore_theme_selection_fg_color: true,
+            ignore_theme_selection_fg_color: false,
         }
     }
 }

--- a/rio-config/src/lib.rs
+++ b/rio-config/src/lib.rs
@@ -112,6 +112,8 @@ pub struct Config {
     pub developer: Developer,
     #[serde(default = "Bindings::default")]
     pub bindings: bindings::Bindings,
+    #[serde(default = "bool::default")]
+    pub ignore_theme_selection_fg_color: bool,
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -355,6 +357,7 @@ impl Default for Config {
             use_fork: default_use_fork(),
             window: Window::default(),
             working_dir: default_working_dir(),
+            ignore_theme_selection_fg_color: true,
         }
     }
 }

--- a/rio/src/screen/state.rs
+++ b/rio/src/screen/state.rs
@@ -317,6 +317,7 @@ impl State {
         stack
     }
 
+    #[inline]
     fn fg_square_to_color_array(&self, square: &Square) -> ColorArray {
         match square.fg {
             AnsiColor::Named(NamedColor::Black) => self.named_colors.black,


### PR DESCRIPTION
Using the same color when selecting as the existing foreground color can be desired, since the color can include information about the text. 

This PR aims to add a configuration option for easily turning that feature on. By default the option is disabled. 

With the option set to false: 

![image](https://github.com/raphamorim/rio/assets/56034786/a77547b9-3f60-49ef-a8ca-3664ec97bceb)

With the option set to true: 

![image](https://github.com/raphamorim/rio/assets/56034786/9c4413d4-d1a2-4233-a48e-339e327d4ac3)

I apologize if this is not a desired feature, or if it already exists. I looked around the project but was unable to find anything about this. 