### PR TITLE
Use as default thin lto instead to use full lto

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,5 @@ rustflags = [
 ]
 runner = 'wasm-bindgen-test-runner'
 
+[target.x86_64-pc-windows-gnu]
+lto = true  

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,5 +5,12 @@ rustflags = [
 ]
 runner = 'wasm-bindgen-test-runner'
 
+[target.aarch64-apple-darwin]
+rustflags = [
+    # We can guarantee that this target will always run on a CPU with _at least_
+    # these capabilities, so let's optimize for them
+    "-Ctarget-cpu=apple-m1"
+]
+
 [target.x86_64-pc-windows-gnu]
 lto = true  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,3 @@ split-debuginfo = "unpacked"
 lto = false
 incremental = true
 opt-level = 0
-
-[target.x86_64-pc-windows-gnu]
-lto = true  
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,7 @@ split-debuginfo = "unpacked"
 lto = false
 incremental = true
 opt-level = 0
+
+[target.x86_64-pc-windows-gnu.profile.release]
+lto = true  
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ tracing = "0.1.40"
 objc = "0.2.7"
 
 [profile.release]
-lto = true
+lto = "thin"
 strip = true
 debug = "limited"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,6 @@ lto = false
 incremental = true
 opt-level = 0
 
-[target.x86_64-pc-windows-gnu.profile.release]
+[target.x86_64-pc-windows-gnu]
 lto = true  
 


### PR DESCRIPTION
Hello, I noticed issue #737, and after some investigation, I would like to suggest switching from full LTO to ThinLTO. This change will optimize the compilation process more effectively than full LTO, resolve the compilation issues associated with it, and speed up the overall compilation time.

Best Regards,
NextWorks