### PR TITLE
Add install instructions for scoop

### DIFF
--- a/docs/docs/install/windows.md
+++ b/docs/docs/install/windows.md
@@ -25,6 +25,12 @@ choco install rio-terminal
 ```
 
 - Using MINGW package manager: [packages.msys2.org/base/mingw-w64-rio](https://packages.msys2.org/base/mingw-w64-rio)
+- [Using scoop](https://scoop.sh/#/apps?q=rio))
+
+```sh
+scoop bucket add extras
+scoop install rio
+```
 
 There's a few things to note about the installer and the portable version:
 


### PR DESCRIPTION
I personally prefer using scoop over chocolatey or winget and the package is already available but it's not mentioned in the install instructions for windows

Side note, chocolatey is mentioned but it only has a _very_ outdated version of rio from december 2023. The scoop version was updated yesterday so it's way more up to date.