### PR TITLE
disambiguate english in config docs

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -22,11 +22,11 @@ Note that all parameters without a header must be at the beginning of the file, 
 program = "vi"
 args = []
 
-theme = "dracula" # ignore it, be under the `editor` header
+theme = "dracula" # won't work, because it's under the `editor` header
 ```
 
 ```toml
-theme = "dracula" # it works, be without heading
+theme = "dracula" # will work
 
 [editor]
 program = "vi"


### PR DESCRIPTION
This section of the docs had some ambiguous English, I thought I'd help clear it up:
![image](https://github.com/user-attachments/assets/59b7d0c9-4b70-473e-b23c-c6e0c383d863)
