### PR TITLE
Read configuration from $XDG_CONFIG_HOME on Linux

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -5,7 +5,9 @@ language: 'en'
 
 The configuration should be the following paths otherwise Rio will use the default configuration.
 
-MacOS and Linux configuration file path is `~/.config/rio/config.toml`.
+MacOS configuration file path is `~/.config/rio/config.toml`.
+
+Linux configuration file path is `$XDG_CONFIG_HOME/rio/config.toml` or `~/.config/rio/config.toml`.
 
 Windows configuration file path is `C:\Users\USER\AppData\Local\rio\config.toml` (replace "USER" with your user name).
 

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -7,7 +7,7 @@ language: 'en'
 
 ## 0.2.16 (unreleased)
 
-- TBD.
+- *Breaking*: support reading from config directory using `$XDG_CONFIG_HOME` on Linux [#1105](https://github.com/raphamorim/rio/pull/1105).
 
 ## 0.2.15
 

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -152,7 +152,8 @@ pub fn default_config_file_content() -> String {
 # Theme
 #
 # It makes Rio look for the specified theme in the themes folder
-# (macos and linux: ~/.config/rio/themes/dracula.toml)
+# (macos: ~/.config/rio/themes/dracula.toml)
+# (linux: $XDG_HOME_CONFIG/rio/themes/dracula.toml or ~/.config/rio/themes/dracula.toml)
 # (windows: C:\Users\USER\AppData\Local\rio\themes\dracula.toml)
 #
 # Example:

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -171,7 +171,7 @@ pub struct CursorConfig {
     pub blinking_interval: u64,
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 #[inline]
 pub fn config_dir_path() -> PathBuf {
     std::env::var("RIO_CONFIG_HOME")
@@ -189,6 +189,19 @@ pub fn config_dir_path() -> PathBuf {
                 .unwrap()
                 .join("AppData")
                 .join("Local")
+                .join("rio"),
+        )
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[inline]
+pub fn config_dir_path() -> PathBuf {
+    std::env::var("RIO_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or(
+            std::env::var("XDG_CONFIG_HOME")
+                .map(PathBuf::from)
+                .unwrap_or(dirs::home_dir().unwrap().join(".config"))
                 .join("rio"),
         )
 }


### PR DESCRIPTION
Uses `$XDG_CONFIG_HOME` to find configuration files on Linux, with a lower priority than `$RIO_CONFIG_HOME` but higher than `$HOME` as specified in [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)

> There is a single base directory relative to which user-specific configuration files should be written. This directory is defined by the environment variable `$XDG_CONFIG_HOME`.

The fallback to `$HOME/.config` is specified further below:

> `$XDG_CONFIG_HOME` defines the base directory relative to which user-specific configuration files should be stored. If `$XDG_CONFIG_HOME` is either not set or empty, a default equal to `$HOME/.config` should be used.

Previous work at #14 and also needed for flathub/flathub#6483