### PR TITLE
Attempted Fix for Input Hanging on Wayland

### DIFF
--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -706,6 +706,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                     self.titles.set_key_val(i, content, None);
                 }
             }
+            //println!("MITIGATION");
 
             self.titles.set_key(id);
         }

--- a/rio-window/src/application.rs
+++ b/rio-window/src/application.rs
@@ -86,9 +86,7 @@ pub trait ApplicationHandler<T: 'static = ()> {
     /// Emitted when an event is sent from [`EventLoopProxy::send_event`].
     ///
     /// [`EventLoopProxy::send_event`]: crate::event_loop::EventLoopProxy::send_event
-    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: T) {
-        let _ = (event_loop, event);
-    }
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: T);
 
     /// Emitted when the OS sends an event to a winit window.
     fn window_event(


### PR DESCRIPTION
Intended to fix #1081 but it doesn't quite work. Removed some dead code and moved Wayland's event dispatcher to an Rc instead of cloning twice like before.

- Added (and commented out) a print statement that helps mitigate the issue #1081 
  - This a a *heisenbug* of sorts. Routinely calling a print statement (in this case in the title update function) mitigates the bug, but only if running from a terminal and printing to stdout (not `/dev/null` or any other file).
- Removed unused function prototype for `user_event`. Unrelated to the issue, but just something that I'd notice.
- Moved some references to the Wayland event dispatcher to an Rc to prevent cloning.
  - This was intended to be a solution, as I was told (by ChatGPT so take with a grain of salt) that cloning the dispatcher did something to the file descriptors that messed up polling. Still, this should save on resources slightly.

I'd be happy if this got merged, but I mostly intend for this to be a starting point for solving #1081 as it's affecting me. Highly curious about what the actual solution is.