### PR TITLE
fix debian conflicts with ncurses-term

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -155,13 +155,20 @@ nfpms:
     package_name: rioterm
     dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11)]
     overrides:
+      deb:
+        dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11), ncurses-term (>= 6.5) | ncurses-base (<< 6.5)]
       rpm:
         dependencies: [glibc, libstdc++]
+        contents:
+          - src: ./misc/rio.desktop
+            dst: /usr/share/applications/rio.desktop
+          - src: ./misc/r/rio
+            dst: /usr/share/terminfo/r/rio
+          - src: ./misc/logo.svg
+            dst: /usr/share/icons/hicolor/scalable/apps/rio.svg
     contents:
       - src: ./misc/rio.desktop
         dst: /usr/share/applications/rio.desktop
-      - src: ./misc/r/rio
-        dst: /usr/share/terminfo/r/rio
       - src: ./misc/logo.svg
         dst: /usr/share/icons/hicolor/scalable/apps/rio.svg
     section: admin
@@ -173,13 +180,20 @@ nfpms:
     package_name: rioterm
     dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11)]
     overrides:
+      deb:
+        dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11), ncurses-term (>= 6.5) | ncurses-base (<< 6.5)]
       rpm:
         dependencies: [glibc, libstdc++]
+        contents:
+          - src: ./misc/rio.desktop
+            dst: /usr/share/applications/rio.desktop
+          - src: ./misc/r/rio
+            dst: /usr/share/terminfo/r/rio
+          - src: ./misc/logo.svg
+            dst: /usr/share/icons/hicolor/scalable/apps/rio.svg
     contents:
       - src: ./misc/rio.desktop
         dst: /usr/share/applications/rio.desktop
-      - src: ./misc/r/rio
-        dst: /usr/share/terminfo/r/rio
       - src: ./misc/logo.svg
         dst: /usr/share/icons/hicolor/scalable/apps/rio.svg
     section: admin
@@ -191,13 +205,20 @@ nfpms:
     package_name: rioterm
     dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11)]
     overrides:
+      deb:
+        dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11), ncurses-term (>= 6.5) | ncurses-base (<< 6.5)]
       rpm:
         dependencies: [glibc, libstdc++]
+        contents:
+          - src: ./misc/rio.desktop
+            dst: /usr/share/applications/rio.desktop
+          - src: ./misc/r/rio
+            dst: /usr/share/terminfo/r/rio
+          - src: ./misc/logo.svg
+            dst: /usr/share/icons/hicolor/scalable/apps/rio.svg
     contents:
       - src: ./misc/rio.desktop
         dst: /usr/share/applications/rio.desktop
-      - src: ./misc/r/rio
-        dst: /usr/share/terminfo/r/rio
       - src: ./misc/logo.svg
         dst: /usr/share/icons/hicolor/scalable/apps/rio.svg
     section: admin
@@ -209,13 +230,20 @@ nfpms:
     package_name: rioterm
     dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11)]
     overrides:
+      deb:
+        dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11), ncurses-term (>= 6.5) | ncurses-base (<< 6.5)]
       rpm:
         dependencies: [glibc, libstdc++]
+        contents:
+          - src: ./misc/rio.desktop
+            dst: /usr/share/applications/rio.desktop
+          - src: ./misc/r/rio
+            dst: /usr/share/terminfo/r/rio
+          - src: ./misc/logo.svg
+            dst: /usr/share/icons/hicolor/scalable/apps/rio.svg
     contents:
       - src: ./misc/rio.desktop
         dst: /usr/share/applications/rio.desktop
-      - src: ./misc/r/rio
-        dst: /usr/share/terminfo/r/rio
       - src: ./misc/logo.svg
         dst: /usr/share/icons/hicolor/scalable/apps/rio.svg
     section: admin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -155,8 +155,6 @@ nfpms:
     package_name: rioterm
     dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11)]
     overrides:
-      deb:
-        dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11), ncurses-term (>= 6.5) | ncurses-base (<< 6.5)]
       rpm:
         dependencies: [glibc, libstdc++]
         contents:
@@ -180,8 +178,6 @@ nfpms:
     package_name: rioterm
     dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11)]
     overrides:
-      deb:
-        dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11), ncurses-term (>= 6.5) | ncurses-base (<< 6.5)]
       rpm:
         dependencies: [glibc, libstdc++]
         contents:
@@ -205,8 +201,6 @@ nfpms:
     package_name: rioterm
     dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11)]
     overrides:
