### PR TITLE
fix(rioterm): inherit workspace readme for crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rust-version = "1.84.0"
 repository = "https://github.com/raphamorim/rio"
 homepage = "https://raphamorim.io/rio"
 documentation = "https://github.com/raphamorim/rio#readme"
+readme = "README.md"
 
 [workspace.dependencies]
 # Note: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
+readme.workspace = true
 
 [[bin]]
 name = "rio"


### PR DESCRIPTION
Fixes the empty readme on crates.io 😄  

![image](https://github.com/user-attachments/assets/c7b2dd7c-242a-4209-aa55-44bbe7a12b6d)
