### PR TITLE
feat: symbol-map

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -294,7 +294,7 @@ Has no default values. Example values are shown below:
 ```toml
 fonts.symbol-map = [
   // covers: '⊗','⊘','⊙'
-  { start = "2297", end = "2299", font-family = "Cascadia Code Nerd Font" }
+  { start = "2297", end = "2299", font-family = "Cascadia Code NF" }
 ]
 ```
 
@@ -305,7 +305,7 @@ In case you would like to map many codepoints:
 ```toml
 fonts.symbol-map = [
   { start = "E0A0", end = "E0A3", font-family = "PowerlineSymbols" },
-  { start = "E0C0", end = "E0C7", font-family = "PowerlineSymbols" },
+  { start = "E0C0", end = "E0C7", font-family = "PowerlineSymbols" }
 ]
 ```
 

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -7,8 +7,12 @@ language: 'en'
 
 ## 0.2.9 (unreleased)
 
+- Support to symbol map configuration: `fonts.symbol-map`:
+```toml
+# covers: '⊗','⊘','⊙'
+fonts.symbol-map = [{ start = "2297", end = "2299", font-family = "Cascadia Code NF" }]
+```
 - Add Switch to Next/Prev Split or Tab command by [@vlabo](https://github.com/vlabo).
-- Support to symbol map configuration: `fonts.symbol-map`.
 - Fix issue whenever the first main font cannot be found.
 
 ## 0.2.8

--- a/frontends/rioterm/src/context/grid.rs
+++ b/frontends/rioterm/src/context/grid.rs
@@ -152,7 +152,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             self.current += 1;
         }
 
-        return true;
+        true
     }
 
     #[inline]
@@ -179,7 +179,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
         } else {
             self.current -= 1;
         }
-        return true;
+        true
     }
 
     #[inline]

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -340,7 +340,14 @@ pub fn default_config_file_content() -> String {
 # [fonts]
 # hinting = false
 #
-# Example:
+# You can also map the specified Unicode codepoints to a particular font.
+# [fonts]
+# symbol-map = [
+#   // covers: '⊗','⊘','⊙'
+#   { start = "2297", end = "2299", font-family = "Cascadia Code NF" }
+# ]
+#
+# Simple example:
 # [fonts]
 # size = 18
 #

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -1049,7 +1049,7 @@ mod tests {
             "symbol-map",
             r#"
             fonts.symbol-map = [
-                // covers: '⊗','⊘','⊙'
+                # covers: '⊗','⊘','⊙'
                 { start = "2297", end = "2299", font-family = "PowerlineSymbols" }
             ]
         "#,

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -526,6 +526,7 @@ mod tests {
     use super::*;
     use colors::{hex_to_color_arr, hex_to_color_wgpu};
     use std::io::Write;
+    use sugarloaf::font::fonts::parse_unicode;
 
     fn tmp_dir() -> PathBuf {
         std::env::temp_dir()
@@ -1044,11 +1045,6 @@ mod tests {
 
     #[test]
     fn test_symbol_map() {
-        fn unsafe_parse_unicode(input: &str) -> char {
-            let unicode = u32::from_str_radix(input, 16).unwrap();
-            char::from_u32(unicode).unwrap()
-        }
-
         let result = create_temporary_config(
             "symbol-map",
             r#"
@@ -1066,7 +1062,7 @@ mod tests {
         assert_eq!(symbol_map[0].start, "E0C0");
         assert_eq!(symbol_map[0].end, "E0C7");
 
-        assert_eq!(unsafe_parse_unicode(&symbol_map[0].start), '\u{E0C0}');
-        assert_eq!(unsafe_parse_unicode(&symbol_map[0].end), '\u{E0C7}');
+        assert_eq!(parse_unicode(&symbol_map[0].start), Some('\u{E0C0}'));
+        assert_eq!(parse_unicode(&symbol_map[0].end), Some('\u{E0C7}'));
     }
 }

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -1050,19 +1050,27 @@ mod tests {
             r#"
             fonts.symbol-map = [
                 # covers: '⊗','⊘','⊙'
-                { start = "2297", end = "2299", font-family = "PowerlineSymbols" }
+                { start = "2297", end = "2299", font-family = "PowerlineSymbols" },
+                { start = "E0C0", end = "E0C7", font-family = "Cascadia Code NF" },
             ]
         "#,
         );
 
         assert!(result.fonts.symbol_map.is_some());
         let symbol_map = result.fonts.symbol_map.unwrap();
-        assert_eq!(symbol_map.len(), 1);
+        assert_eq!(symbol_map.len(), 2);
         assert_eq!(symbol_map[0].font_family, "PowerlineSymbols");
-        assert_eq!(symbol_map[0].start, "E0C0");
-        assert_eq!(symbol_map[0].end, "E0C7");
+        assert_eq!(symbol_map[0].start, "2297");
+        assert_eq!(symbol_map[0].end, "2299");
 
-        assert_eq!(parse_unicode(&symbol_map[0].start), Some('\u{E0C0}'));
-        assert_eq!(parse_unicode(&symbol_map[0].end), Some('\u{E0C7}'));
+        assert_eq!(parse_unicode(&symbol_map[0].start), Some('\u{2297}'));
+        assert_eq!(parse_unicode(&symbol_map[0].end), Some('\u{2299}'));
+
+        assert_eq!(symbol_map[1].font_family, "Cascadia Code NF");
+        assert_eq!(symbol_map[1].start, "E0C0");
+        assert_eq!(symbol_map[1].end, "E0C7");
+
+        assert_eq!(parse_unicode(&symbol_map[1].start), Some('\u{E0C0}'));
+        assert_eq!(parse_unicode(&symbol_map[1].end), Some('\u{E0C7}'));
     }
 }

--- a/sugarloaf/src/font/fonts.rs
+++ b/sugarloaf/src/font/fonts.rs
@@ -141,6 +141,16 @@ pub struct SugarloafFonts {
     pub symbol_map: Option<Vec<SymbolMap>>,
 }
 
+pub fn parse_unicode(input: &str) -> Option<char> {
+    if let Ok(unicode) = u32::from_str_radix(input, 16) {
+        if let Some(result) = char::from_u32(unicode) {
+            return Some(result);
+        }
+    }
+
+    None
+}
+
 impl Default for SugarloafFonts {
     fn default() -> SugarloafFonts {
         SugarloafFonts {


### PR DESCRIPTION
Fixes https://github.com/raphamorim/rio/issues/124

```toml
# covers: '⊗','⊘','⊙'
fonts.symbol-map = [{ start = "2297", end = "2299", font-family = "Cascadia Code NF" }]
```