### PR TITLE
docs: 'split' color option

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -80,6 +80,7 @@ tabs-active = '#303030'
 tabs-active-highlight = '#ffa133'
 tabs-active-foreground = '#FFFFFF'
 bar = '#1b1a1a'
+split = '#292527'
 
 # Search
 search-match-background = '#44C9F0'
@@ -1356,6 +1357,7 @@ tabs-active = ""
 tabs-active-foreground = ""
 tabs-active-highlight = ""
 bar = ""
+split = ""
 cursor = ""
 vi-cursor = ""
 

--- a/docs/docs/default-colors.md
+++ b/docs/docs/default-colors.md
@@ -30,6 +30,7 @@ tabs-active = '#303030'
 tabs-active-highlight = '#ffa133'
 tabs-active-foreground = '#FFFFFF'
 bar = '#1b1a1a'
+split = '#292527'
 
 # Search
 search-match-background = '#44C9F0'

--- a/extra/man/rio.5.scd
+++ b/extra/man/rio.5.scd
@@ -252,6 +252,10 @@ Colors are specified using their hexadecimal values with a _#_ prefix: _#RRGGBB_
 
 	Navigation bar background color.
 
+*split* = _"<string>"_
+
+	Split separator color.
+
 *search-match-background* = _"<string>"_
 
 	Search match background color.


### PR DESCRIPTION
## Problem
The documentation did not mention the option for the split separator color or its default value.

## Solution

Add the missing 'split' color entry to config, default-colors, and man pages.
