### PR TITLE
Update build-from-source.md

### DIFF
--- a/docs/docs/install/build-from-source.md
+++ b/docs/docs/install/build-from-source.md
@@ -8,7 +8,7 @@ language: 'en'
 Before compiling Rio terminal, you'll have to first clone the source code:
 
 ```sh
-git clone https://github.com/raphamorim/rio.git
+git clone --depth=1 https://github.com/raphamorim/rio.git
 ```
 
 Then install the Rust compiler with `rustup` ([rustup.rs](https://rustup.rs/)).


### PR DESCRIPTION
Add --depth=1 in "git clone" to avoid dealing with a very long download time that can annoy beginners and new users.