### PR TITLE
docs: use-current-path requires use-fork to be false

### DIFF
--- a/docs/docs/configuration-file.md
+++ b/docs/docs/configuration-file.md
@@ -308,7 +308,7 @@ divider = 1.0
 	- `Plain`
 
 - `clickable` - Enable click on tabs to switch.
-- `use-current-path` - Use same path whenever a new tab is created.
+- `use-current-path` - Use same path whenever a new tab is created (Note: requires [`use-fork`](/docs/configuration-file/#use-fork) to be set to false).
 - `color-automation` - Set a specific color for the tab whenever a specific program is running, or in a specific directory.
 
 ```toml

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -321,7 +321,7 @@ blinking-cursor = false
 #   • Plain
 #
 # "clickable" - Enable click on tabs to switch.
-# "use-current-path" - Use same path whenever a new tab is created.
+# "use-current-path" - Use same path whenever a new tab is created (Note: requires `use-fork` to be set to false).
 # "color-automation" - Set a specific color for the tab whenever a specific program is running, or in a specific directory.
 #
 # Example:


### PR DESCRIPTION
`create_pty_with_fork` does not support starting in specific path (*yet?*).

[https://github.com/raphamorim/rio/blob/f4f8d6c381d905c7c108efacf6132ea0c9614aaf/teletypewriter/src/unix/mod.rs#L581](https://github.com/raphamorim/rio/blob/f4f8d6c381d905c7c108efacf6132ea0c9614aaf/teletypewriter/src/unix/mod.rs#L581)