### PR TITLE
refactor(cross-winit): remove unnecessary cloning of key events

### DIFF
--- a/frontends/cross-winit/src/screen/bindings/kitty_keyboard_protocol.rs
+++ b/frontends/cross-winit/src/screen/bindings/kitty_keyboard_protocol.rs
@@ -8,7 +8,7 @@ use winit::keyboard::KeyLocation;
 use winit::keyboard::NamedKey::*;
 
 #[inline(never)]
-pub fn build_key_sequence(key: KeyEvent, mods: ModifiersState, mode: Mode) -> Vec<u8> {
+pub fn build_key_sequence(key: &KeyEvent, mods: ModifiersState, mode: Mode) -> Vec<u8> {
     let mut modifiers = 0;
     if mods.shift_key() {
         modifiers |= 0b0001;
@@ -248,7 +248,7 @@ pub fn build_key_sequence(key: KeyEvent, mods: ModifiersState, mode: Mode) -> Ve
     if mode.contains(Mode::KEYBOARD_REPORT_ASSOCIATED_TEXT)
         && key.state != ElementState::Released
     {
-        if let Some(text) = key.text {
+        if let Some(text) = &key.text {
             let mut codepoints = text.chars().map(u32::from);
             if let Some(codepoint) = codepoints.next() {
                 payload.push_str(&format!(";{codepoint}"));

--- a/frontends/cross-winit/src/screen/context.rs
+++ b/frontends/cross-winit/src/screen/context.rs
@@ -57,11 +57,8 @@ impl ContextManagerTitles {
     ) -> ContextManagerTitles {
         let last_title_update = Instant::now();
         ContextManagerTitles {
-            titles: HashMap::from([(
-                idx,
-                [program.to_owned(), terminal_title.to_owned()],
-            )]),
             key: format!("{}{}{};", idx, program, terminal_title),
+            titles: HashMap::from([(idx, [program, terminal_title])]),
             last_title_update,
         }
     }
@@ -431,7 +428,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                         let window_title = if terminal_title.is_empty() {
                             program.to_owned()
                         } else {
-                            format!("{} ({})", terminal_title, program).to_owned()
+                            format!("{} ({})", terminal_title, program)
                         };
 
                         self.event_proxy

--- a/frontends/cross-winit/src/screen/mod.rs
+++ b/frontends/cross-winit/src/screen/mod.rs
@@ -494,9 +494,7 @@ impl Screen {
                     Key::Named(NamedKey::Delete) => [b'\x7f'].as_slice().into(),
                     Key::Named(NamedKey::Escape) => [b'\x1b'].as_slice().into(),
                     _ => bindings::kitty_keyboard_protocol::build_key_sequence(
-                        key.to_owned(),
-                        mods,
-                        mode,
+                        key, mods, mode,
                     )
                     .into(),
                 };
@@ -810,11 +808,7 @@ impl Screen {
                 bytes
             } else {
                 // Otherwise we should build the key sequence for the given input.
-                bindings::kitty_keyboard_protocol::build_key_sequence(
-                    key.to_owned(),
-                    mods,
-                    mode,
-                )
+                bindings::kitty_keyboard_protocol::build_key_sequence(key, mods, mode)
             }
         };
 


### PR DESCRIPTION
I know it is pretty minor, but while jumping around in the code I noticed a few places cloning could be removed. 

Feel free to close the PR if I am mistaken, or there is a good reason for it :) 