### PR TITLE
[i18n] Japanese support for landing page

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -14,6 +14,7 @@ const tagline = {
   'pt-br': 'Terminal moderno para o século 21',
   es: 'Una terminal moderna para el siglo 21.',
   pl: 'Nowoczesny terminal na miarę XXI wieku.',
+  ja: '21世紀のモダンターミナル'
 };
 
 /** @type {import('@docusaurus/types').Config} */
@@ -29,7 +30,7 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   i18n: {
     defaultLocale,
-    locales: ['en', 'ko', 'pt-br', 'es', 'pl'],
+    locales: ['en', 'ko', 'pt-br', 'es', 'pl', 'ja'],
   },
 
   headTags: [

--- a/docs/i18n/ja/code.json
+++ b/docs/i18n/ja/code.json
@@ -1,0 +1,46 @@
+{
+  "Install": {
+    "message": "インストール"
+  },
+
+  "Loved by many engineers": {
+    "message": "エンジニアから広く愛されています"
+  },
+
+  "home.features.fast-and-fast.title": {
+    "message": "超高速"
+  },
+  "home.features.fast-and-fast.description": {
+    "message": "RioはRustや高度なレンダリングアーキテクチャを活用することで圧倒的なパフォーマンスを実現しています。"
+  },
+  "home.features.24-bit-true-color.title": {
+    "message": "24ビット トゥルーカラー"
+  },
+  "home.features.24-bit-true-color.description": {
+    "message": "一般的なターミナルは256色に制限されていますが、Rioは「トゥルーカラー」に対応し、1,600万色もの豊かな色彩表現が可能です。"
+  },
+  "home.features.images-in-terminal.title": {
+    "message": "ターミナル内で画像を表示"
+  },
+  "home.features.images-in-terminal.description": {
+    "message": "SixelやiTerm2の画像プロトコルを使用し、ターミナル内で画像を表示することが可能です。"
+  },
+  "home.features.cross-platform.title": {
+    "message": "クロスプラットフォーム"
+  },
+  "home.features.cross-platform.description": {
+    "message": "RioはWindows、macOS、Linux、FreeBSDで動作するクロスプラットフォームアプリです。"
+  },
+  "home.features.font-ligatures.title": {
+    "message": "フォント合字"
+  },
+  "home.features.font-ligatures.description": {
+    "message": "よく使われる記号列や演算子の可読性を向上させるため、フォント合字に対応しています。"
+  },
+  "home.features.splits.title": {
+    "message": "画面分割"
+  },
+  "home.features.splits.description": {
+    "message": "あらゆるプラットフォームで、ターミナル画面を分割・管理することができます。"
+  }
+}

--- a/docs/i18n/ja/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/ja/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,30 @@
+{
+  "item.label.Install": {
+    "message": "インストール",
+    "description": "Navbar item with label Install"
+  },
+  "item.label.Config": {
+    "message": "設定",
+    "description": "Navbar item with label Config"
+  },
+  "item.label.Features": {
+    "message": "機能",
+    "description": "Navbar item with label Features"
+  },
+  "item.label.Releases": {
+    "message": "リリース",
+    "description": "Navbar item with label Releases"
+  },
+  "item.label.Blog": {
+    "message": "ブログ",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.Discord": {
+    "message": "Discord",
+    "description": "Navbar item with label Discord"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/docs/src/data/features.js
+++ b/docs/src/data/features.js
@@ -80,12 +80,12 @@ const FEATURES = [
   {
     title: translate({
       message: 'Splits',
-      id: 'home.features.font-ligatures.title',
+      id: 'home.features.splits.title',
     }),
     Icon: Splits,
     description: (
-      <Translate id="home.features.font-ligatures.description">
-        Support to split and manage terminal screens in any platform that you would want to. 
+      <Translate id="home.features.splits.description">
+        Support to split and manage terminal screens in any platform that you would want to.
       </Translate>
     ),
   },


### PR DESCRIPTION
Added Japanese translation for landing page :)

![Screenshot 2024-09-22 at 0 13 49](https://github.com/user-attachments/assets/c8f69a0c-4816-46a2-b6ad-247369ff10c4)
