### PR TITLE
sugarloaf: adding `repository` to `Cargo.toml`

### DIFF
--- a/sugarloaf/Cargo.toml
+++ b/sugarloaf/Cargo.toml
@@ -14,6 +14,7 @@ include = [
 ]
 description = "Sugarloaf is Rio rendering engine, desgined to be multiplatform. It is based on WebGPU, Rust library for Desktops and WebAssembly for Web (JavaScript). This project is created and maintaned for Rio terminal purposes but feel free to use it."
 documentation = "https://docs.rs/crate/sugarloaf/latest"
+repository = "https://github.com/raphamorim/rio/tree/main/sugarloaf"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
Currently [`sugarloaf`] hasn't a `repository` url as you can see in the image:
![image](https://github.com/raphamorim/rio/assets/50843046/22588fde-489e-4b60-ba52-a09b2ec28b64)

this should be fixed with this PR.

[`sugarloaf`]: https://crates.io/crates/sugarloaf