### PR TITLE
add support for moving forward tabs

### DIFF
--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -18,6 +18,7 @@ language: 'en'
 - Kitty keyboard protocol is now enabled by default.
 - Allow `Renderer` to be configured cross-platform by `Platform` property.
 - Add `ToggleFullscreen` to configurable actions.
+- Support for `CSI n I` (Cursor Forward Tabulation) to move the cursor forward by a specified number of tabs.
 
 ## 0.2.2
 

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -2348,6 +2348,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
             let cell = self.grid.cursor_square();
             if cell.c == ' ' {
                 cell.c = c;
+                self.damage_cursor();
             }
 
             loop {
@@ -2377,7 +2378,9 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
     #[inline]
     fn move_forward_tabs(&mut self, count: u16) {
-        trace!("[unimplemented] Moving forward {} tabs", count);
+        trace!("Moving forward {} tabs", count);
+
+        self.put_tab(count);
     }
 
     #[inline]


### PR DESCRIPTION
This adds support for moving forward tabs in the grid using `CSI n I`. This sequence behaves like using tabs `\t` but also accepts a count argument to move multiple tabs forward.