### PR TITLE
fix: remove duplicate kitty backspace keybinds

### DIFF
--- a/frontends/cross-winit/src/screen/bindings/mod.rs
+++ b/frontends/cross-winit/src/screen/bindings/mod.rs
@@ -750,9 +750,6 @@ pub fn default_key_bindings(
             Key::Named(F4), ~BindingMode::VI, ~BindingMode::ALL_KEYS_AS_ESC, ~BindingMode::DISAMBIGUATE_KEYS; Action::Esc("\x1bOS".into());
             Key::Named(Tab), ModifiersState::SHIFT, ~BindingMode::VI,   ~BindingMode::ALL_KEYS_AS_ESC; Action::Esc("\x1b[Z".into());
             Key::Named(Tab), ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::VI, ~BindingMode::ALL_KEYS_AS_ESC; Action::Esc("\x1b\x1b[Z".into());
-            Key::Named(Backspace), ~BindingMode::VI, ~BindingMode::ALL_KEYS_AS_ESC; Action::Esc("\x7f".into());
-            Key::Named(Backspace), ModifiersState::ALT, ~BindingMode::VI, ~BindingMode::ALL_KEYS_AS_ESC; Action::Esc("\x1b\x7f".into());
-            Key::Named(Backspace), ModifiersState::SHIFT, ~BindingMode::VI, ~BindingMode::ALL_KEYS_AS_ESC; Action::Esc("\x7f".into());
         ));
     }
 


### PR DESCRIPTION
The deleted keybindings were duplicates of https://github.com/raphamorim/rio/blob/208e913ed727c19e61847638f4ff226e37a0a189/frontends/cross-winit/src/screen/bindings/mod.rs#L742-L744 with the only difference between them being the spaces.

After deleting the lines I no longer had any issues with backspace deleting 2 characters when Kitty protocol is turned on (#344).

Before with Kitty `false`:
![Before with Kitty false](https://github.com/raphamorim/rio/assets/56034786/010439a6-b66b-489c-a1f9-48e6fb4b7676)

Before with Kitty `true`:
![Before with Kitty true](https://github.com/raphamorim/rio/assets/56034786/b443e073-a0e6-494c-984d-1bd28690ce8e)

After with Kitty `false`:

![After with Kitty false](https://github.com/raphamorim/rio/assets/56034786/5634544e-e586-4e49-9e1f-c25be3a847ba)

After with Kitty `true`:

![After with Kitty true](https://github.com/raphamorim/rio/assets/56034786/498787d5-3a7f-4d3d-97da-695b9c00dbd9)
