### PR TITLE
docs: fix typo in tagline

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Meet Rio | Rio Terminal',
-  tagline: 'A modern terminal for the 21th century.',
+  tagline: 'A modern terminal for the 21st century.',
   favicon: '/assets/rio-logo.ico',
   url: 'https://raphamorim.io',
   baseUrl: '/rio',


### PR DESCRIPTION
Small typo fix (21th -> 21st) in the website's tagline (unless that was intentional 🙂).

<img width="522" alt="image" src="https://github.com/raphamorim/rio/assets/12696894/040a7b04-73f2-4f20-a7bd-8f54055d317d">
