### PR TITLE
feat(config): support creating config via `--write-config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## Unreleased
 
-- TODO
+- Support writing the config to a custom/default location via `--write-config` (Ref: #605)
 
 ## 0.1.8
 

--- a/docs/versioned_docs/version-0.0.x/command-line-interface.md
+++ b/docs/versioned_docs/version-0.0.x/command-line-interface.md
@@ -14,6 +14,7 @@ Usage: rio [OPTIONS]
 Options:
   -e, --command <COMMAND>...  Command and args to execute (must be last argument)
   --working-dir <WORKING_DIR>  Start the shell in the specified working directory
+  --write-config [<PATH>]      Writes the config to a given path or the default location
   -h, --help                  Print help
   -V, --version               Print version
 ```

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -4,6 +4,7 @@
 use clap::{Args, Parser, ValueHint};
 use rio_backend::config::Shell;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Parser, Default, Debug)]
 #[clap(author, about, version)]
@@ -29,6 +30,10 @@ pub struct TerminalOptions {
     /// Start the shell in the specified working directory.
     #[clap(long, value_hint = ValueHint::FilePath)]
     pub working_dir: Option<String>,
+
+    /// Writes the config to a given path or the default location.
+    #[clap(short, long, value_hint = ValueHint::FilePath)]
+    pub write_config: Option<Option<PathBuf>>,
 }
 
 impl TerminalOptions {

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -32,7 +32,7 @@ pub struct TerminalOptions {
     pub working_dir: Option<String>,
 
     /// Writes the config to a given path or the default location.
-    #[clap(long, value_hint = ValueHint::FilePath)]
+    #[clap(long, value_name = "PATH", value_hint = ValueHint::FilePath)]
     pub write_config: Option<Option<PathBuf>>,
 }
 

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -32,7 +32,7 @@ pub struct TerminalOptions {
     pub working_dir: Option<String>,
 
     /// Writes the config to a given path or the default location.
-    #[clap(short, long, value_hint = ValueHint::FilePath)]
+    #[clap(long, value_hint = ValueHint::FilePath)]
     pub write_config: Option<Option<PathBuf>>,
 }
 

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -108,6 +108,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load command line options.
     let args = cli::Cli::parse();
 
+    let write_config_path = args.window_options.terminal_options.write_config.clone();
+    if write_config_path.is_some() {
+        let _ = setup_logs_by_filter_level("TRACE");
+        rio_backend::config::create_config_file(write_config_path.unwrap());
+        return Ok(());
+    }
+
     let (mut config, config_error) = match rio_backend::config::Config::try_load() {
         Ok(config) => (config, None),
         Err(err) => (rio_backend::config::Config::default(), Some(err)),

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -9,8 +9,6 @@ use rio_backend::config::Config as RioConfig;
 use rio_backend::error::{RioError, RioErrorLevel, RioErrorType};
 use std::collections::HashMap;
 use std::error::Error;
-use std::fs::File;
-use std::io::Write;
 use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 #[cfg(not(any(target_os = "macos", windows)))]
@@ -129,52 +127,12 @@ impl Route {
         }
 
         if self.path == RoutePath::Welcome && is_enter {
-            self.create_config_file();
+            rio_backend::config::create_config_file(None);
             self.path = RoutePath::Terminal;
             return true;
         }
 
         true
-    }
-
-    #[inline]
-    pub fn create_config_file(&self) {
-        let default_file_path = rio_backend::config::config_file_path();
-        if default_file_path.exists() {
-            return;
-        }
-
-        let default_dir_path = rio_backend::config::config_dir_path();
-        match std::fs::create_dir_all(&default_dir_path) {
-            Ok(_) => {
-                log::info!("configuration path created {}", default_dir_path.display());
-            }
-            Err(err_message) => {
-                log::error!("could not create config directory: {err_message}");
-            }
-        }
-
-        match File::create(&default_file_path) {
-            Err(err_message) => {
-                log::error!(
-                    "could not create config file {}: {err_message}",
-                    default_file_path.display()
-                )
-            }
-            Ok(mut created_file) => {
-                log::info!("configuration file created {}", default_file_path.display());
-
-                if let Err(err_message) = writeln!(
-                    created_file,
-                    "{}",
-                    rio_backend::config::config_file_content()
-                ) {
-                    log::error!(
-                        "could not update config file with defaults: {err_message}"
-                    )
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
closes #600

```bash
$ rio --write-config rio.toml
[INFO] rio_backend::config configuration file created rio.toml

$ rio --write-config
[INFO] rio_backend::config configuration path created /home/orhun/.config/rio
[INFO] rio_backend::config configuration file created /home/orhun/.config/rio/config.toml
```

Let me know if this needs any documentation update / other fixes :bear:
