### PR TITLE
fix: build on Darwin

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
 use flake
+
+watch_file pkgRio.nix

--- a/pkgRio.nix
+++ b/pkgRio.nix
@@ -29,6 +29,7 @@ let
       darwin.libobjc
       darwin.apple_sdk_11_0.frameworks.AppKit
       darwin.apple_sdk_11_0.frameworks.AVFoundation
+      darwin.apple_sdk_11_0.frameworks.MetalKit
       darwin.apple_sdk_11_0.frameworks.Vision
     ]
     else


### PR DESCRIPTION
This fixes the build on Darwin by adding a dependency on MetalKit. I also did
some drive-by fixes of the `envrc` setup.

- **fix(envrc): reload when pkgRio.nix changes**
- **fix(envrc): evaluate the nix shellHook**
- **fix(pkgRio): add MetalKit for build on Darwin**
