### PR TITLE
Use standard config directory

### DIFF
--- a/docs/docs/configuration-file.md
+++ b/docs/docs/configuration-file.md
@@ -5,9 +5,9 @@ language: 'en'
 
 The configuration should be the following paths otherwise Rio will use the default configuration.
 
-MacOS and Linux configuration file path is `~/.config/rio/config.toml`.
-
-Windows configuration file path is `C:\Users\USER\AppData\Local\rio\config.toml` (replace "USER" with your user name).
+- macOS: `~/Library/Application Support/rio/config.toml`
+- Linux: `$XDG_CONFIG_HOME/rio/config.toml` or `~/.config/rio/config.toml`
+- Windows: `C:\Users\USER\AppData\Local\rio\config.toml` (replace "USER" with your user name)
 
 Updates to the configuration file automatically triggers Rio to render the terminal with the new configuration.
 
@@ -57,7 +57,8 @@ performance = "High"
 # Themes
 #
 # Rio looks for a specified theme in the themes folder
-# (macos and linux: ~/.config/rio/themes/dracula.toml)
+# (macos: ~/Library/Application Support/rio/themes/dracula.toml)
+# (linux: $XDG_CONFIG_HOME/rio/themes/dracula.toml or ~/.config/rio/themes/dracula.toml)
 # (windows: C:\Users\USER\AppData\Local\rio\themes\dracula.toml)
 #
 # Example:
@@ -249,9 +250,9 @@ performance = "High"
 
 # Colors
 #
-# Defining colors in the configuration file will override any                                                                                                                     
-# colors set in the theme if you're using a theme. The default                                                                                                                  
-# configuration is without a theme.    
+# Defining colors in the configuration file will override any
+# colors set in the theme if you're using a theme. The default
+# configuration is without a theme.
 #
 # Example:
 # [colors]

--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -7,7 +7,7 @@ Rio has a configuration property called "theme". You can set the theme that you 
 
 In the example below, we will setup Dracula theme for Rio (https://github.com/dracula/rio-terminal).
 
-After download the `dracula.toml` file and moved it to folder called "themes" inside of the configuration folder, for example in macos/linux `~/.config/rio/themes/dracula.toml`.
+After download the `dracula.toml` file and moved it to folder called "themes" inside of the configuration folder, for example in linux `$XDG_CONFIG_HOME/rio/themes/dracula.toml`.
 
 ```toml
 theme = "dracula"
@@ -17,7 +17,7 @@ It should look like this:
 
 ![Dracula theme example](/assets/posts/0.0.5/dracula-nvim.png)
 
-Another example would be install [Lucario color scheme for Rio terminal](https://github.com/raphamorim/lucario/#rio-terminal). Moving the downloaded file to `~/.config/rio/themes/lucario.toml`
+Another example would be install [Lucario color scheme for Rio terminal](https://github.com/raphamorim/lucario/#rio-terminal). Moving the downloaded file to `$XDG_CONFIG_HOME/rio/themes/lucario.toml`
 
 ```toml
 theme = "lucario"

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -150,7 +150,8 @@ performance = "High"
 # Theme
 #
 # It makes Rio look for the specified theme in the themes folder
-# (macos and linux: ~/.config/rio/themes/dracula.toml)
+# (macos: ~/Library/Application Support/rio/themes/dracula.toml)
+# (linux: $XDG_CONFIG_HOME/rio/themes/dracula.toml or ~/.config/rio/themes/dracula.toml)
 # (windows: C:\Users\USER\AppData\Local\rio\themes\dracula.toml)
 #
 # Example:

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -239,7 +239,7 @@ impl Config {
 
     pub fn load() -> Self {
         let config_path_str = config_dir_path();
-        let path = format!("{config_path_str}/config.toml");
+        let path = config_file_path();
         if std::path::Path::new(&path).exists() {
             let content = std::fs::read_to_string(path).unwrap();
             match toml::from_str::<Config>(&content) {
@@ -270,7 +270,7 @@ impl Config {
 
     pub fn try_load() -> Result<Self, ConfigError> {
         let config_path_str = config_dir_path();
-        let path = format!("{config_path_str}/config.toml");
+        let path = config_file_path();
         if std::path::Path::new(&path).exists() {
             let content = std::fs::read_to_string(path).unwrap();
             match toml::from_str::<Config>(&content) {

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -129,20 +129,11 @@ pub struct Config {
     pub hide_cursor_when_typing: bool,
 }
 
-#[cfg(not(target_os = "windows"))]
 #[inline]
 pub fn config_dir_path() -> String {
-    let base_dir_buffer = dirs::home_dir().unwrap();
-    let home = base_dir_buffer.to_str().unwrap_or_default();
-    format!("{home}/.config/rio")
-}
-
-#[cfg(target_os = "windows")]
-#[inline]
-pub fn config_dir_path() -> String {
-    let base_dir_buffer = dirs::home_dir().unwrap();
-    let home = base_dir_buffer.to_str().unwrap_or_default();
-    format!("{home}/AppData/Local/rio")
+    let config_local_dir = dirs::config_local_dir().unwrap();
+    let rio_config_dir = config_local_dir.join("rio");
+    rio_config_dir.to_str().unwrap_or_default().to_string()
 }
 
 #[inline]


### PR DESCRIPTION
Use standard config directory defined in https://dirs.dev/
Ref [this](https://github.com/dirs-dev/dirs-rs#features):
Function name | Value on Linux/Redox | Value on Windows | Value on macOS
-- | -- | -- | --
`config_local_dir` | `Some($XDG_CONFIG_HOME)` or `Some($HOME/.config)` | `Some({FOLDERID_LocalAppData})` | `Some($HOME/Library/Application Support)`

This will be a breaking change for macOS and Linux users.
- Linux:
  `~/.config/rio/` to `~/.config/rio/` or `$XDG_CONFIG_HOME/rio/`
- macOS:
  `~/.config/rio/` to `~/Library/Application Support/rio/`

How can effectively announce breaking change?

---

It also includes bug fixes on Windows, along with some refactoring:
![image_2023-11-16_09-42-14](https://github.com/raphamorim/rio/assets/72999818/d5267ecd-e391-4dd1-ad30-083ec1cc90a1)
![image_2023-11-16_09-43-29](https://github.com/raphamorim/rio/assets/72999818/43c758f7-20a8-4c5a-8993-b4c7d5d4832e)
The welcome message now prints a valid path separator.