### PR TITLE
update default font style from normal to Normal

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -210,25 +210,25 @@ features = []
 
 [fonts.regular]
 family = "cascadiacode"
-style = "normal"
+style = "Normal"
 width = "Normal"
 weight = 400
 
 [fonts.bold]
 family = "cascadiacode"
-style = "normal"
+style = "Normal"
 width = "Normal"
 weight = 800
 
 [fonts.italic]
 family = "cascadiacode"
-style = "italic"
+style = "Italic"
 width = "Normal"
 weight = 400
 
 [fonts.bold-italic]
 family = "cascadiacode"
-style = "italic"
+style = "Italic"
 width = "Normal"
 weight = 800
 ```
@@ -870,7 +870,7 @@ Result: `zsh`
 ## title.placeholder
 
 Configure initial title.
-  
+
 ```toml
 [title]
 placeholder = "▲"
@@ -1015,7 +1015,7 @@ Example:
 decorations = "Enabled"
 ```
 
-## window.macos-use-unified-titlebar 
+## window.macos-use-unified-titlebar
 
 You can use MacOS unified titlebar by config, it's disabled by default.
 

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -346,22 +346,22 @@ pub fn default_config_file_content() -> String {
 #
 # [fonts.regular]
 # family = "cascadiamono"
-# style = "normal"
+# style = "Normal"
 # weight = 400
 #
 # [fonts.bold]
 # family = "cascadiamono"
-# style = "normal"
+# style = "Normal"
 # weight = 800
 #
 # [fonts.italic]
 # family = "cascadiamono"
-# style = "italic"
+# style = "Italic"
 # weight = 400
 #
 # [fonts.bold-italic]
 # family = "cascadiamono"
-# style = "italic"
+# style = "Italic"
 # weight = 800
 
 # Scroll


### PR DESCRIPTION
## Update default font style on config and docs

Default font style values is writtend as 'normal' and 'italic' both throw an error because is expect that styles to be "Normal" and "Italic"

![Screenshot 2025-02-01 at 10 04 56](https://github.com/user-attachments/assets/dfa8765d-10ff-46e7-b2cc-7fa29a6064ce)

### What I did

*Capitalize font style values in the docs and in `rio-backend/src/config/defaults.rs` 
  - Change "normal" to "Normal"
  - Change "italic" to "Italic"

  

