### PR TITLE
Some refactors

### DIFF
--- a/frontends/multi/src/router/settings/mod.rs
+++ b/frontends/multi/src/router/settings/mod.rs
@@ -56,11 +56,11 @@ impl Settings {
         Settings {
             default_file_path: rio_backend::config::config_file_path()
                 .to_str()
-                .unwrap()
+                .unwrap_or_default()
                 .to_string(),
             default_dir_path: rio_backend::config::config_dir_path()
                 .to_str()
-                .unwrap()
+                .unwrap_or_default()
                 .to_string(),
             config: rio_backend::config::Config::default(),
             inner: helpers::config_to_settings(

--- a/frontends/multi/src/router/settings/mod.rs
+++ b/frontends/multi/src/router/settings/mod.rs
@@ -5,7 +5,7 @@ use rio_backend::sugarloaf::font::loader::Database;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 pub struct SettingsState {
@@ -21,8 +21,8 @@ pub struct Setting {
 }
 
 pub struct Settings {
-    pub default_file_path: String,
-    pub default_dir_path: String,
+    pub default_file_path: PathBuf,
+    pub default_dir_path: PathBuf,
     pub config: rio_backend::config::Config,
     pub inner: HashMap<usize, Setting>,
     pub state: SettingsState,
@@ -54,14 +54,8 @@ impl Settings {
         font_families.push(String::from("Cascadia Mono (built-in)"));
 
         Settings {
-            default_file_path: rio_backend::config::config_file_path()
-                .to_str()
-                .unwrap_or_default()
-                .to_string(),
-            default_dir_path: rio_backend::config::config_dir_path()
-                .to_str()
-                .unwrap_or_default()
-                .to_string(),
+            default_file_path: rio_backend::config::config_file_path(),
+            default_dir_path: rio_backend::config::config_dir_path(),
             config: rio_backend::config::Config::default(),
             inner: helpers::config_to_settings(
                 rio_backend::config::Config::load(),
@@ -156,8 +150,7 @@ impl Settings {
     pub fn write_current_config_into_file(&mut self) {
         let config = helpers::settings_to_config(&self.inner);
         if let Ok(config_str) = config.to_string() {
-            let file = Path::new(&self.default_file_path);
-            match File::create(file) {
+            match File::create(&self.default_file_path) {
                 Err(err_message) => {
                     log::error!("could not open config file: {err_message}")
                 }
@@ -175,27 +168,34 @@ impl Settings {
 
     #[inline]
     pub fn create_file(&self) {
-        let file = Path::new(&self.default_file_path);
-        if file.exists() {
+        if self.default_file_path.exists() {
             return;
         }
 
         match std::fs::create_dir_all(&self.default_dir_path) {
             Ok(_) => {
-                log::info!("configuration path created {}", self.default_dir_path);
+                log::info!(
+                    "configuration path created {}",
+                    self.default_dir_path.display()
+                );
             }
             Err(err_message) => {
                 log::error!("could not create config directory: {err_message}");
             }
         }
 
-        let display = file.display();
-        match File::create(file) {
+        match File::create(&self.default_file_path) {
             Err(err_message) => {
-                log::error!("could not create config file {display}: {err_message}")
+                log::error!(
+                    "could not create config file {}: {err_message}",
+                    self.default_file_path.display()
+                )
             }
             Ok(mut created_file) => {
-                log::info!("configuration file created {}", self.default_file_path);
+                log::info!(
+                    "configuration file created {}",
+                    self.default_file_path.display()
+                );
 
                 if let Err(err_message) = writeln!(
                     created_file,

--- a/frontends/multi/src/router/settings/mod.rs
+++ b/frontends/multi/src/router/settings/mod.rs
@@ -54,8 +54,14 @@ impl Settings {
         font_families.push(String::from("Cascadia Mono (built-in)"));
 
         Settings {
-            default_file_path: rio_backend::config::config_file_path(),
-            default_dir_path: rio_backend::config::config_dir_path(),
+            default_file_path: rio_backend::config::config_file_path()
+                .to_str()
+                .unwrap()
+                .to_string(),
+            default_dir_path: rio_backend::config::config_dir_path()
+                .to_str()
+                .unwrap()
+                .to_string(),
             config: rio_backend::config::Config::default(),
             inner: helpers::config_to_settings(
                 rio_backend::config::Config::load(),

--- a/frontends/multi/src/router/settings/screen.rs
+++ b/frontends/multi/src/router/settings/screen.rs
@@ -55,7 +55,7 @@ pub fn render(sugarloaf: &mut Sugarloaf, settings: &crate::router::settings::Set
         (10., sugarloaf.layout.margin.top_y + 80.),
         format!(
             "{} • v{}",
-            settings.default_file_path,
+            settings.default_file_path.display(),
             env!("CARGO_PKG_VERSION")
         ),
         FONT_ID_BUILTIN,

--- a/frontends/multi/src/router/welcome.rs
+++ b/frontends/multi/src/router/welcome.rs
@@ -116,15 +116,13 @@ pub fn screen(sugarloaf: &mut Sugarloaf) {
 }
 
 #[inline]
-#[cfg(target_os = "macos")]
 fn welcome_content() -> String {
-    format!("Your configuration file will be created in\n{}\n\nTo open settings menu use\n\"Command\" + \",\" (comma)\n\n\n\nMore info in raphamorim.io/rio/docs
-    ", rio_backend::config::config_file_path().to_str().unwrap())
-}
+    #[cfg(target_os = "macos")]
+    let shortcut = "\"Command\" + \",\" (comma)";
 
-#[inline]
-#[cfg(not(target_os = "macos"))]
-fn welcome_content() -> String {
-    format!("Your configuration file will be created in\n{}\n\nTo open settings menu use\n\"Control\" + \"Shift\" + \",\" (comma)\n\n\n\nMore info in raphamorim.io/rio/docs
-    ", rio_backend::config::config_file_path().to_str().unwrap())
+    #[cfg(not(target_os = "macos"))]
+    let shortcut = "\"Control\" + \"Shift\" + \",\" (comma)";
+
+    format!("Your configuration file will be created in\n{}\n\nTo open settings menu use\n{}\n\n\n\nMore info in raphamorim.io/rio/docs
+    ", rio_backend::config::config_file_path().to_str().unwrap(), shortcut)
 }

--- a/frontends/multi/src/router/welcome.rs
+++ b/frontends/multi/src/router/welcome.rs
@@ -119,12 +119,12 @@ pub fn screen(sugarloaf: &mut Sugarloaf) {
 #[cfg(target_os = "macos")]
 fn welcome_content() -> String {
     format!("Your configuration file will be created in\n{}\n\nTo open settings menu use\n\"Command\" + \",\" (comma)\n\n\n\nMore info in raphamorim.io/rio/docs
-    ", rio_backend::config::config_file_path())
+    ", rio_backend::config::config_file_path().to_str().unwrap())
 }
 
 #[inline]
 #[cfg(not(target_os = "macos"))]
 fn welcome_content() -> String {
     format!("Your configuration file will be created in\n{}\n\nTo open settings menu use\n\"Control\" + \"Shift\" + \",\" (comma)\n\n\n\nMore info in raphamorim.io/rio/docs
-    ", rio_backend::config::config_file_path())
+    ", rio_backend::config::config_file_path().to_str().unwrap())
 }

--- a/frontends/multi/src/router/welcome.rs
+++ b/frontends/multi/src/router/welcome.rs
@@ -124,5 +124,5 @@ fn welcome_content() -> String {
     let shortcut = "\"Control\" + \"Shift\" + \",\" (comma)";
 
     format!("Your configuration file will be created in\n{}\n\nTo open settings menu use\n{}\n\n\n\nMore info in raphamorim.io/rio/docs
-    ", rio_backend::config::config_file_path().to_str().unwrap(), shortcut)
+    ", rio_backend::config::config_file_path().to_str().unwrap_or_default(), shortcut)
 }

--- a/frontends/multi/src/router/welcome.rs
+++ b/frontends/multi/src/router/welcome.rs
@@ -124,5 +124,5 @@ fn welcome_content() -> String {
     let shortcut = "\"Control\" + \"Shift\" + \",\" (comma)";
 
     format!("Your configuration file will be created in\n{}\n\nTo open settings menu use\n{}\n\n\n\nMore info in raphamorim.io/rio/docs
-    ", rio_backend::config::config_file_path().to_str().unwrap_or_default(), shortcut)
+    ", rio_backend::config::config_file_path().display(), shortcut)
 }

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -13,6 +13,7 @@ use colors::Colors;
 use log::warn;
 use serde::{Deserialize, Serialize};
 use std::default::Default;
+use std::path::PathBuf;
 use sugarloaf::font::fonts::SugarloafFonts;
 use theme::{AdaptiveColors, AdaptiveTheme, Theme};
 
@@ -131,24 +132,21 @@ pub struct Config {
 
 #[cfg(not(target_os = "windows"))]
 #[inline]
-pub fn config_dir_path() -> String {
-    let base_dir_buffer = dirs::home_dir().unwrap();
-    let home = base_dir_buffer.to_str().unwrap_or_default();
-    format!("{home}/.config/rio")
+pub fn config_dir_path() -> PathBuf {
+    let home_dir = dirs::home_dir().unwrap();
+    home_dir.join(".config").join("rio")
 }
 
 #[cfg(target_os = "windows")]
 #[inline]
-pub fn config_dir_path() -> String {
-    let base_dir_buffer = dirs::home_dir().unwrap();
-    let home = base_dir_buffer.to_str().unwrap_or_default();
-    format!("{home}/AppData/Local/rio")
+pub fn config_dir_path() -> PathBuf {
+    let home_dir = dirs::home_dir().unwrap();
+    home_dir.join("AppData").join("Local").join("rio")
 }
 
 #[inline]
-pub fn config_file_path() -> String {
-    let config_dir_path_str = config_dir_path();
-    format!("{config_dir_path_str}/config.toml")
+pub fn config_file_path() -> PathBuf {
+    config_dir_path().join("config.toml")
 }
 
 #[inline]
@@ -179,11 +177,8 @@ impl Config {
                         return Ok(decoded);
                     }
 
-                    let tmp = std::env::temp_dir()
-                        .to_str()
-                        .unwrap_or_default()
-                        .to_string();
-                    let path = format!("{tmp}/{theme}.toml");
+                    let tmp = std::env::temp_dir();
+                    let path = tmp.join(theme).with_extension("toml");
                     if let Ok(loaded_theme) = Config::load_theme(&path) {
                         decoded.colors = loaded_theme.colors;
                     } else {
@@ -192,7 +187,7 @@ impl Config {
 
                     if let Some(adaptive_theme) = &decoded.adaptive_theme {
                         let light_theme = &adaptive_theme.light;
-                        let path = format!("{tmp}/{light_theme}.toml");
+                        let path = tmp.join(light_theme).with_extension("toml");
                         let mut adaptive_colors = AdaptiveColors {
                             dark: None,
                             light: None,
@@ -206,7 +201,7 @@ impl Config {
                         }
 
                         let dark_theme = &adaptive_theme.dark;
-                        let path = format!("{tmp}/{dark_theme}.toml");
+                        let path = tmp.join(dark_theme).with_extension("toml");
                         if let Ok(dark_loaded_theme) = Config::load_theme(&path) {
                             adaptive_colors.dark = Some(dark_loaded_theme.colors);
                             println!("carregou");
@@ -230,8 +225,8 @@ impl Config {
         }
     }
 
-    fn load_theme(path: &str) -> Result<Theme, String> {
-        if std::path::Path::new(&path).exists() {
+    fn load_theme(path: &PathBuf) -> Result<Theme, String> {
+        if path.exists() {
             let content = std::fs::read_to_string(path).unwrap();
             match toml::from_str::<Theme>(&content) {
                 Ok(decoded) => Ok(decoded),
@@ -247,9 +242,9 @@ impl Config {
     }
 
     pub fn load() -> Self {
-        let config_path_str = config_dir_path();
+        let config_path = config_dir_path();
         let path = config_file_path();
-        if std::path::Path::new(&path).exists() {
+        if path.exists() {
             let content = std::fs::read_to_string(path).unwrap();
             match toml::from_str::<Config>(&content) {
                 Ok(mut decoded) => {
@@ -258,7 +253,10 @@ impl Config {
                         return decoded;
                     }
 
-                    let path = format!("{config_path_str}/themes/{theme}.toml");
+                    let path = config_path
+                        .join("themes")
+                        .join(theme)
+                        .with_extension("toml");
                     if let Ok(loaded_theme) = Config::load_theme(&path) {
                         decoded.colors = loaded_theme.colors;
                     } else {
@@ -278,16 +276,16 @@ impl Config {
     }
 
     pub fn try_load() -> Result<Self, ConfigError> {
-        let config_path_str = config_dir_path();
+        let config_path = config_dir_path();
         let path = config_file_path();
         if std::path::Path::new(&path).exists() {
             let content = std::fs::read_to_string(path).unwrap();
             match toml::from_str::<Config>(&content) {
                 Ok(mut decoded) => {
                     let theme = &decoded.theme;
-                    let theme_path = format!("{config_path_str}/themes");
+                    let theme_path = config_path.join("themes");
                     if !theme.is_empty() {
-                        let path = format!("{theme_path}/{theme}.toml");
+                        let path = theme_path.join(theme).with_extension("toml");
                         match Config::load_theme(&path) {
                             Ok(loaded_theme) => {
                                 decoded.colors = loaded_theme.colors;
@@ -305,7 +303,7 @@ impl Config {
                         };
 
                         let light_theme = &adaptive_theme.light;
-                        let path = format!("{theme_path}/{light_theme}.toml");
+                        let path = theme_path.join(light_theme).with_extension("toml");
                         match Config::load_theme(&path) {
                             Ok(light_loaded_theme) => {
                                 adaptive_colors.light = Some(light_loaded_theme.colors)
@@ -317,7 +315,7 @@ impl Config {
                         }
 
                         let dark_theme = &adaptive_theme.dark;
-                        let path = format!("{theme_path}/{dark_theme}.toml");
+                        let path = theme_path.join(dark_theme).with_extension("toml");
                         match Config::load_theme(&path) {
                             Ok(dark_loaded_theme) => {
                                 adaptive_colors.dark = Some(dark_loaded_theme.colors)

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -248,7 +248,7 @@ impl Config {
 
     pub fn load() -> Self {
         let config_path_str = config_dir_path();
-        let path = format!("{config_path_str}/config.toml");
+        let path = config_file_path();
         if std::path::Path::new(&path).exists() {
             let content = std::fs::read_to_string(path).unwrap();
             match toml::from_str::<Config>(&content) {
@@ -279,7 +279,7 @@ impl Config {
 
     pub fn try_load() -> Result<Self, ConfigError> {
         let config_path_str = config_dir_path();
-        let path = format!("{config_path_str}/config.toml");
+        let path = config_file_path();
         if std::path::Path::new(&path).exists() {
             let content = std::fs::read_to_string(path).unwrap();
             match toml::from_str::<Config>(&content) {


### PR DESCRIPTION
Refactor some codes:
- Apply SSOT for config file path
  It also includes bug fixes on Windows:
  ![image_2023-11-16_09-42-14](https://github.com/raphamorim/rio/assets/72999818/d5267ecd-e391-4dd1-ad30-083ec1cc90a1)
  ![image_2023-11-16_09-43-29](https://github.com/raphamorim/rio/assets/72999818/43c758f7-20a8-4c5a-8993-b4c7d5d4832e)
  The welcome message now prints a valid path separator.
- Use `PathBuf` noramlly -> Reduce type conversions.
- Merge `welcome_content()` functions

If there's a refactoring you think is unnecessary, let me know and I'll remove it.