-      deb:
-        dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11), ncurses-term (>= 6.5) | ncurses-base (<< 6.5)]
       rpm:
         dependencies: [glibc, libstdc++]
         contents:
@@ -230,8 +224,6 @@ nfpms:
     package_name: rioterm
     dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11)]
     overrides:
-      deb:
-        dependencies: [libc6 (>= 2.35), libstdc++6 (>= 11), ncurses-term (>= 6.5) | ncurses-base (<< 6.5)]
       rpm:
         dependencies: [glibc, libstdc++]
         contents:

--- a/docs/docs/frequently-asked-questions/index.md
+++ b/docs/docs/frequently-asked-questions/index.md
@@ -7,26 +7,43 @@ language: 'en'
 
 The famous case of "'rio' unknown terminal type".
 
-All these issues have the same root cause: the rio terminfo is not available. Common scenarios include:
+All these issues have the same root cause: the rio terminfo is not available. 
+
+#### Common Scenarios
 
 1. **SSH connections**: The remote system doesn't have Rio's terminfo installed
-2. **Older Linux distributions**: The system doesn't include Rio's terminfo
-3. **Package conflicts**: On Debian 13+/Ubuntu 24.04+, conflicts with ncurses-term package
+2. **Ubuntu 22.04 and older**: Rio's .deb packages don't include terminfo (to avoid conflicts), so manual installation is needed
+3. **Debian 13+/Ubuntu 24.04+**: Terminfo is provided by the system's ncurses-term package
 
-#### Solutions:
+#### Solutions by Distribution
 
-**For Debian 13+ / Ubuntu 24.04+ users:**
-- Rio's terminfo is included in `ncurses-term` (6.5+)
-- If you get installation conflicts, your system already has the terminfo
-- Simply ensure ncurses-term is up to date: `sudo apt install ncurses-term`
+**For Ubuntu 22.04 and older Debian/Ubuntu:**
+```bash
+# Rio .deb packages don't include terminfo, install it manually:
+curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
+sudo tic -xe xterm-rio,rio rio.terminfo
+rm rio.terminfo
+```
 
-**For other distributions:**
-- Install terminfo on the remote/local machine following [install/terminfo](/docs/install/terminfo)
-- Arch Linux users can install: `sudo pacman -S rio-terminfo`
+**For Debian 13+ / Ubuntu 24.04+:**
+- Terminfo is included in `ncurses-term` (6.5+)
+- Simply ensure ncurses-term is installed: `sudo apt install ncurses-term`
 
-**Quick workarounds:**
+**For Arch Linux:**
+```bash
+sudo pacman -S rio-terminfo
+```
+
+**For RPM-based distributions:**
+- Rio's RPM packages include terminfo, no action needed
+
+#### Quick Workarounds
+
 - Use a fallback TERM for SSH: `TERM=xterm-256color ssh user@host`
 - Configure a different TERM in Rio's config file
+- Copy terminfo to remote hosts: `infocmp -a xterm-rio | ssh myserver tic -x -o ~/.terminfo /dev/stdin`
+
+For more details, see [install/terminfo](/docs/install/terminfo).
 
 ### Colors scheme not working as intended with tmux
 

--- a/docs/docs/frequently-asked-questions/index.md
+++ b/docs/docs/frequently-asked-questions/index.md
@@ -3,15 +3,30 @@ title: 'Frequently Asked Questions'
 language: 'en'
 ---
 
-### I get errors about the terminal being unknown or opening the terminal failing or functional keys like arrow keys don’t work?
+### I get errors about the terminal being unknown or opening the terminal failing or functional keys like arrow keys don't work?
 
 The famous case of "'rio' unknown terminal type".
 
-All the issues all have the same root cause: the rio terminfo is not available. The most common way this happens is SSHing into a computer that does not have the rio terminfo files. The simplest fix would be install the terminfo files on the remote machine (following terminfo instruction in install section [install/terminfo](/docs/install/terminfo))
+All these issues have the same root cause: the rio terminfo is not available. Common scenarios include:
 
-Other alternative is use a different terminfo either in config or per connection with environment variable like `TERM=xterm-256color ssh`.
+1. **SSH connections**: The remote system doesn't have Rio's terminfo installed
+2. **Older Linux distributions**: The system doesn't include Rio's terminfo
+3. **Package conflicts**: On Debian 13+/Ubuntu 24.04+, conflicts with ncurses-term package
 
