### PR TITLE
fix: underline height making text hard to read

### DIFF
--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -29,6 +29,9 @@ use std::ops::RangeInclusive;
 use rustc_hash::FxHashMap;
 use unicode_width::UnicodeWidthChar;
 
+/// Draw the underline this amount of pixels below the text
+pub const UNDERLINE_OFFSET: f32 = -6.0;
+
 #[derive(Default)]
 pub struct Search {
     rich_text_id: Option<usize>,
@@ -188,7 +191,7 @@ impl Renderer {
 
         if square.flags.contains(Flags::UNDERLINE) {
             decoration = Some(FragmentStyleDecoration::Underline(UnderlineInfo {
-                offset: -1.0,
+                offset: UNDERLINE_OFFSET,
                 size: 1.0,
                 is_doubled: false,
                 shape: UnderlineShape::Regular,
@@ -197,28 +200,28 @@ impl Renderer {
             decoration = Some(FragmentStyleDecoration::Strikethrough);
         } else if square.flags.contains(Flags::DOUBLE_UNDERLINE) {
             decoration = Some(FragmentStyleDecoration::Underline(UnderlineInfo {
-                offset: -1.0,
+                offset: UNDERLINE_OFFSET,
                 size: 1.0,
                 is_doubled: true,
                 shape: UnderlineShape::Regular,
             }));
         } else if square.flags.contains(Flags::DOTTED_UNDERLINE) {
             decoration = Some(FragmentStyleDecoration::Underline(UnderlineInfo {
-                offset: -1.0,
+                offset: UNDERLINE_OFFSET,
                 size: 2.0,
                 is_doubled: false,
                 shape: UnderlineShape::Dotted,
             }));
         } else if square.flags.contains(Flags::DASHED_UNDERLINE) {
             decoration = Some(FragmentStyleDecoration::Underline(UnderlineInfo {
-                offset: -1.0,
+                offset: UNDERLINE_OFFSET,
                 size: 2.0,
                 is_doubled: false,
                 shape: UnderlineShape::Dashed,
             }));
         } else if square.flags.contains(Flags::UNDERCURL) {
             decoration = Some(FragmentStyleDecoration::Underline(UnderlineInfo {
-                offset: -1.0,
+                offset: UNDERLINE_OFFSET,
                 size: 2.0,
                 is_doubled: false,
                 shape: UnderlineShape::Curly,
@@ -273,15 +276,13 @@ impl Renderer {
                     self.create_style(square, term_colors)
                 };
 
-            if hyperlink_range.is_some()
-                && square.hyperlink().is_some()
+            if square.hyperlink().is_some()
                 && hyperlink_range
-                    .unwrap()
-                    .contains(Pos::new(line, Column(column)))
+                    .is_some_and(|range| range.contains(Pos::new(line, Column(column))))
             {
                 style.decoration =
                     Some(FragmentStyleDecoration::Underline(UnderlineInfo {
-                        offset: -1.0,
+                        offset: UNDERLINE_OFFSET,
                         size: -1.0,
                         is_doubled: false,
                         shape: UnderlineShape::Regular,


### PR DESCRIPTION
Currently, underline height is too high which makes text harder to read. The PR fixes that by rendering them 5px lower.

Before | After

![image](https://github.com/user-attachments/assets/2a1fb6d8-1e2b-402f-8049-0a96ef7a1777)

This example shows an invalid snippet of code rendering the underlines

WezTerm (for reference) | Rio Before this PR | Rio With this PR 

![image](https://github.com/user-attachments/assets/d761ea25-e3ee-4d5b-9182-096c982136fd)


Closes https://github.com/raphamorim/rio/issues/1115 

---

Note: The PR isn't really ready for merge
- I think decreasing it further by 1px or 2px will yield better results
- At the moment the underlines get clipped, as you can see their bottom part does not get rendered. I'm trying to figure out how to let them be drawn out of bounds of the cells