### PR TITLE
Update nix files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
+[*.nix]
+indent_size = 2
+
 [*.scd]
 indent_style = tab
 indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # required by nix
 .direnv/
 result/
+/result
 
 target/
 .DS_Store

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,3 @@
+[[language]]
+name = "nix"
+formatter = { command = "alejandra" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["graphics", "terminal", "application"]
 # Minimal stable rust version (MSRV)
 rust-version = "1.90.0"
 repository = "https://github.com/raphamorim/rio"
-homepage = "https://raphamorim.io/rio"
+homepage = "https://rioterm.com"
 documentation = "https://github.com/raphamorim/rio#readme"
 readme = "README.md"
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1760813311,
-        "narHash": "sha256-lbHQ7FXGzt6/IygWvJ1lCq+Txcut3xYYd6VIpF1ojkg=",
+        "lastModified": 1760948891,
+        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4e627ac2e1b8f1de7f5090064242de9a259dbbc8",
+        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760524057,
-        "narHash": "sha256-EVAqOteLBFmd7pKkb0+FIUyzTF61VKi7YmvP1tw4nEw=",
+        "lastModified": 1760878510,
+        "narHash": "sha256-K5Osef2qexezUfs0alLvZ7nQFTGS9DL2oTVsIXsqLgs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "544961dfcce86422ba200ed9a0b00dd4b1486ec5",
+        "rev": "5e2a59a5b1a82f89f2c7e598302a9cacebb72a67",
         "type": "github"
       },
       "original": {
@@ -49,22 +49,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -75,14 +59,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1760754684,
-        "narHash": "sha256-B4+gmoRuvjZGKvDQtMjYkqyA89gZLjrXObZrXFrcKOk=",
+        "lastModified": 1761100675,
+        "narHash": "sha256-LX3TCDBeNpCWTDXtGyRASVcLmRPChSli34bgHnZ1DCw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "16c233757f1b200936f1b39961c901733936c616",
+        "rev": "72161c6c53f6e3f8dadaf54b2204a5094c6a16ae",
         "type": "github"
       },
       "original": {
@@ -92,7 +78,6 @@
       }
     },
     "systems": {
-      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -5,20 +5,17 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    systems = {
-      url = "github:nix-systems/default";
-      flake = false;
-    };
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    systems.url = "github:nix-systems/default";
   };
 
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {
-      imports = [];
+      imports = [flake-parts.flakeModules.easyOverlay];
 
       systems = import inputs.systems;
 
       perSystem = {
-        config,
         self',
         inputs',
         pkgs,
@@ -26,47 +23,46 @@
         lib,
         ...
       }: let
-        mkRio = import ./pkgRio.nix;
-
+        # Defines a devshell using the `rust-toolchain`, allowing for
+        # different versions of rust to be used.
         mkDevShell = rust-toolchain: let
           runtimeDeps = self'.packages.rio.runtimeDependencies;
-          tools = self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs ++ [rust-toolchain];
+          tools =
+            self'.packages.rio.nativeBuildInputs ++ self'.packages.rio.buildInputs ++ [rust-toolchain];
         in
           pkgs.mkShell {
-            packages =
-              [
-                # Derivations in `rust-toolchain` provide the toolchain,
-                # which must be listed first to take precedence over nightly.
-                rust-toolchain
-
-                # Use rustfmt, and other tools that require nightly features.
-                (pkgs.rust-bin.selectLatestNightlyWith (toolchain:
-                  toolchain.minimal.override {
-                    extensions = ["rustfmt" "rust-analyzer"];
-                  }))
-              ]
-              ++ tools;
-            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath runtimeDeps}";
+            packages = [self'.formatter] ++ tools;
+            LD_LIBRARY_PATH = "${lib.makeLibraryPath runtimeDeps}";
           };
+        toolchains = rec {
+          msrv = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          stable = pkgs.rust-bin.stable.latest.minimal;
+          nightly = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal);
+          rio = msrv;
+          default = rio;
+        };
       in {
+        formatter = pkgs.alejandra;
         _module.args.pkgs = import inputs.nixpkgs {
           inherit system;
           overlays = [(import inputs.rust-overlay)];
         };
 
-        formatter = pkgs.alejandra;
-        packages.default = self'.packages.rio;
-        devShells.default = self'.devShells.msrv;
-
-        apps.default = {
-          type = "app";
-          program = self'.packages.default;
-        };
-        packages.rio = pkgs.callPackage mkRio {rust-toolchain = pkgs.rust-bin.stable.latest.minimal;};
-
-        devShells.msrv = mkDevShell (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
-        devShells.stable = mkDevShell pkgs.rust-bin.stable.latest.minimal;
-        devShells.nightly = mkDevShell (pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal));
+        # Create overlay to override `rio` with this flake's default
+        overlayAttrs = {inherit (self'.packages) rio;};
+        packages =
+          lib.mapAttrs' (
+            k: v: {
+              name =
+                if builtins.elem k ["rio" "default"]
+                then k
+                else "rio-${k}";
+              value = pkgs.callPackage ./pkgRio.nix {rust-toolchain = v;};
+            }
+          )
+          toolchains;
+        # Different devshells for different rust versions
+        devShells = lib.mapAttrs (_: v: mkDevShell v) toolchains;
       };
     };
 }


### PR DESCRIPTION
* Format with `alejandra` and add it to all devShells
* Use `lib.fileset` to get only the needed files for the build
* Fix build inputs for Darwin
* Make `wayland` and `x11` optional using the package args `with*`
* Create a separate `terminfo` output[^1]
* Fix nix file indentation to 2 instead of 4
* Remove `app`, `package` already has a `meta.mainProgram` attribute
* Add an overlay that can be used to override the `rio` package using flake-part's easyOverlay module[^2]
* Create separate package for `msrv`, `stable` and `nightly`, matching the different `devShells` available
* Removed the `flake = false` attribute for `inputs.systems`
* Create `legacyPackages.rio` containing four sub packages using different versions of the rust-toolchain:
    * `rio.msrv` - uses `./rust-toolchain.toml`
    * `rio.stable` - uses `rust-bin.stable`
    * `rio.nightly` - uses the latest nightly rust
    * `rio.default` - Same as `rio.msrv`
* Added `/result` to get rid of the `nix build` output file[^3]


[^1]: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ri/rio/package.nix
[^2]: https://flake.parts/options/flake-parts-easyoverlay
[^3]: A simpler version of #1233, that _just_ adds this one line