### PR TITLE
Makes editor.args and shell.args optional in config.toml

### DIFF
--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -33,6 +33,7 @@ pub enum ConfigError {
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Shell {
     pub program: String,
+    #[serde(default)]
     pub args: Vec<String>,
 }
 
@@ -1003,6 +1004,19 @@ mod tests {
 
         assert_eq!(result.shell.program, "/bin/fish");
         assert_eq!(result.shell.args, ["--hello"]);
+    }
+
+    #[test]
+    fn test_shell_no_args() {
+        let result = create_temporary_config(
+            "change-shell-and-editor",
+            r#"
+            shell = { program = "/bin/bash" }
+        "#,
+        );
+
+        assert_eq!(result.shell.program, "/bin/bash");
+        assert_eq!(result.shell.args, Vec::<&str>::new());
     }
 
     #[test]

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -1009,13 +1009,13 @@ mod tests {
     #[test]
     fn test_shell_no_args() {
         let result = create_temporary_config(
-            "change-shell-and-editor",
+            "change-shell-and-editor-no-args",
             r#"
-            shell = { program = "/bin/bash" }
+            shell = { program = "/bin/fish" }
         "#,
         );
 
-        assert_eq!(result.shell.program, "/bin/bash");
+        assert_eq!(result.shell.program, "/bin/fish");
         assert_eq!(result.shell.args, Vec::<&str>::new());
     }
 


### PR DESCRIPTION
Fixes: https://github.com/raphamorim/rio/issues/801