### PR TITLE
refactor: disable cursor blink on selection (ref #437)

### DIFF
--- a/frontends/rioterm/src/app/route.rs
+++ b/frontends/rioterm/src/app/route.rs
@@ -1530,7 +1530,11 @@ impl Route {
 
                 // In this case the configuration of blinking cursor is enabled
                 // and the terminal also have instructions of blinking enabled
-                if self.state.has_blinking_enabled && has_blinking_enabled {
+                // TODO: enable blinking for selection after adding debounce (https://github.com/raphamorim/rio/issues/437)
+                if self.state.has_blinking_enabled
+                    && has_blinking_enabled
+                    && self.selection_is_empty()
+                {
                     self.superloop
                         .send_event(RioEvent::PrepareRender(800), self.id);
                 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1251,7 +1251,11 @@ impl Screen {
 
         // In this case the configuration of blinking cursor is enabled
         // and the terminal also have instructions of blinking enabled
-        if self.state.has_blinking_enabled && has_blinking_enabled {
+        // TODO: enable blinking for selection after adding debounce (https://github.com/raphamorim/rio/issues/437)
+        if self.state.has_blinking_enabled
+            && has_blinking_enabled
+            && self.selection_is_empty()
+        {
             self.context_manager.schedule_render(800);
         }
     }


### PR DESCRIPTION
Disables `blinking-cursor` when selecting text, since it results in the application scheduling a lot of “unnecessary” rerenders, as described in #437.

There is still a small delay on first selection render, but it is not noticeable after.

_With the change_:

[Screencast from 2024-01-30 00-20-41.webm](https://github.com/raphamorim/rio/assets/56034786/468338b2-fdf6-498e-af8b-8673dc2520e4)

_Without_:

[Screencast from 2024-01-28 23-59-41.webm](https://github.com/raphamorim/rio/assets/56034786/0ae43942-94db-4bbc-acd0-89df39990ee3)
