### PR TITLE
Adaptive theme support for linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f8bd58b44ea371b48d21cdc217380cfcafd4b2bb1ad50d27514ec5beca71a2d"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3983,6 +4000,7 @@ name = "rio-window"
 version = "0.4.7"
 dependencies = [
  "ahash",
+ "ashpd",
  "atomic-waker",
  "bindgen 0.70.1",
  "bitflags 2.13.0",
@@ -3995,6 +4013,7 @@ dependencies = [
  "core-graphics 0.24.0",
  "cursor-icon",
  "dpi",
+ "futures-util",
  "image",
  "js-sys",
  "libc",
@@ -4013,6 +4032,7 @@ dependencies = [
  "smithay-client-toolkit 0.19.2",
  "smol_str",
  "softbuffer",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "tracing-web",
@@ -4455,6 +4475,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "softbuffer"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4881,6 +4911,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5111,6 +5157,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6382,6 +6429,7 @@ dependencies = [
  "serde_repr",
  "sha1",
  "static_assertions",
+ "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.52.0",
@@ -6535,6 +6583,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
+ "url",
  "zvariant_derive",
 ]
 

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -61,6 +61,25 @@ impl Application<'_> {
             rio_backend::config::config_dir_path(),
             event_proxy.clone(),
         );
+
+        // Start monitoring system theme changes on Linux
+        #[cfg(all(
+            unix,
+            not(any(target_os = "redox", target_family = "wasm", target_os = "macos"))
+        ))]
+        {
+            let theme_event_proxy = event_proxy.clone();
+            let _ = rio_window::platform::linux::theme_monitor::start_theme_monitor(
+                move || {
+                    // Request config update to apply the new theme
+                    theme_event_proxy.send_event(
+                        RioEventType::Rio(RioEvent::UpdateConfig),
+                        rio_backend::event::WindowId::from(0),
+                    );
+                },
+            );
+        }
+
         let scheduler = Scheduler::new(proxy);
         event_loop.listen_device_events(DeviceEvents::Never);
 
@@ -383,7 +402,30 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 for (_id, route) in self.router.routes.iter_mut() {
                     // Apply system theme to ensure colors are consistent
                     if !has_checked_adaptive_colors {
+                        // On Linux, read cached theme (non-blocking)
+                        #[cfg(all(
+                            unix,
+                            not(any(
+                                target_os = "redox",
+                                target_family = "wasm",
+                                target_os = "macos"
+                            ))
+                        ))]
+                        let system_theme =
+                            rio_window::platform::linux::theme_monitor::get_cached_theme(
+                            );
+
+                        // On other platforms, use window.theme()
+                        #[cfg(not(all(
+                            unix,
+                            not(any(
+                                target_os = "redox",
+                                target_family = "wasm",
+                                target_os = "macos"
+                            ))
+                        )))]
                         let system_theme = route.window.winit_window.theme();
+
                         let theme = self
                             .config
                             .force_theme

--- a/rio-window/Cargo.toml
+++ b/rio-window/Cargo.toml
@@ -155,7 +155,10 @@ winres = "0.1.12"
 
 [target.'cfg(all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "macos"))))'.dependencies]
 ahash = { version = "0.8.7", features = ["no-rng"], optional = true }
+ashpd = { version = "0.9", default-features = false, features = ["tokio"] }
 bytemuck = { version = "1.13.1", default-features = false, optional = true }
+futures-util = "0.3"
+tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 calloop = "0.13.0"
 libc = { workspace = true }
 memmap2 = { workspace = true, optional = true }

--- a/rio-window/src/platform/linux.rs
+++ b/rio-window/src/platform/linux.rs
@@ -1,0 +1,9 @@
+//! Linux-specific functionality.
+
+#[cfg(any(x11_platform, wayland_platform))]
+#[doc(inline)]
+pub use crate::platform_impl::common::theme_monitor;
+
+#[cfg(any(x11_platform, wayland_platform))]
+#[doc(inline)]
+pub use crate::platform_impl::common::xdg_desktop_portal;

--- a/rio-window/src/platform/mod.rs
+++ b/rio-window/src/platform/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! Only the modules corresponding to the platform you're compiling to will be available.
 
