### PR TITLE
docs: reordering keys to avoid conflicts

### DIFF
--- a/docs/docs/configuration-file.md
+++ b/docs/docs/configuration-file.md
@@ -90,6 +90,35 @@ Possible choices: `both`, `left` and `right`.
 option-as-alt = 'left'
 ```
 
+## Startup directory
+
+Directory the shell is started in. If this is unset the working directory of the parent process will be used.
+
+This configuration only works if `use-fork` is disabled
+
+```toml
+working-dir = "/Users/raphael/Documents/"
+```
+
+## Environment variables
+
+The example below sets fish as the default SHELL using env vars, please do not copy this if you do not need it.
+
+```toml
+env-vars = []
+```
+
+## Use fork
+
+Defaults for POSIX-based systems (Windows is not configurable):
+
+- MacOS: spawn processes
+- Linux/BSD: fork processes
+
+```toml
+use-fork = false
+```
+
 ## Window
 
 - `width` - define the intial window width.
@@ -304,54 +333,33 @@ Default:
 1. MacOS using fish shell from bin path:
 
 ```toml
-shell = { program = "/bin/fish", args = ["--login"] }
+[shell]
+program = "/bin/fish"
+args = ["--login"]
 ```
 
 2. Windows using powershell:
 
 ```toml
-shell = { program = "pwsh", args = [] }
+[shell]
+program = "pwsh"
+args = []
 ```
 
 3. Windows using powershell with login:
 
 ```toml
-shell = { program = "pwsh", args = ["-l"] }
+[shell]
+program = "pwsh"
+args = ["-l"]
 ```
 
 4. MacOS with tmux installed by homebrew:
 
 ```toml
-shell = { program = "/opt/homebrew/bin/tmux", args = ["new-session", "-c", "/var/www"] }
-```
-
-## Startup directory
-
-Directory the shell is started in. If this is unset the working directory of the parent process will be used.
-
-This configuration only works if `use-fork` is disabled
-
-```toml
-working-dir = "/Users/raphael/Documents/"
-```
-
-## Environment variables
-
-The example below sets fish as the default SHELL using env vars, please do not copy this if you do not need it.
-
-```toml
-env-vars = []
-```
-
-## Use fork
-
-Defaults for POSIX-based systems (Windows is not configurable):
-
-- MacOS: spawn processes
-- Linux/BSD: fork processes
-
-```toml
-use-fork = false
+[shell]
+program = "/opt/homebrew/bin/tmux"
+args = ["new-session", "-c", "/var/www"]
 ```
 
 ## Colors

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -162,6 +162,33 @@ blinking-cursor = false
 # Example:
 # option-as-alt = 'left'
 
+# Startup directory
+#
+# Directory the shell is started in. If this is unset the working
+# directory of the parent process will be used.
+#
+# This configuration only has effect if use-fork is disabled
+#
+# Example:
+# working-dir = "/Users/raphael/Documents/"
+
+# Environment variables
+#
+# The example below sets fish as the default SHELL using env vars
+# please do not copy this if you do not need
+#
+# Example:
+# env-vars = []
+
+# Use fork
+#
+# Defaults for POSIX-based systems (Windows is not configurable):
+# MacOS: spawn processes
+# Linux/BSD: fork processes
+#
+# Example:
+# use-fork = false
+
 # Window configuration
 #
 # • width - define the intial window width.
@@ -316,46 +343,27 @@ blinking-cursor = false
 #
 # Example 1 using fish shell from bin path:
 #
-# shell = { program = "/bin/fish", args = ["--login"] }
+# [shell]
+# program = "/bin/fish"
+# args = ["--login"]
 #
 # Example 2 for Windows using powershell
 #
-# shell = { program = "pwsh", args = [] }
+# [shell]
+# program = "pwsh"
+# args = []
 #
 # Example 3 for Windows using powershell with login
 #
-# shell = { program = "pwsh", args = ["-l"] }
+# [shell]
+# program = "pwsh"
+# args = ["-l"]
 #
 # Example 4 for MacOS with tmux installed by homebrew
 #
-# shell = { program = "/opt/homebrew/bin/tmux", args = ["new-session", "-c", # "/var/www"] }
-
-# Startup directory
-#
-# Directory the shell is started in. If this is unset the working
-# directory of the parent process will be used.
-#
-# This configuration only has effect if use-fork is disabled
-#
-# Example:
-# working-dir = "/Users/raphael/Documents/"
-
-# Environment variables
-#
-# The example below sets fish as the default SHELL using env vars
-# please do not copy this if you do not need
-#
-# Example:
-# env-vars = []
-
-# Use fork
-#
-# Defaults for POSIX-based systems (Windows is not configurable):
-# MacOS: spawn processes
-# Linux/BSD: fork processes
-#
-# Example:
-# use-fork = false
+# [shell]
+# program = "/opt/homebrew/bin/tmux"
+# args = ["new-session", "-c", "/var/www"]
 
 # Colors
 #


### PR DESCRIPTION
Reordering non-grouped keys to the top to prevent conflicts and unexpected scenarios.

Reason for this change:

In my OS (Arch Linux + Hyprland WM), the shell key is being merged with the [fonts] properties.

My config.toml:

```toml
# some docs here
[fonts]
family = "Maple Mono SC NF"
size = 20 

# some docs here
shell = { program = "/usr/bin/tmux", args = ["new-session", "-c", "/var/www"] }
```

As a result, an interpretation of how `rio-backend` sees the "fonts" group:
```json
{
  "fonts": {
    "family": "Maple Mono SC NF",
    "size": 20,
    "shell": {
       "program": "/usr/bin/tmux",
       "args": ["new-session", "-c", "/var/www"]
    }
  }
}
```
and shell is None because it was merged into fonts, disregarding my configuration.

My suggestion is to move up all keys that aren't grouped with brackets ([example]) to avoid merging and unexpected scenarios:

```toml
# non-grouped keys first
cursor = '▇'
theme = "catppuccin-macchiato"
padding-x = 0
env-vars = []
use-fork = false

# some doc here
[fonts]
family = "Maple Mono SC NF"
size = 20 

# some doc here
[shell]
program = "/usr/bin/tmux"
args = ["new-session", "-c", "/var/www"] 
```