### PR TITLE
refactor(cli): support a short variant (`-w`) for `--working-dir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ## Unreleased
 
 - Fix scale update on transitioning between screens with different DPI.
+- Support a short variant (`-w`) for `--working-dir` argument
 
 ## 0.1.8
 

--- a/docs/versioned_docs/version-0.0.x/command-line-interface.md
+++ b/docs/versioned_docs/version-0.0.x/command-line-interface.md
@@ -12,10 +12,10 @@ A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run 
 Usage: rio [OPTIONS]
 
 Options:
-  -e, --command <COMMAND>...  Command and args to execute (must be last argument)
-  --working-dir <WORKING_DIR>  Start the shell in the specified working directory
-  -h, --help                  Print help
-  -V, --version               Print version
+  -e, --command <COMMAND>...       Command and args to execute (must be last argument)
+  -w, --working-dir <WORKING_DIR>  Start the shell in the specified working directory
+  -h, --help                       Print help
+  -V, --version                    Print version
 ```
 
 The options "-e" and "--command" executes the command and closes the terminal right way after the execution.

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -27,7 +27,7 @@ pub struct TerminalOptions {
     pub command: Vec<String>,
 
     /// Start the shell in the specified working directory.
-    #[clap(long, value_hint = ValueHint::FilePath)]
+    #[clap(short, long, value_hint = ValueHint::FilePath)]
     pub working_dir: Option<String>,
 }
 


### PR DESCRIPTION
see #605 for the rationale
