### PR TITLE
fix(crosswords): show beam cursor in nvim insert mode when using Zellij

### DIFF
--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -1098,7 +1098,11 @@ impl<U: EventListener> Crosswords<U> {
 
         // If is not using app cursor then use default
         if content != CursorShape::Hidden && !self.mode.contains(Mode::APP_CURSOR) {
-            content = self.default_cursor_shape;
+            content = if content == CursorShape::Beam {
+                CursorShape::Beam
+            } else {
+                self.default_cursor_shape
+            };
         }
 
         CursorState { pos, content }


### PR DESCRIPTION
I recently switched to Zellij, but I was having some trouble getting the cursor to change from `▇` to `|` when going into insert mode, in NeoVim.

![image](https://github.com/raphamorim/rio/assets/56034786/3e03f11d-7b41-41d1-bfb0-07d6d2349b27)

Removing the following lines resulted in the cursor changing as expected:

https://github.com/raphamorim/rio/blob/0cbed145e864d0e0d6c724b09f5a41fbd7892881/rio-backend/src/crosswords/mod.rs#L1100-L1102

Which is rather ironic since it was introduced as a fix for the cursor shape not being restored in the first place (https://github.com/raphamorim/rio/commit/e6d582775356a358346c492d1a47bb06a7a63d14).

For now I have changed the code above to

```rust
content = if content == CursorShape::Beam {
	CursorShape::Beam
} else {
	self.default_cursor_shape
};
```

which fixes the issue for me. As far as I can tell it does not reintroduce the original bug (#279), but I am unsure if this change has other unwanted side effects.
