### PR TITLE
fixed documentation for default values of window.decorations fixes #1132 

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -1454,9 +1454,9 @@ y = 0.0
 
 Set window decorations.
 
-- `Enabled` (default for Windows/Linux/BSD) enable window decorations.
+- `Enabled` (default for Windows/Linux/BSD/macOS) enable window decorations.
 - `Disabled` disable all window decorations.
-- `Transparent` (default for MacOS) window decorations with transparency.
+- `Transparent` window decorations with transparency.
 - `Buttonless` remove buttons from window decorations.
 
 Example:


### PR DESCRIPTION
The default value of `window.decorations` on macOS was changed to enabled in `v0.2.17`. This is documented in the release notes but was not changed in the online documentation. This commit fixes that discrepancy.

See release notes too: 
https://github.com/raphamorim/rio/blob/7ef143fd3a5de979a912e181882fc1de97be6460/docs/docs/releases.md?plain=1#L18

fixes #1132 
