### PR TITLE
fix(macos): Fix issue where minimized windows couldn't be restored fr…

### DIFF
--- a/rio-window/src/platform_impl/macos/app_delegate.rs
+++ b/rio-window/src/platform_impl/macos/app_delegate.rs
@@ -173,9 +173,29 @@ declare_class!(
             _sender: Option<&AnyObject>,
             has_open_windows: bool,
         ) -> bool {
-            if self.is_launched() && !has_open_windows {
-                self.dispatch_application_reopen();
-                true
+            if self.is_launched() {
+                // Check if there are open windows but all windows are minimized
+                if !has_open_windows {
+                    self.dispatch_application_reopen();
+                    true
+                } else {
+                    let mtm = MainThreadMarker::from(self);
+                    let app = NSApplication::sharedApplication(mtm);
+
+                    // Check if there are visible windows
+                    let windows = app.windows();
+                    let has_visible_window = windows.iter().any(|window| {
+                        window.isVisible() && !window.isMiniaturized()
+                    });
+
+                    // If there are no visible windows (all windows are minimized), restore the windows
+                    if !has_visible_window {
+                        self.dispatch_application_reopen();
+                        true
+                    } else {
+                        false
+                    }
+                }
             } else {
                 false
             }


### PR DESCRIPTION
# Fix macOS Window Restoration from Dock When Minimized

## Problem Description
On macOS, when all terminal windows are minimized to the Dock, clicking the Dock icon fails to restore these windows. Users have to manually right-click the Dock icon and select "Show All Windows" to restore minimized windows.

## Root Cause
macOS's `applicationShouldHandleReopen:hasVisibleWindows:` method returns `true` for the `has_open_windows` parameter even when all windows are minimized, causing the application to think there are visible windows and skip the restoration process.

## Solution
Modified the `should_handle_reopen` method in `app_delegate.rs` to not only check the `has_open_windows` parameter but also verify if there are actually visible (non-minimized) windows:

1. Maintained existing logic when `has_open_windows` is `false`
2. When `has_open_windows` is `true`, iterate through all windows to check if any are visible and non-minimized
3. If all windows are minimized (no visible windows), trigger the window restoration process

## Testing Method
1. Open the Rio terminal application
2. Minimize all windows to the Dock
3. Click the Dock icon
4. Verify that all windows are properly restored

This fix maintains standard macOS application behavior and improves user experience.