### PR TITLE
Fix `LD_LIBRARY_PATH` in Nix flake dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,11 +35,12 @@
 
           mkDevShell = rust-toolchain:
             let
-              dependencies = self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs;
+              runtimeDeps = self'.packages.rio.runtimeDependencies;
+              tools = self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs ++ [ rust-toolchain ];
             in
             pkgs.mkShell {
-              LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath dependencies}:$LD_LIBRARY_PATH";
-              packages = dependencies ++ [ rust-toolchain ];
+              LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath runtimeDeps}";
+              packages = tools ++ [ rust-toolchain ];
             };
         in
         {


### PR DESCRIPTION
The Nix flake dev shell needs to pull conditionally loaded dynamic libraries such as `libxkbcommon` into scope manually because the `patch` step is missing when using `cargo` directly. The previous implementation of the dev shell includes the `buildInputs` into `LD_LIBRARY_PATH`, which are just the headers and not the dynamic libraries. This PR fixes that issue and makes the shell work on my machine :tm: .

c/o @TornaxO7 who recommended I open this PR.