+#[cfg(any(x11_platform, wayland_platform, docsrs))]
+pub mod linux;
 #[cfg(any(macos_platform, docsrs))]
 pub mod macos;
 #[cfg(any(orbital_platform, docsrs))]

--- a/rio-window/src/platform_impl/linux/common/mod.rs
+++ b/rio-window/src/platform_impl/linux/common/mod.rs
@@ -1,1 +1,3 @@
+pub mod theme_monitor;
+pub mod xdg_desktop_portal;
 pub mod xkb;

--- a/rio-window/src/platform_impl/linux/common/theme_monitor.rs
+++ b/rio-window/src/platform_impl/linux/common/theme_monitor.rs
@@ -1,0 +1,122 @@
+//! Background monitor for system theme changes via XDG Desktop Portal.
+//!
+//! This module sets up a listener for the SettingsChanged signal from the
+//! XDG Desktop Portal, specifically monitoring for color-scheme preference changes.
+
+use crate::window::Theme;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+
+// Cache for the current theme (0 = None, 1 = Dark, 2 = Light)
+static CACHED_THEME: AtomicU8 = AtomicU8::new(0);
+
+/// Get the cached theme without blocking
+pub fn get_cached_theme() -> Option<Theme> {
+    match CACHED_THEME.load(Ordering::Relaxed) {
+        1 => Some(Theme::Dark),
+        2 => Some(Theme::Light),
+        _ => None,
+    }
+}
+
+pub(crate) fn set_cached_theme(theme: Option<Theme>) {
+    let value = match theme {
+        Some(Theme::Dark) => 1,
+        Some(Theme::Light) => 2,
+        None => 0,
+    };
+    CACHED_THEME.store(value, Ordering::Relaxed);
+}
+
+/// Starts monitoring for system theme changes in a background thread.
+///
+/// When the system color scheme preference changes (dark/light), the provided
+/// callback will be invoked. This allows applications to respond to theme
+/// changes in real-time without needing to restart.
+///
+/// # Arguments
+///
+/// * `on_change` - Callback function to invoke when theme changes are detected
+///
+/// # Returns
+///
+/// Returns `Ok(())` if the monitor was successfully started, or `Err` if
+/// the XDG Desktop Portal is not available or there was an error setting up
+/// the signal listener.
+pub fn start_theme_monitor<F>(on_change: F) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    let callback = Arc::new(on_change);
+
+    std::thread::spawn(move || {
+        // Create a new tokio runtime for this thread
+        let rt = match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt,
+            Err(_) => return,
+        };
+
+        rt.block_on(async {
+            let _ = monitor_theme_changes(callback).await;
+        });
+    });
+
+    Ok(())
+}
+
+async fn monitor_theme_changes<F>(
+    on_change: Arc<F>,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    use ashpd::zbus::fdo::DBusProxy;
+    use ashpd::zbus::{Connection, MatchRule, MessageStream};
+    use futures_util::stream::StreamExt;
+
+    // Connect to session bus
+    let connection = Connection::session().await?;
+
+    // Create match rule for Settings.SettingChanged signal
+    let match_rule = MatchRule::builder()
+        .msg_type(ashpd::zbus::message::Type::Signal)
+        .interface("org.freedesktop.portal.Settings")?
+        .member("SettingChanged")?
+        .build();
+
+    let dbus_proxy = DBusProxy::new(&connection).await?;
+    dbus_proxy.add_match_rule(match_rule.clone()).await?;
+
+    // Create message stream
+    let mut stream =
+        MessageStream::for_match_rule(match_rule, &connection, Some(100)).await?;
+
+    // Process signals as they arrive
+    while let Some(msg) = stream.next().await {
+        let msg = msg?;
+
+        // Try to parse the signal arguments
+        if let Ok((namespace, key, value)) =
+            msg.body()
+                .deserialize::<(String, String, ashpd::zbus::zvariant::Value)>()
+        {
+            if namespace == "org.freedesktop.appearance" && key == "color-scheme" {
+                // Extract the theme value (uint32: 0=no pref, 1=dark, 2=light)
+                if let Ok(variant) = value.downcast::<ashpd::zbus::zvariant::Value>() {
+                    if let Ok(scheme_value) = variant.downcast::<u32>() {
+                        let theme = match scheme_value {
+                            1 => Some(Theme::Dark),
+                            2 => Some(Theme::Light),
+                            _ => None,
+                        };
+                        set_cached_theme(theme);
+                        // Invoke the callback to notify the application
+                        on_change();
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rio-window/src/platform_impl/linux/common/xdg_desktop_portal.rs
+++ b/rio-window/src/platform_impl/linux/common/xdg_desktop_portal.rs
@@ -1,0 +1,50 @@
+//! XDG Desktop Portal integration for reading system preferences.
+//!
+//! This module provides access to system settings via the XDG Desktop Portal,
+//! which is the standard cross-desktop API on Linux systems.
+
+use crate::window::Theme;
+
+/// Queries the system color scheme preference via XDG Desktop Portal.
+///
+/// This function uses the org.freedesktop.portal.Settings interface to read
+/// the color-scheme preference from org.freedesktop.appearance namespace.
+///
+/// The color-scheme value is a uint32 where:
+/// - 0: No preference
+/// - 1: Prefer dark appearance
+/// - 2: Prefer light appearance
+///
+/// Returns `None` if the portal is not available, the setting doesn't exist,
+/// or if there's an error querying the portal.
+pub fn get_color_scheme() -> Option<Theme> {
+    // Use blocking API since this is called during event loop initialization
+    // and we need the result immediately
+    let result = std::panic::catch_unwind(|| {
+        tokio::runtime::Runtime::new()
+            .ok()?
+            .block_on(async { query_color_scheme_async().await })
+    });
+
+    let theme = match result {
+        Ok(Some(theme)) => Some(theme),
+        _ => None,
+    };
+
+    // Also update the cached theme
+    super::theme_monitor::set_cached_theme(theme);
+    theme
+}
+
+async fn query_color_scheme_async() -> Option<Theme> {
+    use ashpd::desktop::settings::{ColorScheme, Settings};
+
+    let settings = Settings::new().await.ok()?;
+    let color_scheme = settings.color_scheme().await.ok()?;
+
+    match color_scheme {
+        ColorScheme::PreferDark => Some(Theme::Dark),
+        ColorScheme::PreferLight => Some(Theme::Light),
+        ColorScheme::NoPreference => None,
+    }
+}

--- a/rio-window/src/platform_impl/linux/mod.rs
+++ b/rio-window/src/platform_impl/linux/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSourc
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
-pub(crate) mod common;
+pub mod common;
 #[cfg(wayland_platform)]
 pub(crate) mod wayland;
 #[cfg(x11_platform)]

--- a/rio-window/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/rio-window/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -735,7 +735,7 @@ impl ActiveEventLoop {
     }
 
     pub(crate) fn system_theme(&self) -> Option<Theme> {
-        None
+        super::super::common::xdg_desktop_portal::get_color_scheme()
     }
 
     #[inline]

--- a/rio-window/src/platform_impl/linux/x11/mod.rs
+++ b/rio-window/src/platform_impl/linux/x11/mod.rs
@@ -1029,7 +1029,7 @@ impl ActiveEventLoop {
     }
 
     pub(crate) fn system_theme(&self) -> Option<Theme> {
-        None
+        super::common::xdg_desktop_portal::get_color_scheme()
     }
 
     pub(crate) fn exit_code(&self) -> Option<i32> {


### PR DESCRIPTION
Adds support for [adaptive-theme](https://rioterm.com/docs/config#adaptive-theme) on linux, based on dbus. This mechanism is commonly used, e.g. by Firefox and other linux applications that support theme switching.


Fixes: https://github.com/raphamorim/rio/issues/408


To test this, configure adaptive theme as documented and set the value using:
```bash
dconf write /org/gnome/desktop/interface/color-scheme "'prefer-dark'"
# or
dconf write /org/gnome/desktop/interface/color-scheme "'prefer-light'"
```

Running rio instances should switch to the preferred colorscheme.