### PR TITLE
docs(config): mention blur requires restart

### DIFF
--- a/docs/docs/configuration-file.md
+++ b/docs/docs/configuration-file.md
@@ -128,7 +128,7 @@ option-as-alt = 'left'
 - `background-opacity` Set background opacity.
 	- Default: `1.0`.
 
-- `blur` Set blur on background.
+- `blur` Set blur on the window background. Changing this config requires restarting Rio to take effect.
 	- Default: `false`.
 
 - `background-image` Set an image as background.

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -201,7 +201,7 @@ performance = "High"
 #
 # • foreground-opacity - Set foreground opacity
 #
-# • blur - Set background blur
+# • blur - Set blur on the window background. Changing this config requires restarting Rio to take effect.
 #
 # Example:
 # [window]


### PR DESCRIPTION
Mention in the configuration docs that enabling/disabling background blur requires restarting Rio to take effect