### PR TITLE
ci: native macos notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
       MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-      MACOS_NOTARY_PROFILE: ${{ secrets.MACOS_NOTARY_PROFILE }}
+      MACOS_NOTARY_KEYCHAIN_PROFILE: ${{ secrets.MACOS_NOTARY_KEYCHAIN_PROFILE }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
 
           # create notary profile
-          xcrun notarytool store-credentials $MACOS_NOTARY_PROFILE \
+          xcrun notarytool store-credentials $MACOS_NOTARY_KEYCHAIN_PROFILE \
             --key $KEY_PATH \
             --key-id $MACOS_NOTARY_KEY_ID \
             --issuer $MACOS_NOTARY_ISSUER_ID \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,10 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
 
           # create notary profile
-          xcrun notarytool store-credentials $MACOS_NOTARY_KEYCHAIN_PROFILE \
-            --key $KEY_PATH \
-            --key-id $MACOS_NOTARY_KEY_ID \
-            --issuer $MACOS_NOTARY_ISSUER_ID \
+          xcrun notarytool store-credentials "$MACOS_NOTARY_KEYCHAIN_PROFILE" \
+            --key "$KEY_PATH" \
+            --key-id "$MACOS_NOTARY_KEY_ID" \
+            --issuer "$MACOS_NOTARY_ISSUER_ID" \
             --keychain $KEYCHAIN_PATH
 
           # export the keychain path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,14 @@
 name: Release
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
     paths:
-      - '.github/workflows/release.yml'
-      - '.goreleaser.yaml'
+      - ".github/workflows/release.yml"
+      - ".goreleaser.yaml"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 concurrency:
   group: release-${{ github.event_name }}-${{ github.ref_name }}
@@ -42,6 +42,8 @@ jobs:
       MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
       MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
       MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      MACOS_NOTARY_PROFILE: ${{ secrets.MACOS_NOTARY_PROFILE }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,6 +60,37 @@ jobs:
         run: rustup target add x86_64-apple-darwin
       - if: matrix.os == 'windows-latest'
         run: rustup target add aarch64-pc-windows-msvc
+      - if: matrix.os == 'macos-latest'
+        run: |
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/goreleaser.p12
+          KEY_PATH=$RUNNER_TEMP/goreleaser.p8
+          KEYCHAIN_PATH=$RUNNER_TEMP/goreleaser.keychain-db
+
+          # import certificate and key from secrets
+          echo -n "$MACOS_SIGN_P12" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$MACOS_NOTARY_KEY" | base64 --decode -o $KEY_PATH
+
+          # create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$MACOS_SIGN_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # create notary profile
+          xcrun notarytool store-credentials $MACOS_NOTARY_PROFILE \
+            --key $KEY_PATH \
+            --key-id $MACOS_NOTARY_KEY_ID \
+            --issuer $MACOS_NOTARY_ISSUER_ID \
+            --keychain $KEYCHAIN_PATH
+
+          # export the keychain path
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >>$GITHUB_ENV
+
       - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && steps.cache-check.outputs.cache-hit != 'true'
         uses: goreleaser/goreleaser-action@v6.2.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ misc/72/
 
 # goreleaser
 dist/
-.intentionally-empty-file.o

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ misc/72/
 
 # goreleaser
 dist/
+.intentionally-empty-file.o

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,10 +119,10 @@ notarize:
     - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
       sign:
         identity: "Developer ID Application: Hugo Amorim"
+        keychain: "{{ .Env.KEYCHAIN_PATH }}"
         options: [runtime]
       notarize:
         wait: true
-        keychain: "{{ .Env.KEYCHAIN_PATH }}"
         profile_name: "{{ .Env.MACOS_NOTARY_KEYCHAIN_PROFILE }}"
 
 app_bundles:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -115,17 +115,15 @@ dmg:
     use: appbundle
 
 notarize:
-  macos:
-    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+  macos_native:
+    - enabled: "true"
       sign:
-        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
-        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+        identity: "Developer ID Application: Hugo Amorim"
+        options: [runtime]
       notarize:
-        issuer_id: "{{ .Env.MACOS_NOTARY_ISSUER_ID }}"
-        key: "{{ .Env.MACOS_NOTARY_KEY }}"
-        key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
         wait: true
-        timeout: 20m
+        keychain: "{{ .Env.KEYCHAIN_PATH }}"
+        profile_name: "{{ .Env.MACOS_NOTARY_PROFILE }}"
 
 app_bundles:
   - icon: ./misc/osx/Rio.app/Contents/Resources/icon.icns
@@ -249,32 +247,32 @@ winget:
 after:
   hooks:
     - cmd: brew bump-cask-pr rio --version {{ .Version }}
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       env: ["HOMEBREW_GITHUB_API_TOKEN={{ .Env.GITHUB_TOKEN }}"]
       output: true
     - cmd: cargo publish -p rio-window
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       output: true
     - cmd: cargo publish -p sugarloaf
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       output: true
     - cmd: cargo publish -p rio-proc-macros
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       output: true
     - cmd: cargo publish -p copa
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       output: true
     - cmd: cargo publish -p corcovado
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       output: true
     - cmd: cargo publish -p teletypewriter
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       output: true
     - cmd: cargo publish -p rio-backend
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       output: true
     - cmd: cargo publish -p rioterm
-      if: "{{ not .IsNightly }}"
+      if: "{{ .IsRelease }}"
       output: true
 
 metadata:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -123,7 +123,7 @@ notarize:
       notarize:
         wait: true
         keychain: "{{ .Env.KEYCHAIN_PATH }}"
-        profile_name: "{{ .Env.MACOS_NOTARY_PROFILE }}"
+        profile_name: "{{ .Env.MACOS_NOTARY_KEYCHAIN_PROFILE }}"
 
 app_bundles:
   - icon: ./misc/osx/Rio.app/Contents/Resources/icon.icns

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -116,7 +116,7 @@ dmg:
 
 notarize:
   macos_native:
-    - enabled: "true"
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
       sign:
         identity: "Developer ID Application: Hugo Amorim"
         options: [runtime]


### PR DESCRIPTION
@raphamorim you'll need to set 2 more secrets:

```sh
gh secret set KEYCHAIN_PASSWORD --body "some password to lock and unlock the keychain"
gh secret set MACOS_NOTARY_KEYCHAIN_PROFILE --body "a profile name"
```

this uses the recently added native notarization: https://goreleaser.com/customization/notarize/#application-bundles-and-dmgs