### PR TITLE
fix nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,57 +11,54 @@
     };
   };
 
-  outputs = inputs @ { flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      imports = [ ];
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      imports = [];
 
       systems = import inputs.systems;
 
-      perSystem =
-        { config
-        , self'
-        , inputs'
-        , pkgs
-        , system
-        , lib
-        , ...
-        }:
-        let
-          rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
-            extensions = [ "rust-src" "rust-analyzer" ];
-          };
-
-          mkRio = import ./pkgRio.nix;
-
-          mkDevShell = rust-toolchain:
-            let
-              runtimeDeps = self'.packages.rio.runtimeDependencies;
-              tools = self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs ++ [ rust-toolchain ];
-            in
-            pkgs.mkShell {
-              LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath runtimeDeps}";
-              packages = tools ++ [ rust-toolchain ];
-            };
-        in
-        {
-          _module.args.pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [ (import inputs.rust-overlay) ];
-          };
-
-          formatter = pkgs.alejandra;
-          packages.default = self'.packages.rio;
-          devShells.default = self'.devShells.msrv;
-
-          apps.default = {
-            type = "app";
-            program = self'.packages.default;
-          };
-          packages.rio = pkgs.callPackage mkRio { };
-
-          devShells.msrv = mkDevShell rust-toolchain;
-          devShells.stable = mkDevShell pkgs.rust-bin.stable.latest.default;
-          devShells.nightly = mkDevShell (pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default));
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        lib,
+        ...
+      }: let
+        rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+          extensions = ["rust-src" "rust-analyzer"];
         };
+
+        mkRio = import ./pkgRio.nix;
+
+        mkDevShell = rust-toolchain: let
+          runtimeDeps = self'.packages.rio.runtimeDependencies;
+          tools = self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs ++ [rust-toolchain];
+        in
+          pkgs.mkShell {
+            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath runtimeDeps}";
+            packages = tools ++ [rust-toolchain];
+          };
+      in {
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [(import inputs.rust-overlay)];
+        };
+
+        formatter = pkgs.alejandra;
+        packages.default = self'.packages.rio;
+        devShells.default = self'.devShells.msrv;
+
+        apps.default = {
+          type = "app";
+          program = self'.packages.default;
+        };
+        packages.rio = pkgs.callPackage mkRio {rust-toolchain = rust-toolchain;};
+
+        devShells.msrv = mkDevShell rust-toolchain;
+        devShells.stable = mkDevShell pkgs.rust-bin.stable.latest.default;
+        devShells.nightly = mkDevShell (pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default));
+      };
     };
 }

--- a/pkgRio.nix
+++ b/pkgRio.nix
@@ -1,28 +1,33 @@
-{ rustPlatform
-, stdenv
-, lib
-, fontconfig
-, darwin
-, gcc-unwrapped
-, libGL
-, libxkbcommon
-, vulkan-loader
-, libX11
-, libXcursor
-, libXi
-, libXrandr
-, libxcb
-, wayland
-, ncurses
-, pkg-config
-, cmake
-, autoPatchelfHook
-, withX11 ? !stdenv.isDarwin
-, withWayland ? !stdenv.isDarwin
-, ...
-}:
-let
+{
+  rust-toolchain,
+  makeRustPlatform,
+  stdenv,
+  lib,
+  fontconfig,
+  darwin,
+  gcc-unwrapped,
+  libGL,
+  libxkbcommon,
+  vulkan-loader,
+  libX11,
+  libXcursor,
+  libXi,
+  libXrandr,
+  libxcb,
+  wayland,
+  ncurses,
+  pkg-config,
+  cmake,
+  autoPatchelfHook,
+  withX11 ? !stdenv.isDarwin,
+  withWayland ? !stdenv.isDarwin,
+  ...
+}: let
   cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+  rustPlatform = makeRustPlatform {
+    cargo = rust-toolchain;
+    rustc = rust-toolchain;
+  };
   rlinkLibs =
     if stdenv.isDarwin
     then [
@@ -51,35 +56,35 @@ let
         wayland
       ];
 in
-rustPlatform.buildRustPackage {
-  inherit (cargoToml.workspace.package) version;
-  name = "rio";
-  src = ./.;
-  cargoLock.lockFile = ./Cargo.lock;
+  rustPlatform.buildRustPackage {
+    inherit (cargoToml.workspace.package) version;
+    name = "rio";
+    src = ./.;
+    cargoLock.lockFile = ./Cargo.lock;
 
-  cargoBuildFlags = "-p rioterm";
+    cargoBuildFlags = "-p rioterm";
 
-  buildInputs = rlinkLibs;
-  runtimeDependencies = rlinkLibs;
+    buildInputs = rlinkLibs;
+    runtimeDependencies = rlinkLibs;
 
-  nativeBuildInputs =
-    [
-      ncurses
-    ]
-    ++ lib.optionals stdenv.isLinux [
-      pkg-config
-      cmake
-      autoPatchelfHook
-    ];
+    nativeBuildInputs =
+      [
+        ncurses
+      ]
+      ++ lib.optionals stdenv.isLinux [
+        pkg-config
+        cmake
+        autoPatchelfHook
+      ];
 
-  buildNoDefaultFeatures = true;
-  buildFeatures = [ "x11" "wayland" ];
-  meta = {
-    description = "A hardware-accelerated GPU terminal emulator focusing to run in desktops and browsers";
-    homepage = "https://raphamorim.io/rio";
-    license = lib.licenses.mit;
-    platforms = lib.platforms.unix;
-    changelog = "https://github.com/raphamorim/rio/blob/master/CHANGELOG.md";
-    mainProgram = "rio";
-  };
-}
+    buildNoDefaultFeatures = true;
+    buildFeatures = ["x11" "wayland"];
+    meta = {
+      description = "A hardware-accelerated GPU terminal emulator focusing to run in desktops and browsers";
+      homepage = "https://raphamorim.io/rio";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+      changelog = "https://github.com/raphamorim/rio/blob/master/CHANGELOG.md";
+      mainProgram = "rio";
+    };
+  }


### PR DESCRIPTION
fixes: nixos builds, as well as dev shells not containing the correct rust version, for example `devShells.x86_64-linux.nightly` had a rustc version of `1.77.1`