### PR TITLE
Fix configured arguments for spawned shells being ignored when `use-fork = true`

### DIFF
--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -235,6 +235,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                 tracing::info!("rio -> teletypewriter: create_pty_with_fork");
                 pty = match create_pty_with_fork(
                     &Cow::Borrowed(&config.shell.program),
+                    config.shell.args.as_ref(),
                     cols,
                     rows,
                 ) {
@@ -1781,7 +1782,7 @@ pub mod test {
     /// Common functionality between [`test_forking_context_creation_propagate_correct_arguments`]
     /// and [`test_spawning_context_creation_propagate_correct_arguments`]
     #[cfg(not(target_os = "windows"))]
-    fn test_context_creation_propagate_correct_arguments<>(use_fork: bool) {
+    fn test_context_creation_propagate_correct_arguments(use_fork: bool) {
         let window_id = WindowId::from(0);
         let test_file_path: &str = if use_fork {
             "/tmp/rio_test_forking_context_creation_propagate_correct_arguments"
@@ -1810,6 +1811,7 @@ pub mod test {
             ContextManager::start_with_capacity_and_config(5, config, VoidListener {}, window_id).unwrap();
         context_manager.add_context(false, 0);
 
+        //TODO: This might be racey?
         assert!(matches!(std::fs::exists(test_file_path), Ok(true)));
 
         // Clean up

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -1814,9 +1814,14 @@ pub mod test {
             window_id,
         )
         .unwrap();
-        context_manager.add_context(false, 0);
+        context_manager.add_context(true, 0);
+        // Wait for the command to finish running
+        context_manager
+            .current_mut()
+            ._io_thread
+            .take()
+            .map(|thread| thread.join());
 
-        //TODO: This might be racey?
         assert!(matches!(std::fs::exists(test_file_path), Ok(true)));
 
         // Clean up

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -1807,8 +1807,13 @@ pub mod test {
         // Make sure the file doesn't exist already
         let _ = std::fs::remove_file(test_file_path);
 
-        let mut context_manager =
-            ContextManager::start_with_capacity_and_config(5, config, VoidListener {}, window_id).unwrap();
+        let mut context_manager = ContextManager::start_with_capacity_and_config(
+            5,
+            config,
+            VoidListener {},
+            window_id,
+        )
+        .unwrap();
         context_manager.add_context(false, 0);
 
         //TODO: This might be racey?

--- a/teletypewriter/examples/spawn.rs
+++ b/teletypewriter/examples/spawn.rs
@@ -10,7 +10,7 @@ fn main() -> std::io::Result<()> {
     use teletypewriter::{create_pty_with_fork, ProcessReadWrite, Pty};
 
     let shell = Cow::Borrowed("bash");
-    let mut process: Pty = create_pty_with_fork(&shell, 80, 25)?;
+    let mut process: Pty = create_pty_with_fork(&shell, &[], 80, 25)?;
 
     process.writer().write_all(b"1").unwrap();
     process.writer().write_all(b"2").unwrap();


### PR DESCRIPTION
Currently when `use-fork` is set to true in the configuration, the created processes don't receive the correct command line arguments.

This is most noticeable on linux with the default configuration, as triggering `OpenConfigEditor` doesn't open the configuration, just opens `vi` with a scratch buffer.

The fix should be rather simple, just plumbing the parameters through `teletypewriter::unix::create_pty_with_fork` and `default_shell_command`