### PR TITLE
 Implement `--app-id` flag

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -35,6 +35,7 @@ pub struct Application<'a> {
     event_proxy: EventProxy,
     router: Router<'a>,
     scheduler: Scheduler,
+    app_id: Option<String>,
 }
 
 impl Application<'_> {
@@ -42,6 +43,7 @@ impl Application<'_> {
         config: rio_backend::config::Config,
         config_error: Option<rio_backend::config::ConfigError>,
         event_loop: &EventLoop<EventPayload>,
+        app_id: Option<String>,
     ) -> Application<'app> {
         // SAFETY: Since this takes a pointer to the winit event loop, it MUST be dropped first,
         // which is done in `loop_exiting`.
@@ -70,6 +72,7 @@ impl Application<'_> {
             event_proxy,
             router,
             scheduler,
+            app_id,
         }
     }
 
@@ -195,6 +198,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             self.event_proxy.clone(),
             &self.config,
             None,
+            self.app_id.as_deref(),
         );
 
         // Schedule title updates every 2s
@@ -689,6 +693,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     self.event_proxy.clone(),
                     &self.config,
                     None,
+                    self.app_id.as_deref(),
                 );
             }
             #[cfg(target_os = "macos")]
@@ -800,6 +805,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     self.event_proxy.clone(),
                     config,
                     Some(url),
+                    self.app_id.as_deref(),
                 );
             }
             return;

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -42,6 +42,10 @@ pub struct TerminalOptions {
     /// Start window with specified title
     #[clap(long, name = "title-placeholder")]
     pub title_placeholder: Option<String>,
+
+    /// Set the Wayland app_id or X11 WM_CLASS (Linux/BSD only)
+    #[clap(long)]
+    pub app_id: Option<String>,
 }
 
 impl TerminalOptions {

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -234,8 +234,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let window_event_loop =
         rio_window::event_loop::EventLoop::<EventPayload>::with_user_event().build()?;
 
-    let mut application =
-        crate::application::Application::new(config, config_error, &window_event_loop);
+    let app_id = args.window_options.terminal_options.app_id;
+
+    let mut application = crate::application::Application::new(
+        config,
+        config_error,
+        &window_event_loop,
+        app_id,
+    );
     let _ = application.run(window_event_loop);
 
     #[cfg(windows)]

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -375,6 +375,7 @@ impl Router<'_> {
             None,
             None,
             self.clipboard.clone(),
+            None,
         );
         let id = window.winit_window.id();
         let route = Route::new(Assistant::new(), RoutePath::Terminal, window);
@@ -419,6 +420,7 @@ impl Router<'_> {
         event_proxy: EventProxy,
         config: &'a rio_backend::config::Config,
         open_url: Option<String>,
+        app_id: Option<&str>,
     ) {
         let tab_id = if config.navigation.is_native() {
             let id = self.current_tab_id;
@@ -437,6 +439,7 @@ impl Router<'_> {
             tab_id.as_deref(),
             open_url,
             self.clipboard.clone(),
+            app_id,
         );
         let id = window.winit_window.id();
 
@@ -473,6 +476,7 @@ impl Router<'_> {
             tab_id,
             open_url,
             self.clipboard.clone(),
+            None,
         );
         self.routes.insert(
             window.winit_window.id(),
@@ -592,9 +596,11 @@ impl<'a> RouteWindow<'a> {
         tab_id: Option<&str>,
         open_url: Option<String>,
         clipboard: Rc<RefCell<Clipboard>>,
+        app_id: Option<&str>,
     ) -> RouteWindow<'a> {
         #[allow(unused_mut)]
-        let mut window_builder = create_window_builder(window_name, config, tab_id);
+        let mut window_builder =
+            create_window_builder(window_name, config, tab_id, app_id);
 
         #[cfg(not(any(target_os = "macos", windows)))]
         if let Some(token) = event_loop.read_token_from_env() {

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -19,6 +19,7 @@ pub fn create_window_builder(
     title: &str,
     config: &Config,
     #[allow(unused_variables)] tab_id: Option<&str>,
+    #[allow(unused_variables)] app_id: Option<&str>,
 ) -> WindowAttributes {
     let image_icon = image_rs::load_from_memory(LOGO_ICON).unwrap();
     let icon = Icon::from_rgba(
@@ -64,15 +65,15 @@ pub fn create_window_builder(
     #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
     {
         use rio_window::platform::x11::WindowAttributesExtX11;
-        window_builder =
-            window_builder.with_name(APPLICATION_ID.to_lowercase(), APPLICATION_ID);
+        let app_name = app_id.unwrap_or(APPLICATION_ID);
+        window_builder = window_builder.with_name(app_name.to_lowercase(), app_name);
     }
 
     #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
     {
         use rio_window::platform::wayland::WindowAttributesExtWayland;
-        window_builder =
-            window_builder.with_name(APPLICATION_ID.to_lowercase(), APPLICATION_ID);
+        let app_name = app_id.unwrap_or(APPLICATION_ID);
+        window_builder = window_builder.with_name(app_name.to_lowercase(), app_name);
     }
 
     #[cfg(target_os = "windows")]

--- a/sugarloaf/src/components/layer/atlas.rs
+++ b/sugarloaf/src/components/layer/atlas.rs
@@ -175,9 +175,8 @@ impl Atlas {
             let offset = row * padded_width;
             let src_row_bytes = (bytes_per_pixel * width) as usize;
 
-            padded_data[offset..offset + src_row_bytes].copy_from_slice(
-                &data[row * src_row_bytes..(row + 1) * src_row_bytes],
-            )
+            padded_data[offset..offset + src_row_bytes]
+                .copy_from_slice(&data[row * src_row_bytes..(row + 1) * src_row_bytes])
         }
 
         match &entry {


### PR DESCRIPTION
This adds the `--app-id` flag on Linux, similar to other terminal emulators (e.g. foot), which allows setting the wayland app or X11 WM_CLASS property using `--app-id=mytermimal`.

 It is useful in window managers like sway, that allow to defind custom rules for specific windows, e.g. to implement a "dropdown" terminal.
