### PR TITLE
Revert "nix: add hash value for a dependency"

### DIFF
--- a/pkgRio.nix
+++ b/pkgRio.nix
@@ -60,13 +60,7 @@ in
     inherit (cargoToml.workspace.package) version;
     name = "rio";
     src = ./.;
-    cargoLock = {
-      lockFile = ./Cargo.lock;
-
-      outputHashes = {
-        "dpi-0.1.1" = "sha256-LoA66thPDtA9Q6QkSkQU1M2ekYM3kN1qFnGEJFojFPs=";
-      };
-    };
+    cargoLock.lockFile = ./Cargo.lock;
 
     cargoBuildFlags = "-p rioterm";
 


### PR DESCRIPTION
Reverts raphamorim/rio#516

Using nix to compile rio currently fails with `error: A hash was specified for dpi-0.1.1, but there is no corresponding git dependency.`

With this I'm successfully able to use `nix run`.