-If you are using a well maintained Linux distribution, it will have a rio-terminfo package that you can simply install to make the rio terminfo files available system-wide. Then the problem will no longer occur. Arch Linux for example [rio-terminfo](https://archlinux.org/packages/extra/x86_64/rio-terminfo/)
+#### Solutions:
+
+**For Debian 13+ / Ubuntu 24.04+ users:**
+- Rio's terminfo is included in `ncurses-term` (6.5+)
+- If you get installation conflicts, your system already has the terminfo
+- Simply ensure ncurses-term is up to date: `sudo apt install ncurses-term`
+
+**For other distributions:**
+- Install terminfo on the remote/local machine following [install/terminfo](/docs/install/terminfo)
+- Arch Linux users can install: `sudo pacman -S rio-terminfo`
+
+**Quick workarounds:**
+- Use a fallback TERM for SSH: `TERM=xterm-256color ssh user@host`
+- Configure a different TERM in Rio's config file
 
 ### Colors scheme not working as intended with tmux
 

--- a/docs/docs/install/index.md
+++ b/docs/docs/install/index.md
@@ -16,3 +16,12 @@ Rio has two type of builds: stable and nightly.
 While stable versions are thoroughly tested and takes longer to release, nightly versions are created on a daily basis.
 
 [Github releases for Nightly](https://github.com/raphamorim/rio/releases/tag/nightly)
+
+## Important Notes
+
+### Linux Users
+- **Ubuntu 22.04 and older Debian/Ubuntu**: After installing the .deb package, you'll need to [manually install the terminfo](/docs/install/terminfo)
+- **Debian 13+ / Ubuntu 24.04+**: Terminfo is provided by the system's ncurses-term package
+- **RPM-based distributions**: Terminfo is included in the package
+
+See the [Linux installation guide](/docs/install/linux) for detailed instructions.

--- a/docs/docs/install/linux.md
+++ b/docs/docs/install/linux.md
@@ -82,32 +82,44 @@ nix profile install github:raphamorim/rio/main
 
 ## Terminfo
 
-To ensure Rio works correctly, the "rio" terminfo must be installed. The installation method depends on your distribution:
+To ensure Rio works correctly, the "rio" terminfo must be installed. The installation method depends on your distribution and package type:
 
-### Debian 13+ / Ubuntu 24.04+
+### Debian/Ubuntu (Using .deb packages)
 
-These distributions include Rio's terminfo in the `ncurses-term` package (version 6.5+). The Rio package will automatically use the system-provided terminfo. You can verify it's installed:
+**Note:** Rio's .deb packages do not include terminfo files to avoid conflicts with system packages.
+
+#### Debian 13+ / Ubuntu 24.04+
+
+These distributions include Rio's terminfo in the `ncurses-term` package (version 6.5+). No additional steps needed:
 
 ```bash
+# Verify terminfo is installed
 infocmp rio
 ```
 
-If you encounter conflicts during installation, ensure you have the latest ncurses-term:
+#### Ubuntu 22.04 and older Debian/Ubuntu versions
 
-```bash
-sudo apt update
-sudo apt install ncurses-term
-```
-
-### Other Linux Distributions
-
-For older Debian/Ubuntu versions or other distributions, the terminfo may need manual installation:
+You'll need to install the terminfo manually after installing Rio:
 
 ```bash
 # Check if terminfo is already installed
-infocmp rio
+infocmp rio 2>/dev/null || {
+  # If not found, install it manually
+  curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
+  sudo tic -xe xterm-rio,rio rio.terminfo
+  rm rio.terminfo
+}
+```
 
-# If not found, install manually:
+### RPM-based distributions (Fedora, RHEL, openSUSE)
+
+Rio's RPM packages include the terminfo files. No additional steps needed.
+
+### Other distributions
+
+For distributions using other package formats or building from source, install the terminfo manually:
+
+```bash
 curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
 sudo tic -xe xterm-rio,rio rio.terminfo
 rm rio.terminfo

--- a/docs/docs/install/linux.md
+++ b/docs/docs/install/linux.md
@@ -82,15 +82,32 @@ nix profile install github:raphamorim/rio/main
 
 ## Terminfo
 
-To ensure Rio works correctly, the "rio" terminfo must be installed. Most package managers will install this automatically, but you can verify it's present:
+To ensure Rio works correctly, the "rio" terminfo must be installed. The installation method depends on your distribution:
+
+### Debian 13+ / Ubuntu 24.04+
+
+These distributions include Rio's terminfo in the `ncurses-term` package (version 6.5+). The Rio package will automatically use the system-provided terminfo. You can verify it's installed:
 
 ```bash
 infocmp rio
 ```
 
-If the command returns an error, install the terminfo manually:
+If you encounter conflicts during installation, ensure you have the latest ncurses-term:
 
 ```bash
+sudo apt update
+sudo apt install ncurses-term
+```
+
+### Other Linux Distributions
+
+For older Debian/Ubuntu versions or other distributions, the terminfo may need manual installation:
+
+```bash
+# Check if terminfo is already installed
+infocmp rio
+
+# If not found, install manually:
 curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
 sudo tic -xe xterm-rio,rio rio.terminfo
 rm rio.terminfo

--- a/docs/docs/install/terminfo.md
+++ b/docs/docs/install/terminfo.md
@@ -5,15 +5,49 @@ language: 'en'
 
 To make sure Rio works correctly, the Rio terminfo must be used. The rio terminfo will be picked up automatically if it is installed.
 
+## Installation Status
+
 If the following command returns without any errors, the xterm-rio terminfo is already installed:
 
 ```sh
 infocmp rio
 ```
 
-If it is not present already, you can install it globally with the following command:
+## Installation Methods
 
-When cloned locally, from the root of the repository run `sudo tic -xe xterm-rio,rio misc/rio.terminfo`
+### System Package Manager (Recommended)
+
+#### Debian 13+ / Ubuntu 24.04+
+
+These distributions include Rio's terminfo in the `ncurses-term` package (version 6.5+). No manual installation is needed:
+
+```sh
+# Verify ncurses-term is up to date
+sudo apt update
+sudo apt install ncurses-term
+```
+
+#### Arch Linux
+
+Arch Linux provides a separate package for Rio's terminfo:
+
+```sh
+sudo pacman -S rio-terminfo
+```
+
+### Manual Installation
+
+For distributions that don't include Rio's terminfo, you can install it manually:
+
+#### From Repository
+
+When cloned locally, from the root of the repository run:
+
+```sh
+sudo tic -xe xterm-rio,rio misc/rio.terminfo
+```
+
+#### Without Cloning
 
 If the source code has not been cloned locally:
 
@@ -27,7 +61,27 @@ rm rio.terminfo
 
 The Rio terminfo provides two entries:
 
-- `xterm-rio`: A compatibility entry for applications that look for "xterm-" prefixed terminals to detect capabilities
-- `rio`: The terminfo entry that was used by the `TERM` environment variable until v0.2.27
+- `xterm-rio`: A compatibility entry for applications that look for "xterm-" prefixed terminals to detect capabilities (used by default since v0.2.28)
+- `rio`: The original terminfo entry (used by default until v0.2.27)
 
 Both entries provide the same terminal capabilities, ensuring compatibility with a wide range of applications.
+
+## Troubleshooting
+
+### File Conflicts on Debian/Ubuntu
+
+If you encounter an error like:
+
+```
+trying to overwrite '/usr/share/terminfo/r/rio', which is also in package ncurses-term
+```
+
+This means your system already has Rio's terminfo installed via ncurses-term. This is expected for Debian 13+ and Ubuntu 24.04+. The Rio package will use the system-provided terminfo automatically.
+
+### SSH Connections
+
+When connecting to remote systems via SSH, the remote system also needs the Rio terminfo. You have several options:
+
+1. Install the terminfo on the remote system using the methods above
+2. Use a fallback TERM value: `TERM=xterm-256color ssh user@host`
+3. Configure Rio to use a different default TERM in your config file

--- a/docs/docs/install/terminfo.md
+++ b/docs/docs/install/terminfo.md
@@ -123,7 +123,4 @@ After installation, verify everything works:
 ```sh
 # Check terminfo is installed
 infocmp rio
-
-# Check Rio detects it
-rio --print-config | grep -i term
 ```

--- a/docs/docs/install/terminfo.md
+++ b/docs/docs/install/terminfo.md
@@ -7,29 +7,44 @@ To make sure Rio works correctly, the Rio terminfo must be used. The rio terminf
 
 ## Installation Status
 
-If the following command returns without any errors, the xterm-rio terminfo is already installed:
+Check if the terminfo is already installed:
 
 ```sh
 infocmp rio
 ```
 
+If this command returns without errors, the terminfo is installed and Rio will work correctly.
+
 ## Installation Methods
 
-### System Package Manager (Recommended)
+### Package-specific Information
+
+#### Debian/Ubuntu (.deb packages)
+
+**Important:** Rio's .deb packages do not include terminfo files to avoid conflicts with system packages.
+
+- **Debian 13+ / Ubuntu 24.04+**: Terminfo is provided by the system's `ncurses-term` package (6.5+)
+- **Ubuntu 22.04 and older**: Manual installation required (see below)
+
+#### RPM packages (Fedora, RHEL, openSUSE)
+
+Rio's RPM packages include the terminfo files. No additional installation needed.
+
+### System Package Manager
 
 #### Debian 13+ / Ubuntu 24.04+
 
-These distributions include Rio's terminfo in the `ncurses-term` package (version 6.5+). No manual installation is needed:
+These distributions include Rio's terminfo in the `ncurses-term` package:
 
 ```sh
-# Verify ncurses-term is up to date
+# Ensure ncurses-term is installed
 sudo apt update
 sudo apt install ncurses-term
 ```
 
 #### Arch Linux
 
-Arch Linux provides a separate package for Rio's terminfo:
+Arch Linux provides a separate package:
 
 ```sh
 sudo pacman -S rio-terminfo
@@ -37,19 +52,51 @@ sudo pacman -S rio-terminfo
 
 ### Manual Installation
 
-For distributions that don't include Rio's terminfo, you can install it manually:
+For distributions that don't include Rio's terminfo, or when using older package versions:
+
+#### Quick Install
+
+```sh
+# Download and install terminfo
+curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
+sudo tic -xe xterm-rio,rio rio.terminfo
+rm rio.terminfo
+```
 
 #### From Repository
 
-When cloned locally, from the root of the repository run:
+If you've cloned the Rio repository:
 
 ```sh
+cd /path/to/rio
 sudo tic -xe xterm-rio,rio misc/rio.terminfo
 ```
 
-#### Without Cloning
+## Terminfo Entries
 
-If the source code has not been cloned locally:
+The Rio terminfo provides two entries:
+
+- `xterm-rio`: A compatibility entry for applications that look for "xterm-" prefixed terminals (used by default since v0.2.28)
+- `rio`: The original terminfo entry (used by default until v0.2.27)
+
+Both entries provide the same terminal capabilities.
+
+## Troubleshooting
+
+### Package Installation Issues
+
+#### "File already exists" error on Debian/Ubuntu
+
+If you see:
+```
+trying to overwrite '/usr/share/terminfo/r/rio', which is also in package ncurses-term
+```
+
+This means your system already provides Rio's terminfo via ncurses-term. The Rio .deb package correctly doesn't include the terminfo to avoid this conflict.
+
+#### Ubuntu 22.04 specific
+
+Ubuntu 22.04 ships with ncurses-term 6.3, which doesn't include Rio's terminfo. After installing Rio's .deb package, manually install the terminfo:
 
 ```sh
 curl -o rio.terminfo https://raw.githubusercontent.com/raphamorim/rio/main/misc/rio.terminfo
@@ -57,31 +104,26 @@ sudo tic -xe xterm-rio,rio rio.terminfo
 rm rio.terminfo
 ```
 
-## Terminfo Entries
-
-The Rio terminfo provides two entries:
-
-- `xterm-rio`: A compatibility entry for applications that look for "xterm-" prefixed terminals to detect capabilities (used by default since v0.2.28)
-- `rio`: The original terminfo entry (used by default until v0.2.27)
-
-Both entries provide the same terminal capabilities, ensuring compatibility with a wide range of applications.
-
-## Troubleshooting
-
-### File Conflicts on Debian/Ubuntu
-
-If you encounter an error like:
-
-```
-trying to overwrite '/usr/share/terminfo/r/rio', which is also in package ncurses-term
-```
-
-This means your system already has Rio's terminfo installed via ncurses-term. This is expected for Debian 13+ and Ubuntu 24.04+. The Rio package will use the system-provided terminfo automatically.
-
 ### SSH Connections
 
-When connecting to remote systems via SSH, the remote system also needs the Rio terminfo. You have several options:
+When connecting to remote systems via SSH, the remote system also needs the Rio terminfo. Options:
 
-1. Install the terminfo on the remote system using the methods above
-2. Use a fallback TERM value: `TERM=xterm-256color ssh user@host`
-3. Configure Rio to use a different default TERM in your config file
+1. **Install on remote system**: Use the manual installation method above
+2. **Use fallback TERM**: `TERM=xterm-256color ssh user@host`
+3. **Configure Rio**: Set a different TERM in your Rio config file
+4. **Automatic copy**: Some users create scripts to automatically copy terminfo when SSHing:
+   ```sh
+   infocmp -a xterm-rio | ssh myserver tic -x -o ~/.terminfo /dev/stdin
+   ```
+
+### Verification
+
+After installation, verify everything works:
+
+```sh
+# Check terminfo is installed
+infocmp rio
+
+# Check Rio detects it
+rio --print-config | grep -i term
+```

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -10,11 +10,11 @@ language: 'en'
 - Fix blinking cursor issue [#1269](https://github.com/raphamorim/rio/issues/1269)
 - Fix Rio uses UNC (\?\) path as working directory, breaking Neovim subprocesses on Windows
 - Add NSCameraUseContinuityCameraDeviceType to plist for macOS
-- **Fix Debian/Ubuntu package conflicts with ncurses-term**: Fixed installation conflicts on Debian 13+ and Ubuntu 24.04+ [#1264](https://github.com/raphamorim/rio/issues/1264)
-  - Rio's terminfo is now included in ncurses-term 6.5+ on these distributions
-  - Debian packages now properly depend on ncurses-term when available
-  - Removed terminfo file from Debian packages to avoid conflicts with system packages
-  - RPM packages continue to include terminfo as they don't have this conflict
+- **Fix Debian/Ubuntu package installation**: Resolved terminfo conflicts with system packages [#1264](https://github.com/raphamorim/rio/issues/1264)
+  - Debian (.deb) packages no longer include terminfo files to avoid conflicts with ncurses-term
+  - Users on Ubuntu 22.04 and older need to manually install terminfo after package installation
+  - Debian 13+ and Ubuntu 24.04+ users get terminfo from system's ncurses-term package
+  - RPM packages continue to include terminfo as before
 
 ## 0.2.28
 

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -10,6 +10,11 @@ language: 'en'
 - Fix blinking cursor issue [#1269](https://github.com/raphamorim/rio/issues/1269)
 - Fix Rio uses UNC (\?\) path as working directory, breaking Neovim subprocesses on Windows
 - Add NSCameraUseContinuityCameraDeviceType to plist for macOS
+- **Fix Debian/Ubuntu package conflicts with ncurses-term**: Fixed installation conflicts on Debian 13+ and Ubuntu 24.04+ [#1264](https://github.com/raphamorim/rio/issues/1264)
+  - Rio's terminfo is now included in ncurses-term 6.5+ on these distributions
+  - Debian packages now properly depend on ncurses-term when available
+  - Removed terminfo file from Debian packages to avoid conflicts with system packages
+  - RPM packages continue to include terminfo as they don't have this conflict
 
 ## 0.2.28
 


### PR DESCRIPTION
Closes #1264

Users on Debian 13+ and Ubuntu 24.04+ are experiencing installation failures when trying to install Rio's `.deb` packages. The error occurs because these distributions now include Rio's terminfo in the `ncurses-term` package (version 6.5+), causing a file conflict:

```
dpkg: error processing archive /home/Data/Downloads/rioterm_0.2.28_amd64_x11.deb (--unpack):
 trying to overwrite '/usr/share/terminfo/r/rio', which is also in package ncurses-term (6.5+20250216-2)
```

# Fix

1. **For Debian packages**:
   - Removed the terminfo file from the package contents completely
   - The terminfo is now provided by the system's ncurses-term package on Debian 13+/Ubuntu 24.04+
   - For older systems (like Ubuntu 22.04 with ncurses-term 6.3), users can manually install the terminfo
   
2. **For RPM packages**:
   - No changes - they continue to include the terminfo file as RPM-based distributions don't have this conflict

### How It Works
- **Ubuntu 22.04 and older**: The package installs without conflicts. Users need to manually install terminfo if not present (documented in install guide)
- **Debian 13+/Ubuntu 24.04+**: The package installs without conflicts as it doesn't include the terminfo file, which is already provided by ncurses-term
- **RPM-based distros**: Continue to work as before with bundled terminfo

Rio already checks at runtime for available terminfo entries (`xterm-rio` or `rio`) and uses the appropriate one, so this change is transparent to users.
