### PR TITLE
fix: handler should process two intermediate bytes in CSI sequences

### DIFF
--- a/rio-backend/src/performer/handler.rs
+++ b/rio-backend/src/performer/handler.rs
@@ -971,7 +971,10 @@ impl<U: Handler, T: Timeout> copa::Perform for Performer<'_, U, T> {
             }};
         }
 
-        if should_ignore || intermediates.len() > 1 {
+        if should_ignore || intermediates.len() > 2 {
+            // We only handle up to two intermediate bytes. I haven't seen any sequences that use
+            // more than that.
+            csi_unhandled!();
             return;
         }
 


### PR DESCRIPTION
There are sequences out there that use a prefix with an intermediate byte where a prefix is something that comes before parameters, and an intermediate byte comes at the end before the final byte. This change allows the handler to process CSI sequences with up to two intermediate i.e. one prefix and one intermediate byte correctly.

It fixes a bug with certain sequences not being handled like DECRPM and others.