### PR TITLE
Fix invalid link in default config.toml

### DIFF
--- a/docs/docs/features/vi-mode.md
+++ b/docs/docs/features/vi-mode.md
@@ -36,7 +36,6 @@ Below you can see the list of all default key bindings related to Vi mode. If yo
 | Arrow down                | Move cursor down           | Vi mode is activated |
 | Arrow left                | Move cursor left           | Vi mode is activated |
 | Arrow right               | Move cursor right          | Vi mode is activated |
-| Arrow right               | Move cursor right          | Vi mode is activated |
 | `0`                       | Move first                 | Vi mode is activated |
 | `4` + `shift`             | Move last                  | Vi mode is activated |
 | `6` + `shift`             | Move first occupied        | Vi mode is activated |

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -436,7 +436,7 @@ pub fn default_config_file_content() -> String {
 # Bindings
 #
 # Create custom Key bindings for Rio terminal
-# More information in: https://raphamorim.io/rio/docs/key-bindings#custom-key-bindings
+# More information in: https://raphamorim.io/rio/docs/config/bindings
 #
 # Example:
 # [bindings]

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -218,7 +218,7 @@ pub fn default_config_file_content() -> String {
 # [cursor]
 # shape = 'block'
 # blinking = false
-# blinking-interval = 800 
+# blinking-interval = 800
 
 # Editor
 #


### PR DESCRIPTION
## Background
On the "bindings" section in default `config.toml`, it shows https://raphamorim.io/rio/docs/key-bindings#custom-key-bindings but this link is invalid now.
It seems https://raphamorim.io/rio/docs/config/bindings is correct, I think.
