### PR TITLE
flake: add `apps` entry and fix runtime error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,136 +11,56 @@
     };
   };
 
-  outputs = inputs @ {flake-parts, ...}:
-    flake-parts.lib.mkFlake {inherit inputs;} {
-      imports = [];
+  outputs = inputs @ { flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ ];
 
       systems = import inputs.systems;
 
-      perSystem = {
-        config,
-        self',
-        inputs',
-        pkgs,
-        system,
-        lib,
-        ...
-      }: let
-        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-        rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
-          extensions = ["rust-src" "rust-analyzer"];
-        };
+      perSystem =
+        { config
+        , self'
+        , inputs'
+        , pkgs
+        , system
+        , lib
+        , ...
+        }:
+        let
+          rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+            extensions = [ "rust-src" "rust-analyzer" ];
+          };
 
-        mkRio = {
-          rustPlatform,
-          stdenv,
-          lib,
-          fontconfig,
-          darwin,
-          gcc-unwrapped,
-          libGL,
-          libxkbcommon,
-          vulkan-loader,
-          libX11,
-          libXcursor,
-          libXi,
-          libXrandr,
-          libxcb,
-          wayland,
-          ncurses,
-          pkg-config,
-          cmake,
-          autoPatchelfHook,
-          withX11 ? !stdenv.isDarwin,
-          withWayland ? !stdenv.isDarwin,
-          ...
-        }: let
-          rlinkLibs =
-            if stdenv.isDarwin
-            then [
-              darwin.libobjc
-              darwin.apple_sdk_11_0.frameworks.AppKit
-              darwin.apple_sdk_11_0.frameworks.AVFoundation
-              darwin.apple_sdk_11_0.frameworks.Vision
-            ]
-            else
-              [
-                (lib.getLib gcc-unwrapped)
-                fontconfig
-                libGL
-                libxkbcommon
-                vulkan-loader
-              ]
-              ++ lib.optionals withX11 [
-                libX11
-                libXcursor
-                libXi
-                libXrandr
-                libxcb
-              ]
-              ++ lib.optionals withWayland [
-                wayland
-              ];
-        in
-          rustPlatform.buildRustPackage {
-            inherit (cargoToml.workspace.package) version;
-            name = "rio";
-            src = ./.;
-            cargoLock.lockFile = ./Cargo.lock;
+          mkRio = import ./pkgRio.nix;
 
-            cargoBuildFlags = "-p rioterm";
-
-            buildInputs = rlinkLibs;
-            runtimeDependencies = rlinkLibs;
-
-            nativeBuildInputs =
-              [
-                ncurses
-              ]
-              ++ lib.optionals stdenv.isLinux [
-                pkg-config
-                cmake
-                autoPatchelfHook
-              ];
-
-            buildNoDefaultFeatures = true;
-            buildFeatures = ["x11" "wayland"];
-            meta = {
-              description = "A hardware-accelerated GPU terminal emulator focusing to run in desktops and browsers";
-              homepage = "https://raphamorim.io/rio";
-              license = lib.licenses.mit;
-              platforms = lib.platforms.unix;
-              changelog = "https://github.com/raphamorim/rio/blob/master/CHANGELOG.md";
-              mainProgram = "rio";
+          mkDevShell = rust-toolchain:
+            let
+              dependencies = self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs;
+            in
+            pkgs.mkShell {
+              LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath dependencies}:$LD_LIBRARY_PATH";
+              packages = dependencies ++ [ rust-toolchain ];
             };
-          };
-
-        mkDevShell = rust-toolchain: let
-          dependencies = self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs;
         in
-          pkgs.mkShell {
-            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath dependencies}:$LD_LIBRARY_PATH";
-            packages = dependencies ++ [rust-toolchain];
+        {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ (import inputs.rust-overlay) ];
           };
