### PR TITLE
docs: set padding-x default to 0

### DIFF
--- a/docs/docs/configuration-file.md
+++ b/docs/docs/configuration-file.md
@@ -74,10 +74,10 @@ theme = "dracula"
 
 ## Padding-x
 
-Define x axis padding (default is 10)
+Define x axis padding (default is 0)
 
 ```toml
-padding-x = 10
+padding-x = 0
 ```
 
 ## Option as Alt

--- a/docs/docs/configuration-file.md
+++ b/docs/docs/configuration-file.md
@@ -77,7 +77,7 @@ theme = "dracula"
 Define x axis padding (default is 0)
 
 ```toml
-padding-x = 0
+padding-x = 10
 ```
 
 ## Option as Alt

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -149,10 +149,10 @@ blinking-cursor = false
 
 # Padding-x
 #
-# define x axis padding (default is 10)
+# define x axis padding (default is 0)
 #
 # Example:
-# padding-x = 10
+# padding-x = 0
 
 # Option as Alt
 #

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -152,7 +152,7 @@ blinking-cursor = false
 # define x axis padding (default is 0)
 #
 # Example:
-# padding-x = 0
+# padding-x = 10
 
 # Option as Alt
 #


### PR DESCRIPTION
`padding-x` was changed to 0 on all platforms in `v0.0.30`. 

[https://github.com/raphamorim/rio/blob/1fa31f7cf6caa1c0c4caf2a5268eb7cea8799d6a/rio-backend/src/config/defaults.rs#L6-L9](https://github.com/raphamorim/rio/blob/1fa31f7cf6caa1c0c4caf2a5268eb7cea8799d6a/rio-backend/src/config/defaults.rs#L6-L9)
