### PR TITLE
(docs)terminfo.md: add instructions to install when not cloned

### DIFF
--- a/docs/docs/install/terminfo.md
+++ b/docs/docs/install/terminfo.md
@@ -15,16 +15,9 @@ If it is not present already, you can install it globally with the following com
 
 When cloned locally, from the root of the repository run `sudo tic -xe rio misc/rio.terminfo`
 
-If has not cloned Rio locally:
+If the source code has not been cloned locally:
 
 ```bash
-curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
-sudo tic -xe rio rio.terminfo
-rm rio.terminfo
-# when cloned locally, from the root of the repository:
-sudo tic -xe rio misc/rio.terminfo
-
-# when not cloned locally
 curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
 sudo tic -xe rio rio.terminfo
 rm rio.terminfo

--- a/docs/docs/install/terminfo.md
+++ b/docs/docs/install/terminfo.md
@@ -11,7 +11,7 @@ If the following command returns without any errors, the rio terminfo is already
 infocmp rio
 ```
 
-If it is not present already, you can install it globally with the following command :
+If it is not present already, you can install it globally with the following command:
 
 ```bash
 # when cloned locally, from the root of the repository:

--- a/docs/docs/install/terminfo.md
+++ b/docs/docs/install/terminfo.md
@@ -11,8 +11,15 @@ If the following command returns without any errors, the rio terminfo is already
 infocmp rio
 ```
 
-If it is not present already, you can install it globally with the following command:
+If it is not present already, you can install it globally with the following command :
 
 ```bash
+# when cloned locally, from the root of the repository:
 sudo tic -xe rio misc/rio.terminfo
+
+# when not cloned locally
+curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
+sudo tic -xe rio rio.terminfo
+rm rio.terminfo
 ```
+

--- a/docs/docs/install/terminfo.md
+++ b/docs/docs/install/terminfo.md
@@ -13,7 +13,14 @@ infocmp rio
 
 If it is not present already, you can install it globally with the following command:
 
+When cloned locally, from the root of the repository run `sudo tic -xe rio misc/rio.terminfo`
+
+If has not cloned Rio locally:
+
 ```bash
+curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
+sudo tic -xe rio rio.terminfo
+rm rio.terminfo
 # when cloned locally, from the root of the repository:
 sudo tic -xe rio misc/rio.terminfo
 


### PR DESCRIPTION
The existing instructions assume, but don't state, that the rio repo has been cloned locally, and that the terminfo file is on disk.

This adds a note to clarify this requirement, and adds instructions on how to download the terminfo file, without cloning, and install it.