### PR TITLE
Fix README.md installation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 | Name | Details |
 | --- | --- |
-| MacOs _as desktop application_ | [Installation guide](https://raphamorim.io/rio/docs/install/macos) |
-| Linux _as desktop application_ | [Installation guide](https://raphamorim.io/rio/docs/install/linux) |
-| Windows _as desktop application_ | [Installation guide](https://raphamorim.io/rio/docs/install/windows) |
+| MacOs _as desktop application_ | [Installation guide](https://raphamorim.io/rio/docs/0.x.x/install/macos) |
+| Linux _as desktop application_ | [Installation guide](https://raphamorim.io/rio/docs/0.x.x/install/linux) |
+| Windows _as desktop application_ | [Installation guide](https://raphamorim.io/rio/docs/0.x.x/install/windows) |
 | Web Browser _(WebAssembly)_ | (Sugarloaf is ready but Rio still need to be ported) |
 
 ## Demo Gallery


### PR DESCRIPTION
Very minor, so I ended up not even opening an issue for this, just a fix for installation links sending to old (invalid) ones.

**EDIT:** If it makes more sense, I can target this change to `0.x.x` branch instead.