### PR TITLE
Allow Setting Window Title

### DIFF
--- a/docs/docs/command-line-interface.md
+++ b/docs/docs/command-line-interface.md
@@ -16,6 +16,7 @@ Options:
   -w, --working-dir <WORKING_DIR>  Start the shell in the specified working directory
       --write-config [<PATH>]      Writes the config to a given path or the default location
       --log-file                   Writes the logs to a file inside the config directory
+      --title <TITLE>              Start window with specified title
   -h, --help                       Print help
   -V, --version                    Print version
 ```

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -39,7 +39,7 @@ pub struct TerminalOptions {
     #[clap(long)]
     pub enable_log_file: bool,
 
-    /// Start windown with specified title
+    /// Start window with specified title
     #[clap(long)]
     pub title: Option<String>,
 }

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -38,6 +38,10 @@ pub struct TerminalOptions {
     /// Writes the logs to a file inside the config directory.
     #[clap(long)]
     pub enable_log_file: bool,
+
+    /// Start windown with specified title
+    #[clap(long)]
+    pub title: Option<String>,
 }
 
 impl TerminalOptions {

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -181,6 +181,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Some(working_dir_cli) = args.window_options.terminal_options.working_dir {
             config.working_dir = Some(working_dir_cli);
         }
+
+        config.window.title = args.window_options.terminal_options.title;
     }
 
     #[cfg(target_os = "linux")]

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -182,7 +182,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             config.working_dir = Some(working_dir_cli);
         }
 
-        config.window.title = args.window_options.terminal_options.title;
+        config.window.initial_title = args.window_options.terminal_options.title;
     }
 
     #[cfg(target_os = "linux")]

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -168,7 +168,7 @@ pub fn configure_window(winit_window: &Window, config: &Config) {
         winit_window.set_has_shadow(!is_transparent);
     }
 
-    if let Some(title) = &config.window.title {
+    if let Some(title) = &config.window.initial_title {
         winit_window.set_title(title);
     }
 

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -168,5 +168,9 @@ pub fn configure_window(winit_window: &Window, config: &Config) {
         winit_window.set_has_shadow(!is_transparent);
     }
 
+    if let Some(title) = &config.window.title {
+        winit_window.set_title(title);
+    }
+
     winit_window.set_blur(config.window.blur);
 }

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -57,7 +57,7 @@ pub struct Window {
     pub decorations: Decorations,
     #[serde(default = "bool::default", rename = "macos-use-unified-titlebar")]
     pub macos_use_unified_titlebar: bool,
-    #[serde(skip_serializing)]
+    #[serde(rename = "initial_title", skip_serializing)]
     pub title: Option<String>,
 }
 

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -57,6 +57,8 @@ pub struct Window {
     pub decorations: Decorations,
     #[serde(default = "bool::default", rename = "macos-use-unified-titlebar")]
     pub macos_use_unified_titlebar: bool,
+    #[serde(skip_serializing)]
+    pub title: Option<String>,
 }
 
 impl Default for Window {
@@ -70,6 +72,7 @@ impl Default for Window {
             decorations: Decorations::default(),
             blur: false,
             macos_use_unified_titlebar: false,
+            title: None,
         }
     }
 }

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -57,7 +57,7 @@ pub struct Window {
     pub decorations: Decorations,
     #[serde(default = "bool::default", rename = "macos-use-unified-titlebar")]
     pub macos_use_unified_titlebar: bool,
-    #[serde(skip_serializing)]
+    #[serde(rename = "initial-title", skip_serializing)]
     pub initial_title: Option<String>,
 }
 

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -57,8 +57,8 @@ pub struct Window {
     pub decorations: Decorations,
     #[serde(default = "bool::default", rename = "macos-use-unified-titlebar")]
     pub macos_use_unified_titlebar: bool,
-    #[serde(rename = "initial_title", skip_serializing)]
-    pub title: Option<String>,
+    #[serde(skip_serializing)]
+    pub initial_title: Option<String>,
 }
 
 impl Default for Window {
@@ -72,7 +72,7 @@ impl Default for Window {
             decorations: Decorations::default(),
             blur: false,
             macos_use_unified_titlebar: false,
-            title: None,
+            initial_title: None,
         }
     }
 }


### PR DESCRIPTION
This PR adds support for specifying a custom window title using the --title argument in the CLI. This feature allows users to define a specific name for the window, improving usability in multi-window setups and enabling better integration with window managers.

### Default window title
![image](https://github.com/user-attachments/assets/8ea6097d-769c-4b27-9c68-20b081577d69)
### Custom name with `--title` flag
![image](https://github.com/user-attachments/assets/d56d7341-4fb8-40dd-bb98-638e69c6b201)


closes #405 