-      in {
-        _module.args.pkgs = import inputs.nixpkgs {
-          inherit system;
-          overlays = [(import inputs.rust-overlay)];
+
+          formatter = pkgs.alejandra;
+          packages.default = self'.packages.rio;
+          devShells.default = self'.devShells.msrv;
+
+          apps.default = {
+            type = "app";
+            program = self'.packages.default;
+          };
+          packages.rio = pkgs.callPackage mkRio { };
+
+          devShells.msrv = mkDevShell rust-toolchain;
+          devShells.stable = mkDevShell pkgs.rust-bin.stable.latest.default;
+          devShells.nightly = mkDevShell (pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default));
         };
-
-        formatter = pkgs.alejandra;
-        packages.default = self'.packages.rio;
-        devShells.default = self'.devShells.msrv;
-
-        apps.default = {
-          type = "app";
-          program = self'.packages.default;
-        };
-        packages.rio = pkgs.callPackage mkRio {};
-
-        devShells.msrv = mkDevShell rust-toolchain;
-        devShells.stable = mkDevShell pkgs.rust-bin.stable.latest.default;
-        devShells.nightly = mkDevShell (pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default));
-      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -31,50 +31,78 @@
           extensions = ["rust-src" "rust-analyzer"];
         };
 
-        runtimeDeps = with pkgs;
-          if stdenv.isDarwin
-          then [
-            darwin.libobjc
-            darwin.apple_sdk_11_0.frameworks.AppKit
-            darwin.apple_sdk_11_0.frameworks.AVFoundation
-            darwin.apple_sdk_11_0.frameworks.Vision
-          ]
-          else
-            (with pkgs; [
-              (lib.getLib gcc-unwrapped)
-              fontconfig
-              libGL
-              libxkbcommon
-              vulkan-loader
-              wayland
-            ])
-            ++ (with pkgs.xorg; [
-              libX11
-              libXcursor
-              libXi
-              libXrandr
-              libxcb
-            ]);
-
-        buildDeps = with pkgs;
-          [
-            ncurses
-          ]
-          ++ lib.optionals stdenv.isLinux [
-            pkg-config
-            cmake
-            autoPatchelfHook
-          ];
-
-        rustPackage = rust-toolchain:
-          pkgs.rustPlatform.buildRustPackage {
+        mkRio = {
+          rustPlatform,
+          stdenv,
+          lib,
+          fontconfig,
+          darwin,
+          gcc-unwrapped,
+          libGL,
+          libxkbcommon,
+          vulkan-loader,
+          libX11,
+          libXcursor,
+          libXi,
+          libXrandr,
+          libxcb,
+          wayland,
+          ncurses,
+          pkg-config,
+          cmake,
+          autoPatchelfHook,
+          withX11 ? !stdenv.isDarwin,
+          withWayland ? !stdenv.isDarwin,
+          ...
+        }: let
+          rlinkLibs =
+            if stdenv.isDarwin
+            then [
+              darwin.libobjc
+              darwin.apple_sdk_11_0.frameworks.AppKit
+              darwin.apple_sdk_11_0.frameworks.AVFoundation
+              darwin.apple_sdk_11_0.frameworks.Vision
+            ]
+            else
+              [
+                (lib.getLib gcc-unwrapped)
+                fontconfig
+                libGL
+                libxkbcommon
+                vulkan-loader
+              ]
+              ++ lib.optionals withX11 [
+                libX11
+                libXcursor
+                libXi
+                libXrandr
+                libxcb
+              ]
+              ++ lib.optionals withWayland [
+                wayland
+              ];
+        in
+          rustPlatform.buildRustPackage {
             inherit (cargoToml.workspace.package) version;
             name = "rio";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
+
             cargoBuildFlags = "-p rioterm";
-            buildInputs = runtimeDeps ++ buildDeps;
-            nativeBuildInputs = buildDeps;
+
+            buildInputs = rlinkLibs;
+            runtimeDependencies = rlinkLibs;
+
+            nativeBuildInputs =
+              [
+                ncurses
+              ]
+              ++ lib.optionals stdenv.isLinux [
+                pkg-config
+                cmake
+                autoPatchelfHook
+              ];
+
             buildNoDefaultFeatures = true;
             buildFeatures = ["x11" "wayland"];
             meta = {
@@ -87,10 +115,12 @@
             };
           };
 
-        mkDevShell = rust-toolchain:
+        mkDevShell = rust-toolchain: let
+          dependencies = self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs;
+        in
           pkgs.mkShell {
-            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath (runtimeDeps ++ buildDeps)}:$LD_LIBRARY_PATH";
-            packages = buildDeps ++ runtimeDeps ++ [rust-toolchain];
+            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath dependencies}:$LD_LIBRARY_PATH";
+            packages = dependencies ++ [rust-toolchain];
           };
       in {
         _module.args.pkgs = import inputs.nixpkgs {
@@ -102,7 +132,11 @@
         packages.default = self'.packages.rio;
         devShells.default = self'.devShells.msrv;
 
-        packages.rio = rustPackage "rio";
+        apps.default = {
+          type = "app";
+          program = self'.packages.rio;
+        };
+        packages.rio = pkgs.callPackage mkRio {};
 
         devShells.msrv = mkDevShell rust-toolchain;
         devShells.stable = mkDevShell pkgs.rust-bin.stable.latest.default;

--- a/flake.nix
+++ b/flake.nix
@@ -134,7 +134,7 @@
 
         apps.default = {
           type = "app";
-          program = self'.packages.rio;
+          program = self'.packages.default;
         };
         packages.rio = pkgs.callPackage mkRio {};
 

--- a/pkgRio.nix
+++ b/pkgRio.nix
@@ -1,0 +1,84 @@
+{ rustPlatform
+, stdenv
+, lib
+, fontconfig
+, darwin
+, gcc-unwrapped
+, libGL
+, libxkbcommon
+, vulkan-loader
+, libX11
+, libXcursor
+, libXi
+, libXrandr
+, libxcb
+, wayland
+, ncurses
+, pkg-config
+, cmake
+, autoPatchelfHook
+, withX11 ? !stdenv.isDarwin
+, withWayland ? !stdenv.isDarwin
+, ...
+}:
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+  rlinkLibs =
+    if stdenv.isDarwin
+    then [
+      darwin.libobjc
+      darwin.apple_sdk_11_0.frameworks.AppKit
+      darwin.apple_sdk_11_0.frameworks.AVFoundation
+      darwin.apple_sdk_11_0.frameworks.Vision
+    ]
+    else
+      [
+        (lib.getLib gcc-unwrapped)
+        fontconfig
+        libGL
+        libxkbcommon
+        vulkan-loader
+      ]
+      ++ lib.optionals withX11 [
+        libX11
+        libXcursor
+        libXi
+        libXrandr
+        libxcb
+      ]
+      ++ lib.optionals withWayland [
+        wayland
+      ];
+in
+rustPlatform.buildRustPackage {
+  inherit (cargoToml.workspace.package) version;
+  name = "rio";
+  src = ./.;
+  cargoLock.lockFile = ./Cargo.lock;
+
+  cargoBuildFlags = "-p rioterm";
+
+  buildInputs = rlinkLibs;
+  runtimeDependencies = rlinkLibs;
+
+  nativeBuildInputs =
+    [
+      ncurses
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      pkg-config
+      cmake
+      autoPatchelfHook
+    ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "x11" "wayland" ];
+  meta = {
+    description = "A hardware-accelerated GPU terminal emulator focusing to run in desktops and browsers";
+    homepage = "https://raphamorim.io/rio";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    changelog = "https://github.com/raphamorim/rio/blob/master/CHANGELOG.md";
+    mainProgram = "rio";
+  };
+}


### PR DESCRIPTION
Fixes the core dump when running `rio` with `nix`. @RaySlash you can take a look if you want.