### PR TITLE
set screen and window background color when changed via OSC

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -13,7 +13,7 @@ use crate::watcher::configuration_file_updates;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use raw_window_handle::HasDisplayHandle;
 use rio_backend::clipboard::{Clipboard, ClipboardType};
-use rio_backend::config::colors::ColorRgb;
+use rio_backend::config::colors::{ColorRgb, NamedColor};
 use rio_window::application::ApplicationHandler;
 use rio_window::event::{
     ElementState, Ime, MouseButton, MouseScrollDelta, StartCause, TouchPhase, WindowEvent,
@@ -783,6 +783,31 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             .winit_window
                             .set_fullscreen(Some(Fullscreen::Borderless(None))),
                         _ => route.window.winit_window.set_fullscreen(None),
+                    }
+                }
+            }
+            RioEventType::Rio(RioEvent::ColorChange(index, color)) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    let window = &mut route.window;
+                    let screen = &mut window.screen;
+                    match index - NamedColor::Foreground as usize {
+                        1 => {
+                            let sugarloaf = &mut screen.sugarloaf;
+                            sugarloaf.set_background_color(color.map(|c| c.to_wgpu()));
+                            sugarloaf.render();
+
+                            #[cfg(target_os = "macos")]
+                            {
+                                let bg_color = color
+                                    .map_or(self.config.colors.background.1, |c| {
+                                        c.to_composition().1
+                                    });
+                                window.winit_window.set_background_color(
+                                    bg_color.r, bg_color.g, bg_color.b, bg_color.a,
+                                );
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/rio-backend/src/config/colors/mod.rs
+++ b/rio-backend/src/config/colors/mod.rs
@@ -66,6 +66,16 @@ impl ColorRgb {
         let temp_dim_self = Self { r, g, b };
         ColorBuilder::from_rgb(temp_dim_self, Format::SRGB0_1).to_arr()
     }
+
+    pub fn to_wgpu(&self) -> ColorWGPU {
+        ColorBuilder::from_rgb(*self, Format::SRGB0_1).to_wgpu()
+    }
+
+    pub fn to_composition(&self) -> ColorComposition {
+        let arr = self.to_arr();
+        let wgpu = self.to_wgpu();
+        (arr, wgpu)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -2442,6 +2442,8 @@ impl<U: EventListener> Handler for Crosswords<U> {
         }
 
         self.colors[index] = Some(color_arr);
+        self.event_proxy
+            .send_event(RioEvent::ColorChange(index, Some(color)), self.window_id);
     }
 
     #[inline]
@@ -2452,6 +2454,8 @@ impl<U: EventListener> Handler for Crosswords<U> {
         }
 
         self.colors[index] = None;
+        self.event_proxy
+            .send_event(RioEvent::ColorChange(index, None), self.window_id);
     }
 
     #[inline]

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -154,6 +154,12 @@ pub enum RioEvent {
     /// Update window titles.
     UpdateTitles,
 
+    /// Update terminal screen colors.
+    ///
+    /// The usize value represents the color index to change. That is 0 for foreground, 1 for
+    /// background, and  2 for cursor color.
+    ColorChange(usize, Option<ColorRgb>),
+
     // No operation
     Noop,
 }
@@ -221,6 +227,9 @@ impl Debug for RioEvent {
             RioEvent::UpdateFontSize(action) => write!(f, "UpdateFontSize({action:?})"),
             RioEvent::UpdateGraphics { route_id, .. } => {
                 write!(f, "UpdateGraphics({route_id})")
+            }
+            RioEvent::ColorChange(color, rgb) => {
+                write!(f, "ColorChange({color:?}, {rgb:?})")
             }
         }
     }


### PR DESCRIPTION
This change makes the frontend receive color change events from the backend and update the terminal screen background color accordingly. On macOS, it also updates the window background color to match the terminal background color.

Before:
<img width="912" height="630" alt="image" src="https://github.com/user-attachments/assets/d3ee89e9-115d-4616-9462-1162bac0fc27" />

After:
<img width="912" height="630" alt="image" src="https://github.com/user-attachments/assets/3992f781-d330-4539-b5ce-f6027cb02735" />
