### PR TITLE
Small changes to macOS info.plist file

### DIFF
--- a/misc/osx/Rio.app/Contents/Info.plist
+++ b/misc/osx/Rio.app/Contents/Info.plist
@@ -92,6 +92,8 @@
   <string>APPL</string>
   <key>CFBundleIconFile</key>
   <string>icon</string>
+  <key>MDItemKeywords</key>
+  <string>Terminal</string>
   <key>CFBundleShortVersionString</key>
   <string>{{.Version}}</string>
   <key>CFBundleVersion</key>

--- a/misc/osx/Rio.app/Contents/Info.plist
+++ b/misc/osx/Rio.app/Contents/Info.plist
@@ -71,6 +71,14 @@
             <string>txt</string>
         </array>
     </dict>
+    <dict>
+        <key>CFBundleTypeRole</key>
+        <string>Shell</string>
+        <key>LSItemContentTypes</key>
+        <array>
+            <string>public.unix-executable</string>
+        </array>
+	</dict>
   </array>
   <key>CFBundleIdentifier</key>
   <string>com.raphaelamorim.rio</string>


### PR DESCRIPTION
Made changes that now allows Rio to be used to execute unix executables, not just trying to open them in an editor.
(Edit, oh yeah and added terminal as a keyword for the app so in shows up in spotlight when searching terminal)

(This may or may not work, I didn't bother to try, just yoinked the idea from an another terminal.)
There's also other goodies in there, if you want you can throw this one into the can and do a bigger refactor :)