### PR TITLE
Add warning about the editor path

### DIFF
--- a/docs/docs/config/editor.md
+++ b/docs/docs/config/editor.md
@@ -3,11 +3,11 @@ title: 'editor'
 language: 'en'
 ---
 
-Default editor is `vi`.
+This setting specifies the editor Rio will use to open the configuration file. By default, the editor is set to `vi`.
 
-Whenever the key binding `OpenConfigEditor` is triggered it will use the value of the editor along with the rio configuration path.
+Whenever the key binding `OpenConfigEditor` is triggered, Rio will use the configured editor and the path to the Rio configuration file.
 
-An example, considering you have VS Code installed and you want to use it as your editor:
+For example, if you have VS Code installed and want to use it as your editor, the configuration would look like this:
 
 ```toml
 [editor]
@@ -15,4 +15,17 @@ program = "code"
 args = []
 ```
 
-Whenever `OpenConfigEditor` runs it will trigger `$ code <path-to-rio-configuration-file>`.
+When `OpenConfigEditor` is triggered, it will execute the command:
+`$ code <path-to-rio-configuration-file>`.
+
+:::warning
+
+If you set a value for `program`, Rio will look for it in the default system application directory (`/usr/bin` on Linux and macOS). If your desired editor is not in this directory, you must specify its full path:
+
+```toml
+[editor]
+program = "/usr/local/bin/code"
+args = []
+```
+
+:::


### PR DESCRIPTION
This PR addresses the discussion in https://github.com/raphamorim/rio/issues/832 by improving the documentation for the `editor` setting. It now mentions that the full path to the editor binary may be required in certain cases. Since I am unfamiliar with how Rio resolves binaries on Windows, the documentation changes are currently focused on Unix-like systems. Please feel free to expand or adjust it as needed!

As a side note, I think it's a good idea to keep that issue open if there are plans to revisit this behavior in the future. Many users likely expect that whatever is in their `PATH` should work seamlessly (at least, that’s my perspective).