### PR TITLE
fix y-axis hint in config and docs

### DIFF
--- a/docs/docs/config/padding.md
+++ b/docs/docs/config/padding.md
@@ -13,7 +13,7 @@ padding-x = 10
 
 ## Padding-y
 
-Define y axis padding based on a format `[top, left]`
+Define y axis padding based on a format `[top, bottom]`
 
 - Default is `[0, 0]`
 

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -294,7 +294,7 @@ args = ["-w"]
 - Fix key bindings when key is uppercased (`alt` or `shift` is inputted along).
 - Support to padding-y (ref: [#400](https://github.com/raphamorim/rio/issues/400))
 
-Define y axis padding based on a format `[top, left]`, default is `[0, 0]`.
+Define y axis padding based on a format `[top, bottom]`, default is `[0, 0]`.
 
 Example:
 

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -157,7 +157,7 @@ pub fn default_config_file_content() -> String {
 
 # Padding-y
 #
-# define y axis padding based on a format [top, left]
+# define y axis padding based on a format [top, bottom]
 # (default is [0, 0])
 #
 # Example:


### PR DESCRIPTION
This little revision corrects the little helper text for the `padding-y` in the config. I was so confused!