### PR TITLE
flake: devShells+packages: fix rust-overlay toolchain usage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
         };
         packages.rio = pkgs.callPackage mkRio {rust-toolchain = rust-toolchain;};
 
-        devShells.msrv = mkDevShell rust-toolchain;
+        devShells.msrv = mkDevShell (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
         devShells.stable = mkDevShell pkgs.rust-bin.stable.latest.default;
         devShells.nightly = mkDevShell (pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default));
       };

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,6 @@
         lib,
         ...
       }: let
-        rust-toolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = ["rust-src" "rust-analyzer"];
-        };
-
         mkRio = import ./pkgRio.nix;
 
         mkDevShell = rust-toolchain: let
@@ -54,7 +50,7 @@
           type = "app";
           program = self'.packages.default;
         };
-        packages.rio = pkgs.callPackage mkRio {rust-toolchain = rust-toolchain;};
+        packages.rio = pkgs.callPackage mkRio {rust-toolchain = pkgs.rust-bin.stable.latest.minimal;};
 
         devShells.msrv = mkDevShell (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
         devShells.stable = mkDevShell pkgs.rust-bin.stable.latest.default;


### PR DESCRIPTION
You don't need a custom `rust-toolchain` if you aren't actually adding any extensions that aren't already present.

- For the `devShells.*.msrv` output, it was never using the project's `rust-toolchain.toml` (that is, assuming you use it for the MSRV toolchain). Now it is.
- For the `packages.*.rio` output, you can just use `rust-bin.stable.latest.minimal`. That's all that is required to build with `rustPlatform.buildRustPackage`.