### PR TITLE
docs: Mention Terra package for Fedora users

### DIFF
--- a/docs/docs/install/linux.md
+++ b/docs/docs/install/linux.md
@@ -12,6 +12,7 @@ Installation options:
 - openSUSE package: [openSUSE:Factory/rioterm](https://software.opensuse.org/package/rioterm)
 - Flathub: [flathub.org/apps/com.rioterm.Rio](https://flathub.org/apps/com.rioterm.Rio)
 - Void Linux package: https://github.com/void-linux/void-packages/tree/master/srcpkgs/rio
+- Terra (Fedora) package: https://github.com/terrapkg/packages/tree/frawhide/anda/devs/rio
 
 Note: Debian packages (`.deb`) and Red Hat packages (`.rpm`) are packaged and released along with [GitHub releases](https://github.com/raphamorim/rio/releases).
 


### PR DESCRIPTION
I hope this is formatted alright? I wasn't sure if I should make an issue or a PR to mention the terminal is available in the Terra repository. I'm using it from there right now. =]