### PR TITLE
chore(config): rename option to hide-mouse-cursor-when-typing

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -15,6 +15,7 @@ language: 'en'
 - `use-kitty-keyboard-protocol` is now `true` as default.
 - Remove tokio runtime.
 - Allow configuring with lowercase values for enums
+- Rename `hide-cursor-when-typing` to `hide-mouse-cursor-when-typing`
 
 ## 0.1.10
 

--- a/docs/docs/config/mouse.md
+++ b/docs/docs/config/mouse.md
@@ -8,5 +8,5 @@ language: 'en'
 Default is `false`
 
 ```toml
-hide-cursor-when-typing = false
+hide-mouse-cursor-when-typing = false
 ```

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -123,7 +123,7 @@ cursor = '▇'
 #
 blinking-cursor = false
 
-# Hide the cursor while typing
+# Hide the mouse cursor while typing
 #
 # Default is `false`
 #

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -124,7 +124,11 @@ pub struct Config {
     pub ignore_selection_fg_color: bool,
     #[serde(default = "default_bool_true", rename = "confirm-before-quit")]
     pub confirm_before_quit: bool,
-    #[serde(default = "bool::default", rename = "hide-cursor-when-typing")]
+    #[serde(
+        default = "bool::default",
+        rename = "hide-mouse-cursor-when-typing",
+        alias = "hide-cursor-when-typing"
+    )]
     pub hide_cursor_when_typing: bool,
     #[serde(default = "Renderer::default")]
     pub renderer: Renderer,


### PR DESCRIPTION
closes #620
