### PR TITLE
feat(i18n): add spanish translation to landing page

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -12,6 +12,7 @@ const tagline = {
   en: 'A modern terminal for the 21st century.',
   ko: '21세기의 현대적인 터미널.',
   'pt-br': 'Terminal moderno para o século 21',
+  es: 'Una terminal moderna para el siglo 21.',
 };
 
 /** @type {import('@docusaurus/types').Config} */
@@ -27,7 +28,7 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   i18n: {
     defaultLocale,
-    locales: ['en', 'ko', 'pt-br'],
+    locales: ['en', 'ko', 'pt-br', 'es'],
   },
 
   headTags: [

--- a/docs/i18n/es/code.json
+++ b/docs/i18n/es/code.json
@@ -1,0 +1,35 @@
+{
+  "Install": {
+    "message": "Instalación"
+  },
+
+  "Loved by many engineers": {
+    "message": "Amada por muchos"
+  },
+
+  "home.features.fast-and-fast.title": {
+    "message": "Alto rendimiento"
+  },
+  "home.features.fast-and-fast.description": {
+    "message": "Rio hace uso de las últimas tecnologías como Rust y arquitecturas de renderizado avanzadas para lograr un rendimiento veloz."
+  },
+  "home.features.24-bit-true-color.title": {
+    "message": "Color verdadero de 24 bits"
+  },
+  "home.features.24-bit-true-color.description": {
+    "message": "Terminales normales están limitadas a 256 colores, Rio soporta \"color verdadero\" con una profundidad de 24 bits, pudiendo mostrar hasta 16 millones de colores distintos."
+  },
+  "home.features.images-in-terminal.title": {
+    "message": "Imágenes en la terminal"
+  },
+  "home.features.images-in-terminal.description": {
+    "message": "Rio puede mostrar imágenes en la terminal usando los protocolos de imágen de iTerm2 y Kitty."
+  },
+  "home.features.cross-platform.title": {
+    "message": "Multi-plataforma"
+  },
+  "home.features.cross-platform.description": {
+    "message": "Rio es una aplicación multi-plataforma que corre en Windows, macOS, Linux y FreeBSD."
+  },
+  "home.footer.install": { "message": "Instalación" }
+}

--- a/docs/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/es/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,26 @@
+{
+  "item.label.Install": {
+    "message": "Instalación",
+    "description": "Navbar item with label Install"
+  },
+  "item.label.Config": {
+    "message": "Configuración",
+    "description": "Navbar item with label Config"
+  },
+  "item.label.Features": {
+    "message": "Funcionalidades",
+    "description": "Navbar item with label Features"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.Discord": {
+    "message": "Discord",
+    "description": "Navbar item with label Discord"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}


### PR DESCRIPTION
This PR adds the Spanish translation to the landing page :) 

There are still some texts that are not translated, like the footer and the page title; but this is common to the other translations (because these seem to be "hard coded"), so I figured that I should open the PR with what I have until we can translate the rest.