### PR TITLE
Store fonts after loading them to prevent aggressive re-loading

### DIFF
--- a/frontends/rioterm/src/renderer/font_cache.rs
+++ b/frontends/rioterm/src/renderer/font_cache.rs
@@ -113,7 +113,7 @@ impl FontCache {
             ),
         ];
 
-        if let Some(font_ctx) = font_context.inner.try_read() {
+        if let Some(mut font_ctx) = font_context.inner.try_write() {
             for &ch in &common_chars {
                 for &attrs in &common_attrs {
                     let key = (ch, attrs);

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -418,7 +418,7 @@ impl Renderer {
 
         // Batch font lookups with a single lock acquisition
         if !font_lookups.is_empty() {
-            let font_ctx = self.font_context.inner.read();
+            let mut font_ctx = self.font_context.inner.write();
             for (style_index, square_content, font_attrs) in font_lookups {
                 let mut width = square_content.width().unwrap_or(1) as f32;
                 let style = &mut styles_and_chars[style_index].0;
@@ -766,7 +766,7 @@ impl Renderer {
 
                     // Batch font lookups with a single lock acquisition
                     if !font_lookups.is_empty() {
-                        let font_ctx = self.font_context.inner.read();
+                        let mut font_ctx = self.font_context.inner.write();
                         for (style_index, character) in font_lookups {
                             let mut width = character.width().unwrap_or(1) as f32;
                             let char_style = &mut char_styles[style_index].0;

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -2098,9 +2098,8 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
     #[inline(never)]
     fn input(&mut self, c: char) {
-        let width = match c.width() {
-            Some(width) => width,
-            None => return,
+        let Some(width) = c.width() else {
+            return;
         };
 
         // Handle zero-width characters.

--- a/sugarloaf/src/components/rich_text/image_cache/glyph.rs
+++ b/sugarloaf/src/components/rich_text/image_cache/glyph.rs
@@ -130,7 +130,7 @@ impl GlyphCacheSession<'_> {
         );
 
         self.scaled_image.data.clear();
-        let font_library_data = self.font_library.inner.read();
+        let mut font_library_data = self.font_library.inner.write();
         let enable_hint = font_library_data.hinting;
         let font_data = font_library_data.get(&self.font);
         let should_embolden = font_data.should_embolden;

--- a/sugarloaf/src/layout/content.rs
+++ b/sugarloaf/src/layout/content.rs
@@ -711,7 +711,7 @@ impl Content {
                 let single_char_content = whitespace_char.to_string();
 
                 // Process the font data directly without cloning FontRef
-                let font_library = &self.fonts.inner.read();
+                let mut font_library = self.fonts.inner.write();
                 if let Some((shared_data, offset, key)) = font_library.get_data(&font_id)
                 {
                     let font_ref = FontRef {
@@ -780,7 +780,7 @@ impl Content {
             } else {
                 // Normal content - shape as usual
                 // Process the font data directly without cloning FontRef
-                let font_library = &self.fonts.inner.read();
+                let mut font_library = self.fonts.inner.write();
                 if let Some((shared_data, offset, key)) = font_library.get_data(&font_id)
                 {
                     let font_ref = FontRef {
@@ -2350,7 +2350,7 @@ mod tests {
         // Helper function to shape content and return clusters
         let shape_content = |use_cache: bool| -> Vec<OwnedGlyphCluster> {
             let mut scx = ShapeContext::new();
-            let font_library_guard = font_library.inner.read();
+            let mut font_library_guard = font_library.inner.write();
             if let Some((shared_data, offset, key)) =
                 font_library_guard.get_data(&font_id)
             {


### PR DESCRIPTION
Right now on main, trying to quickly print a lot of emojis while using an emoji-heavy font introduces a massive amount of lag. This can be easily demonstrated if one sets up neovim to use [folke/drop](https://github.com/folke/drop.nvim) (which "drops" a lot of emojis from the top of the screen as a screensaver) and runs it while using a custom emoji font.

This lag comes from the fact that `FontLibraryData::get_data` doesn't store the data of loaded fonts after it loads it. This means that, if I'm understanding correctly, this function is essentially thrashed each time one of these emojis is loaded, as the whole font has to be loaded from disk time and time again.

So this PR simply stores the font data into `FontLibraryData` after loading it. I tested it and it makes the lag completely go away and significantly reduces resource utilization.

This also makes some small nit changes that I noticed while looking for this fix, such as the `let _ else` and changing `SharedData` to just hold a `Arc<[u8]>` since that's all it actually ever holds.

I don't know if this is the best way to introduce this fix, but it seems to do the job just fine for me. I'm totally happy to close this in favor of a different PR if there's a better way to achieve the same results.