### PR TITLE
refactor: enable full optimizations for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ console_log = "0.2"
 console_error_panic_hook = "0.1.7"
 
 [profile.release]
-opt-level = "s"
+opt-level = 3
 lto = "thin"
 strip = true
 debug = 0


### PR DESCRIPTION
Instead of optimizing the release target for binary size (`s`), let's enable
full optimizations with `opt-level = 3`.
