### PR TITLE
fix: Better handling of Escape and Enter keys

### DIFF
--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -11,6 +11,8 @@ language: 'en'
 	- OSC 7 Escape sequences to advise the terminal of the working directory.
 	- OSC 133 Escape sequence to define Input, Output and Prompt zones.
 	- OSC 1337 Escape sequences to set user vars for tracking additional shell state.
+- Fix: Block writing to the shell when rendering the `Assistant` route.
+- Fix: Immediately render the `Terminal` route when switching from the `Assistant`, `ConfirmToQuit` or `Welcome`, thus avoiding the need to double press `Enter`.
 
 ## 0.2.4
 

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -101,10 +101,10 @@ impl Route<'_> {
 
     #[inline]
     pub fn report_error(&mut self, error: &RioError) {
-        if error.report == RioErrorType::ConfigurationNotFound {
-            self.path = RoutePath::Welcome;
-            return;
-        }
+        // if error.report == RioErrorType::ConfigurationNotFound {
+        //     self.path = RoutePath::Welcome;
+        //     return;
+        // }
 
         self.assistant.set(error.to_owned());
         self.path = RoutePath::Assistant;
@@ -133,13 +133,13 @@ impl Route<'_> {
         }
 
         let is_enter = key_event.logical_key == Key::Named(NamedKey::Enter);
-        if self.path == RoutePath::Assistant && is_enter {
-            if self.assistant.is_warning() {
+        if self.path == RoutePath::Assistant {
+            if self.assistant.is_warning() && is_enter {
                 self.assistant.clear();
                 self.path = RoutePath::Terminal;
+            } else {
+                return true;
             }
-
-            return true;
         }
 
         if self.path == RoutePath::ConfirmQuit {
@@ -147,18 +147,17 @@ impl Route<'_> {
                 self.path = RoutePath::Terminal;
             } else if is_enter {
                 self.quit();
-            }
 
-            return true;
+                return true;
+            }
         }
 
         if self.path == RoutePath::Welcome && is_enter {
             rio_backend::config::create_config_file(None);
             self.path = RoutePath::Terminal;
-            return true;
         }
 
-        true
+        false
     }
 }
 

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -101,10 +101,10 @@ impl Route<'_> {
 
     #[inline]
     pub fn report_error(&mut self, error: &RioError) {
-        // if error.report == RioErrorType::ConfigurationNotFound {
-        //     self.path = RoutePath::Welcome;
-        //     return;
-        // }
+        if error.report == RioErrorType::ConfigurationNotFound {
+            self.path = RoutePath::Welcome;
+            return;
+        }
 
         self.assistant.set(error.to_owned());
         self.path = RoutePath::Assistant;

--- a/frontends/rioterm/src/router/routes/assistant.rs
+++ b/frontends/rioterm/src/router/routes/assistant.rs
@@ -83,7 +83,7 @@ pub fn screen(
         if report.level == RioErrorLevel::Warning {
             objects.push(Object::Text(Text::single_line(
                 (70., context_dimension.margin.top_y + 80.),
-                String::from("(press enter twice to continue)"),
+                String::from("(press enter to continue)"),
                 18.,
                 [1., 1., 1., 1.],
             )));


### PR DESCRIPTION
## Fixes
- No more need to press **twice** the Enter key in `ConfirmQuit`, `Welcome` or `Assistant` routes.
- Writing (and therefore pasting) was allowed while rendering the `Assistant` route. You could run stuff by pasting scripts with breaklines without the need to go to the terminal route

LMK if I broke something but from my own tests all went just fine