### PR TITLE
Skip passing sandbox env to spawned shell in Flatpak

### DIFF
--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -7,7 +7,7 @@ language: 'en'
 
 ## 0.2.17 (unreleased)
 
-- TBD.
+- Skip passing sandbox env in Flatpak, fixes user environment in spawned shell [#1116](https://github.com/raphamorim/rio/pull/1116) by [@ranisalt](https://github.com/ranisalt).
 
 ## 0.2.16
 

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -463,7 +463,8 @@ pub fn create_pty_with_spawn(
             let mut with_args = vec![
                 "--host".to_string(),
                 "--watch-bus".to_string(),
-                "--env=TERM_PROGRAM=rio".to_string(),
+                "--env=COLORTERM=truecolor".to_string(),
+                "--env=TERM=rio".to_string(),
             ];
 
             if let Some(directory) = working_directory {

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -453,28 +453,25 @@ pub fn create_pty_with_spawn(
         cmd
     };
 
-    #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
+    #[cfg(target_os = "linux")]
     {
         // If running inside a flatpak sandbox.
         // Must retrieve $SHELL from outside the sandbox, so ask the host.
         if std::path::PathBuf::from("/.flatpak-info").exists() {
             builder = Command::new("flatpak-spawn");
-            let mut with_args = vec!["--host".to_string(), "--watch-bus".to_string()];
+
+            let mut with_args = vec![
+                "--host".to_string(),
+                "--watch-bus".to_string(),
+                "--env=TERM_PROGRAM=rio".to_string(),
+            ];
+
             if let Some(directory) = working_directory {
                 with_args.push(format!(
                     "--directory={}",
                     std::path::Path::new(directory).display()
                 ));
             }
-
-            // Map only base environment variables
-            for (k, v) in std::env::vars_os() {
-                let key: String = k.into_string().unwrap_or_default();
-                let value: String = v.into_string().unwrap_or_default();
-                with_args.push(format!("--env={key}={value}"));
-            }
-
-            with_args.push("--env=TERM_PROGRAM=rio".to_string());
 
             let output = std::process::Command::new("flatpak-spawn")
                 .args(["--host", "sh", "-c", "echo $SHELL"])


### PR DESCRIPTION
When passing `std::env::vars_os()` to the spawned shell inside a Flatpak sandbox, it ends up overriding important host environment variables with overridden values meant for the sandboxed application (in this case, Rio). Most notably, `$XDG_CONFIG_HOME` is overridden by the value passed to Rio, which is `$HOME/.var/app/com.rioterm.Rio/config` instead of `$HOME/.config` (or whatever value the user has set):

![image](https://github.com/user-attachments/assets/8762c3dd-495e-4dde-bf2e-0b6e1c86c1a5)

(current behavior)

There's no need to pass any environment variables to the shell outside the sandbox, they get inherited from the process that spawned the Flatpak sandbox, which is usually the user session that already has the environment properly set up:

![image](https://github.com/user-attachments/assets/9d2dd90d-e20a-46ef-b37d-2d8713406341)

(fixed behavior)

Additionally, the order of the parameters does not matter in this scenario, so I moved setting `TERM_PROGRAM` (now `TERM` and `COLORTERM`, since `TERM_PROGRAM` is for Mac) to the initial data of the vector and skip the push.

As a bonus, it now renders icons and ligatures as the shell has access to the host fonts :)

![image](https://github.com/user-attachments/assets/a8826149-227e-4e04-bdf7-57dca4c2674b) ![image](https://github.com/user-attachments/assets/f2b0d6c9-a00d-40c3-ba2e-2c11b6f458a9)
