### PR TITLE
Avoid allocating in `pre_exec` closure

### DIFF
--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -548,7 +548,7 @@ pub fn create_pty_with_spawn(
             // Create a new process group.
             let err = libc::setsid();
             if err == -1 {
-                return Err(Error::other("Failed to set session id"));
+                return Err(Error::last_os_error());
             }
 
             if is_controling_terminal {


### PR DESCRIPTION
`Error::other` allocates memory (see https://github.com/rust-lang/rust/pull/148971). This is bad in multi-threaded programs, and teletypewriter is a library which can be used in such. If the fork occurs while the allocator lock is held by another thread, deadlocks can occur, since there's no one left in the new process to unlock the mutex. I do not believe this is UB, and modern libc offer protections against this issue, but this isn't POSIX-compliant and should preferably be avoided.

Non-allocating `std::io::Error::last_os_error` can be used instead. This doesn't allow an additional message to be added, but since error messages aren't transmitted across pre_exec boundary anyway, this doesn't make visible behavior any worse. On the flip side, this ensures that the correct error code is forwarded to the parent process, instead of the default `-EINVAL`.