### PR TITLE
Reuse image crate

### DIFF
--- a/sugarloaf/src/components/layer/atlas.rs
+++ b/sugarloaf/src/components/layer/atlas.rs
@@ -71,10 +71,10 @@ impl Atlas {
         &mut self,
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
-        width: u32,
-        height: u32,
-        data: &[u8],
+        img: &image::RgbaImage,
     ) -> Option<Entry> {
+        let width = img.width();
+        let height = img.height();
         let entry = {
             let current_size = self.layers.len();
             let entry = self.allocate(width, height)?;
@@ -103,7 +103,7 @@ impl Atlas {
             let offset = row * padded_width;
 
             padded_data[offset..offset + 4 * width as usize].copy_from_slice(
-                &data[row * 4 * width as usize..(row + 1) * 4 * width as usize],
+                &img.as_raw()[row * 4 * width as usize..(row + 1) * 4 * width as usize],
             )
         }
 

--- a/sugarloaf/src/components/layer/mod.rs
+++ b/sugarloaf/src/components/layer/mod.rs
@@ -297,7 +297,7 @@ impl LayerBrush {
 
     pub fn dimensions(&self, handle: &image::Handle) -> Size<u32> {
         let mut cache = self.raster_cache.borrow_mut();
-        let memory = cache.load(handle);
+        let memory = cache.load_mut(handle);
 
         memory.dimensions()
     }

--- a/sugarloaf/src/layout/span_style.rs
+++ b/sugarloaf/src/layout/span_style.rs
@@ -12,6 +12,9 @@
 use crate::layout::builder_data::FontSettingKey;
 use crate::layout::builder_data::EMPTY_FONT_SETTINGS;
 use crate::sugarloaf::primitives::SugarCursor;
+use crate::Sugar;
+use crate::SugarDecoration;
+use crate::SugarStyle;
 pub use swash::text::Language;
 use swash::{Setting, Stretch, Style, Weight};
 
@@ -108,6 +111,66 @@ impl FragmentStyle {
             underline_size: None,
             text_transform: TextTransform::None,
         }
+    }
+}
+
+impl From<&Sugar> for FragmentStyle {
+    fn from(sugar: &Sugar) -> Self {
+        let mut style = FragmentStyle::default();
+
+        match sugar.style {
+            SugarStyle::BoldItalic => {
+                style.font_attrs.1 = Weight::BOLD;
+                style.font_attrs.2 = Style::Italic;
+            }
+            SugarStyle::Bold => {
+                style.font_attrs.1 = Weight::BOLD;
+            }
+            SugarStyle::Italic => {
+                style.font_attrs.2 = Style::Italic;
+            }
+            _ => {}
+        }
+
+        let mut has_underline_cursor = false;
+        match sugar.cursor {
+            SugarCursor::Underline(cursor_color) => {
+                style.underline = true;
+                style.underline_offset = Some(-1.);
+                style.underline_color = Some(cursor_color);
+                style.underline_size = Some(-1.);
+
+                has_underline_cursor = true;
+            }
+            SugarCursor::Block(cursor_color) => {
+                style.cursor = SugarCursor::Block(cursor_color);
+            }
+            SugarCursor::Caret(cursor_color) => {
+                style.cursor = SugarCursor::Caret(cursor_color);
+            }
+            _ => {}
+        }
+
+        match &sugar.decoration {
+            SugarDecoration::Underline => {
+                if !has_underline_cursor {
+                    style.underline = true;
+                    style.underline_offset = Some(-2.);
+                    style.underline_size = Some(1.);
+                }
+            }
+            SugarDecoration::Strikethrough => {
+                style.underline = true;
+                style.underline_offset = Some(style.font_size / 2.);
+                style.underline_size = Some(2.);
+            }
+            _ => {}
+        }
+
+        style.color = sugar.foreground_color;
+        style.background_color = Some(sugar.background_color);
+
+        style
     }
 }
 

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -4,6 +4,7 @@ pub mod primitives;
 pub mod state;
 mod tree;
 
+use crate::components::core::image::Data;
 use crate::components::core::{image::Handle, shapes::Rectangle};
 use crate::components::layer::{self, LayerBrush};
 use crate::components::rect::{Rect, RectBrush};
@@ -25,6 +26,7 @@ use raw_window_handle::{
     DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, WindowHandle,
 };
 use state::SugarState;
+use std::path::PathBuf;
 
 #[cfg(target_arch = "wasm32")]
 pub struct Database;
@@ -225,7 +227,7 @@ impl Sugarloaf {
 
     #[inline]
     pub fn set_background_image(&mut self, image: &ImageProperties) -> &mut Self {
-        let handle = Handle::from_path(image.path.to_owned());
+        let handle = Handle::from(Data::Path(PathBuf::from(image.path.clone())));
         self.background_image = Some(layer::types::Image::Raster {
             handle,
             bounds: Rectangle {

--- a/sugarloaf/src/sugarloaf/compositors/advanced.rs
+++ b/sugarloaf/src/sugarloaf/compositors/advanced.rs
@@ -13,7 +13,6 @@ use crate::layout::{
 };
 use crate::sugarloaf::tree::SugarTree;
 
-
 pub struct Advanced {
     pub render_data: RenderData,
     pub mocked_render_data: RenderData,

--- a/sugarloaf/src/sugarloaf/compositors/advanced.rs
+++ b/sugarloaf/src/sugarloaf/compositors/advanced.rs
@@ -7,12 +7,12 @@
 // https://github.com/dfrg/swash_demo/blob/master/LICENSE
 
 use crate::font::FontLibrary;
-use crate::font::{Style, Weight};
+
 use crate::layout::{
     Content, ContentBuilder, Direction, FragmentStyle, LayoutContext, RenderData,
 };
 use crate::sugarloaf::tree::SugarTree;
-use crate::{SugarCursor, SugarDecoration, SugarStyle};
+
 
 pub struct Advanced {
     pub render_data: RenderData,
@@ -98,72 +98,19 @@ impl Advanced {
         }
 
         let line = &tree.lines[line_number];
-
-        for i in 0..line.len() {
-            let mut style = FragmentStyle {
+        for sugar in line.inner() {
+            let style = FragmentStyle {
                 font_size: tree.layout.font_size,
-                ..Default::default()
+                ..FragmentStyle::from(sugar)
             };
 
-            match line[i].style {
-                SugarStyle::BoldItalic => {
-                    style.font_attrs.1 = Weight::BOLD;
-                    style.font_attrs.2 = Style::Italic;
-                }
-                SugarStyle::Bold => {
-                    style.font_attrs.1 = Weight::BOLD;
-                }
-                SugarStyle::Italic => {
-                    style.font_attrs.2 = Style::Italic;
-                }
-                _ => {}
-            }
-
-            let mut has_underline_cursor = false;
-            match line[i].cursor {
-                SugarCursor::Underline(cursor_color) => {
-                    style.underline = true;
-                    style.underline_offset = Some(-1.);
-                    style.underline_color = Some(cursor_color);
-                    style.underline_size = Some(-1.);
-
-                    has_underline_cursor = true;
-                }
-                SugarCursor::Block(cursor_color) => {
-                    style.cursor = SugarCursor::Block(cursor_color);
-                }
-                SugarCursor::Caret(cursor_color) => {
-                    style.cursor = SugarCursor::Caret(cursor_color);
-                }
-                _ => {}
-            }
-
-            match &line[i].decoration {
-                SugarDecoration::Underline => {
-                    if !has_underline_cursor {
-                        style.underline = true;
-                        style.underline_offset = Some(-2.);
-                        style.underline_size = Some(1.);
-                    }
-                }
-                SugarDecoration::Strikethrough => {
-                    style.underline = true;
-                    style.underline_offset = Some(style.font_size / 2.);
-                    style.underline_size = Some(2.);
-                }
-                _ => {}
-            }
-
-            style.color = line[i].foreground_color;
-            style.background_color = Some(line[i].background_color);
-
-            if line[i].repeated > 0 {
-                let text = std::iter::repeat(line[i].content)
-                    .take(line[i].repeated + 1)
+            if sugar.repeated > 0 {
+                let text = std::iter::repeat(sugar.content)
+                    .take(sugar.repeated + 1)
                     .collect::<String>();
                 self.content_builder.add_text(&text, style);
             } else {
-                self.content_builder.add_char(line[i].content, style);
+                self.content_builder.add_char(sugar.content, style);
             }
         }
 

--- a/sugarloaf/src/sugarloaf/primitives.rs
+++ b/sugarloaf/src/sugarloaf/primitives.rs
@@ -340,6 +340,11 @@ impl SugarLine {
         self.inner.len()
     }
 
+    #[inline]
+    pub fn inner(&self) -> &Vec<Sugar> {
+        &self.inner
+    }
+
     // #[inline]
     // fn compute_hash(&mut self) {
     // 00000000000000


### PR DESCRIPTION
This removes self written `Rgba` stuff which is already handled in the `image` crate.