### PR TITLE
Update broken link on generated config.toml

### DIFF
--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -456,7 +456,7 @@ pub fn default_config_file_content() -> String {
 # Bindings
 #
 # Create custom Key bindings for Rio terminal
-# More information in: https://raphamorim.io/rio/docs/config/bindings
+# More information in: https://raphamorim.io/rio/docs/key-bindings
 #
 # Example:
 # [bindings]


### PR DESCRIPTION
I noticed that the link below is deprecated, as it results in a "not found" page:

https://github.com/raphamorim/rio/blob/9bfd12dff3dd69f72c6c3e7db0d48717259e9890/rio-backend/src/config/defaults.rs#L459

This PR is to update this link.