### PR TITLE
fix: trim unix program name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- TBD
+- Fixed bug where color automation did not work on Linux because of line ending character.
 
 ## 0.0.30
 

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -887,6 +887,7 @@ pub fn foreground_process_name(main_fd: RawFd, shell_pid: u32) -> String {
     #[cfg(not(target_os = "macos"))]
     let name = match std::fs::read(comm_path) {
         Ok(comm_str) => String::from_utf8_lossy(&comm_str)
+            .trim_end()
             .parse()
             .unwrap_or_default(),
         Err(..) => String::from(""),


### PR DESCRIPTION
On Linux the program name ends with `\n` which breaks color automation.

# Without trimming:

## CollapsedTab

![without trimming - CollapsedTab](https://github.com/raphamorim/rio/assets/56034786/22f77809-4918-4f85-b47b-daf435c9a7bd)

## BottomTab

![without trimming - BottomTab](https://github.com/raphamorim/rio/assets/56034786/e8a2614e-7eb0-468b-adbc-31dc02a942b2)

## TopTab

![without trimming - TopTab](https://github.com/raphamorim/rio/assets/56034786/32df1e31-c2b4-4870-814a-28e909f33256)

## Breadcrumb

![without trimming - Breadcrumb](https://github.com/raphamorim/rio/assets/56034786/a84d7c9d-c9b1-4435-9b42-56c7103060ae)

# With trimming:

## CollapsedTab

![With trimming - CollapsedTab](https://github.com/raphamorim/rio/assets/56034786/f53b6b20-6154-403b-b4ca-d71843041b46)

## BottomTab

![With trimming - BottomTab](https://github.com/raphamorim/rio/assets/56034786/fac7fe8a-07ae-4028-bf90-ce8e660aa00a)

## TopTab

![With trimming - TopTab](https://github.com/raphamorim/rio/assets/56034786/92274ee1-bd90-497c-a41a-0f10a4323bee)

## Breadcrumb

![With trimming - Breadcrumb](https://github.com/raphamorim/rio/assets/56034786/55390574-3b57-46cc-9dda-73d982a2a473)
