### PR TITLE
Add branding colors to metainfo

### DIFF
--- a/misc/com.rioterm.Rio.metainfo.xml
+++ b/misc/com.rioterm.Rio.metainfo.xml
@@ -12,6 +12,11 @@
     <p>Rio is open source and available for Windows, macOS, and Linux.</p>
   </description>
 
+  <branding>
+    <color type="primary" scheme_preference="light">#b9a5d3</color>
+    <color type="primary" scheme_preference="dark">#2c1e3e</color>
+  </branding>
+
   <project_license>MIT</project_license>
   <metadata_license>CC0-1.0</metadata_license>
 


### PR DESCRIPTION
Branding colors are used by appstream-based stores (such as Flathub) to generate cards for the app. Flathub suggests we add a dark and a light branding color. It should be colorful, have good contrast with the icon but still make sense.

The dark color was suggested by ChatGPT 😆 but it's vivid and I believe it fits well. The light color was obtained by lightening the dark color until it has good enough contrast with the foreground text, ensuring it is accessible. Preview:

![Screenshot From 2025-05-25 18-57-18](https://github.com/user-attachments/assets/b2c50400-a46a-40ee-9a0c-a25cc969d748)

