### PR TITLE
fix: use explicit lifetime for const str

### DIFF
--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -29,14 +29,14 @@ impl Default for NavigationMode {
 }
 
 impl NavigationMode {
-    const PLAIN_STR: &str = "Plain";
-    const COLLAPSED_TAB_STR: &str = "CollapsedTab";
-    const TOP_TAB_STR: &str = "TopTab";
-    const BOTTOM_TAB_STR: &str = "BottomTab";
+    const PLAIN_STR: &'static str = "Plain";
+    const COLLAPSED_TAB_STR: &'static str = "CollapsedTab";
+    const TOP_TAB_STR: &'static str = "TopTab";
+    const BOTTOM_TAB_STR: &'static str = "BottomTab";
     #[cfg(target_os = "macos")]
-    const NATIVE_TAB_STR: &str = "NativeTab";
+    const NATIVE_TAB_STR: &'static str = "NativeTab";
     #[cfg(not(windows))]
-    const BREADCRUMB_STR: &str = "Breadcrumb";
+    const BREADCRUMB_STR: &'static str = "Breadcrumb";
 
     pub fn as_str(&self) -> &'static str {
         match self {


### PR DESCRIPTION
Fixes the following compiler warnings that I got while building the latest version of `rio` for Arch Linux:

```
warning: `&` without an explicit lifetime name cannot be used here
  --> rio-backend/src/config/navigation.rs:32:22
   |
32 |     const PLAIN_STR: &str = "Plain";
   |                      ^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
   = note: `#[warn(elided_lifetimes_in_associated_constant)]` on by default
help: use the `'static` lifetime
   |
32 |     const PLAIN_STR: &'static str = "Plain";
   |                       +++++++

warning: `&` without an explicit lifetime name cannot be used here
  --> rio-backend/src/config/navigation.rs:33:30
   |
33 |     const COLLAPSED_TAB_STR: &str = "CollapsedTab";
   |                              ^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
help: use the `'static` lifetime
   |
33 |     const COLLAPSED_TAB_STR: &'static str = "CollapsedTab";
   |                               +++++++

warning: `&` without an explicit lifetime name cannot be used here
  --> rio-backend/src/config/navigation.rs:34:24
   |
34 |     const TOP_TAB_STR: &str = "TopTab";
   |                        ^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
help: use the `'static` lifetime
   |
34 |     const TOP_TAB_STR: &'static str = "TopTab";
   |                         +++++++

warning: `&` without an explicit lifetime name cannot be used here
  --> rio-backend/src/config/navigation.rs:35:27
   |
35 |     const BOTTOM_TAB_STR: &str = "BottomTab";
   |                           ^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
help: use the `'static` lifetime
   |
35 |     const BOTTOM_TAB_STR: &'static str = "BottomTab";
   |                            +++++++

warning: `&` without an explicit lifetime name cannot be used here
  --> rio-backend/src/config/navigation.rs:39:27
   |
39 |     const BREADCRUMB_STR: &str = "Breadcrumb";
   |                           ^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
help: use the `'static` lifetime
   |
39 |     const BREADCRUMB_STR: &'static str = "Breadcrumb";
```
