### PR TITLE
Update windows-sys crate version to 0.59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3463,7 +3463,7 @@ dependencies = [
  "parking_lot",
  "signal-hook",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/teletypewriter/Cargo.toml
+++ b/teletypewriter/Cargo.toml
@@ -19,7 +19,7 @@ signal-hook = "0.3.17"
 iovec = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48", features = [
+windows-sys = { version = "0.59", features = [
     "Win32_System_Console",
     "Win32_Foundation",
     "Win32_Security",

--- a/teletypewriter/src/windows/conpty.rs
+++ b/teletypewriter/src/windows/conpty.rs
@@ -68,7 +68,7 @@ impl ConptyApi {
         type LoadedFn = unsafe extern "system" fn() -> isize;
         unsafe {
             let hmodule = LoadLibraryW(w!("conpty.dll"));
-            if hmodule == 0 {
+            if hmodule.is_null() {
                 return None;
             }
             let create_fn = GetProcAddress(hmodule, s!("CreatePseudoConsole"))?;

--- a/teletypewriter/src/windows/pipes.rs
+++ b/teletypewriter/src/windows/pipes.rs
@@ -201,7 +201,7 @@ impl Drop for EventedAnonRead {
 
         // Stop reader thread waiting for pipe contents
         unsafe {
-            CancelSynchronousIo(thread.as_raw_handle() as isize);
+            CancelSynchronousIo(thread.as_raw_handle());
         }
 
         thread


### PR DESCRIPTION
- Updates window.sys to version 0.58.
- A key change to this version is that the HANDLE type is now `*mut c_void`, so the code was changed to accomodate this.
- An important change is the manual implementation of the `Send` trait for `ChildExistWatcher`. The trait can no longer derived automatically because `*mut c_void` is not Send. However, pointers
are not Send more as a lint to developers (eg: a pointer to Rc<T>
would be safe), but `c_void` is Send and therefore it should be fine to derive it manually for the pointer.

See https://doc.rust-lang.org/nomicon/send-and-sync.html for details.