### PR TITLE
docs: fix broken link to nixpkgs

### DIFF
--- a/docs/docs/install/linux.md
+++ b/docs/docs/install/linux.md
@@ -7,7 +7,7 @@ Installation options:
 
 - Alpine Linux package: [pkgs.alpinelinux.org/packages?name=rio](https://pkgs.alpinelinux.org/packages?name=rio)
 - Arch Linux package: [archlinux.org/packages/extra/x86_64/rio](https://archlinux.org/packages/extra/x86_64/rio) (or [rio-git](https://aur.archlinux.org/packages/rio-git) from AUR)
-- Nix package: [NixOS/nixpkgs/rio](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/terminal-emulators/rio/default.nix)
+- Nix package: [NixOS/nixpkgs/rio](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ri/rio/package.nix)
 - openSUSE package: [openSUSE:Factory/rioterm](https://software.opensuse.org/package/rioterm)
 - Void Linux package: https://github.com/void-linux/void-packages/tree/master/srcpkgs/rio
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/docs/install/linux.md` file. The change updates the URL for the Nix package to reflect its new location.

Installation options:

* [`docs/docs/install/linux.md`](diffhunk://#diff-5a0f71498c8933d77e8d9628f787709cf3335503e3bb58abefb72a1a39b26107L10-R10): Updated the URL for the Nix package to the new path `pkgs/by-name/ri/rio/package.nix`.