### PR TITLE
fix: update padding top on config change

### DIFF
--- a/frontends/cross-winit/src/screen/mod.rs
+++ b/frontends/cross-winit/src/screen/mod.rs
@@ -63,6 +63,34 @@ const MIN_SELECTION_SCROLLING_HEIGHT: f32 = 5.;
 /// Number of pixels for increasing the selection scrolling speed factor by one.
 const SELECTION_SCROLLING_STEP: f32 = 10.;
 
+#[inline]
+fn padding_top_from_config(config: &Rc<rio_backend::config::Config>) -> f32 {
+    #[cfg(not(target_os = "macos"))]
+    {
+        if config.navigation.is_placed_on_top() {
+            return constants::PADDING_Y_WITH_TAB_ON_TOP;
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if config.navigation.is_native() {
+            return 0.0;
+        }
+    }
+
+    constants::PADDING_Y
+}
+
+#[inline]
+fn padding_bottom_from_config(config: &Rc<rio_backend::config::Config>) -> f32 {
+    if config.navigation.is_placed_on_bottom() {
+        config.fonts.size
+    } else {
+        0.0
+    }
+}
+
 pub struct Screen {
     bindings: bindings::KeyBindings,
     mouse_bindings: Vec<MouseBinding>,
@@ -95,27 +123,9 @@ impl Screen {
             rio_backend::config::Performance::Low => wgpu::PowerPreference::LowPower,
         };
 
-        let mut padding_y_bottom = 0.0;
-        if config.navigation.is_placed_on_bottom() {
-            padding_y_bottom += config.fonts.size
-        }
+        let padding_y_bottom = padding_bottom_from_config(config);
 
-        #[allow(unused_mut)]
-        let mut padding_y_top = constants::PADDING_Y;
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            if config.navigation.is_placed_on_top() {
-                padding_y_top = constants::PADDING_Y_WITH_TAB_ON_TOP;
-            }
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            if config.navigation.is_native() {
-                padding_y_top = 0.0;
-            }
-        }
+        let padding_y_top = padding_top_from_config(config);
 
         let sugarloaf_layout = SugarloafLayout::new(
             size.width as f32,
@@ -271,15 +281,15 @@ impl Screen {
             return;
         }
 
-        let mut padding_y_bottom = 0.0;
-        if config.navigation.is_placed_on_bottom() {
-            padding_y_bottom += config.fonts.size
-        }
+        let padding_y_bottom = padding_bottom_from_config(config);
+
+        let padding_y_top = padding_top_from_config(config);
 
         self.sugarloaf.layout.recalculate(
             config.fonts.size,
             config.line_height,
             config.padding_x,
+            padding_y_top,
             padding_y_bottom,
         );
 

--- a/frontends/cross-winit/src/screen/mod.rs
+++ b/frontends/cross-winit/src/screen/mod.rs
@@ -64,7 +64,7 @@ const MIN_SELECTION_SCROLLING_HEIGHT: f32 = 5.;
 const SELECTION_SCROLLING_STEP: f32 = 10.;
 
 #[inline]
-fn padding_top_from_config(config: &Rc<rio_backend::config::Config>) -> f32 {
+fn padding_top_from_config(config: &rio_backend::config::Config) -> f32 {
     #[cfg(not(target_os = "macos"))]
     {
         if config.navigation.is_placed_on_top() {
@@ -83,7 +83,7 @@ fn padding_top_from_config(config: &Rc<rio_backend::config::Config>) -> f32 {
 }
 
 #[inline]
-fn padding_bottom_from_config(config: &Rc<rio_backend::config::Config>) -> f32 {
+fn padding_bottom_from_config(config: &rio_backend::config::Config) -> f32 {
     if config.navigation.is_placed_on_bottom() {
         config.fonts.size
     } else {

--- a/sugarloaf/src/layout/mod.rs
+++ b/sugarloaf/src/layout/mod.rs
@@ -203,6 +203,7 @@ impl SugarloafLayout {
         font_size: f32,
         line_height: f32,
         margin_x: f32,
+        margin_y_top: f32,
         margin_y_bottom: f32,
     ) -> &mut Self {
         let mut should_apply_changes = false;
@@ -224,6 +225,11 @@ impl SugarloafLayout {
 
         if self.margin.bottom_y != margin_y_bottom {
             self.margin.bottom_y = margin_y_bottom;
+            should_apply_changes = true;
+        }
+
+        if self.margin.top_y != margin_y_top {
+            self.margin.top_y = margin_y_top;
             should_apply_changes = true;
         }
 


### PR DESCRIPTION
Currently the padding top is checked on startup, but not when the config is changed, which means going from `BottomTab` to `TopTab` will result in the navigation overlapping the first line (left @ f26f633):

![BottomTab to TopTab](https://github.com/raphamorim/rio/assets/56034786/53dcfde2-56cf-4d49-877e-db8ab7d1e2b1)

`TopTab` to `BottomTab` results in a "wasted" line:

![TopTab to BottomTab](https://github.com/raphamorim/rio/assets/56034786/1e264cde-0f6b-473f-943b-9ac04fb2563b)

This should fix it :)
