### PR TITLE
refactor: enable CPU-specific optimizations on aarch64-apple-darwin

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,10 @@ rustflags = [
     "--cfg=web_sys_unstable_apis"
 ]
 runner = 'wasm-bindgen-test-runner'
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    # We can guarantee that this target will always run on a CPU with _at least_
+    # these capabilities, so let's optimize for them
+    "-Ctarget-cpu=apple-m1"
+]


### PR DESCRIPTION
See the comment for context, this should enable the compiler to produce better
code for ARM macs
