### PR TITLE
Fixed custom key bindings URL in default config

### DIFF
--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -413,7 +413,7 @@ blinking-cursor = false
 # Bindings
 #
 # Create custom Key bindings for Rio terminal
-# More information in: raphamorim.io/rio/docs/custom-key-bindings
+# More information in: https://raphamorim.io/rio/docs/next/key-bindings#custom-key-bindings
 #
 # Example:
 # [bindings]


### PR DESCRIPTION
I tried entering the URL in the default config, and it showed "Page not found"
I found the actual URL, and replaced it in `default.rs`: https://raphamorim.io/rio/docs/next/key-bindings#custom-key-bindings