### PR TITLE
Add set-min-size configuration option

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -1581,6 +1581,21 @@ Example:
 height = 400
 ```
 
+## window.set-min-size
+
+Whether or not to give window managers a minimum size for the window. If set,
+the size is set to `400x300`
+
+- Default: `true`
+
+Example:
+
+```toml
+[window]
+set-min-size = true
+```
+
+
 ## window.mode
 
 Define how the window will be created

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1407,10 +1407,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
 
-                // let duration = start.elapsed();
-                // println!("Time elapsed in render() is: {:?}", duration);
-                // }
-
                 if self.config.renderer.strategy.is_game() {
                     route.request_redraw();
                 } else if route

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -30,9 +30,13 @@ pub fn create_window_builder(
 
     let mut window_builder = WindowAttributes::default()
         .with_title(title)
-        .with_min_inner_size(rio_window::dpi::LogicalSize {
-            width: DEFAULT_MINIMUM_WINDOW_WIDTH,
-            height: DEFAULT_MINIMUM_WINDOW_HEIGHT,
+        .with_min_inner_size(if config.window.set_min_size {
+            Some(rio_window::dpi::LogicalSize {
+                width: DEFAULT_MINIMUM_WINDOW_WIDTH,
+                height: DEFAULT_MINIMUM_WINDOW_HEIGHT,
+            })
+        } else {
+            None
         })
         .with_resizable(true)
         .with_decorations(true)

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -122,6 +122,11 @@ pub fn default_window_height() -> i32 {
 }
 
 #[inline]
+pub fn default_set_min_size() -> bool {
+    true
+}
+
+#[inline]
 pub fn default_disable_ctlseqs_alt() -> bool {
     #[cfg(target_os = "macos")]
     {

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -77,6 +77,8 @@ pub struct Window {
     pub width: i32,
     #[serde(default = "default_window_height")]
     pub height: i32,
+    #[serde(default = "default_set_min_size", rename = "set-min-size")]
+    pub set_min_size: bool,
     #[serde(default = "WindowMode::default")]
     pub mode: WindowMode,
     #[serde(default = "default_opacity")]
@@ -111,6 +113,7 @@ impl Default for Window {
         Window {
             width: default_window_width(),
             height: default_window_height(),
+            set_min_size: default_set_min_size(),
             mode: WindowMode::default(),
             opacity: default_opacity(),
             background_image: None,

--- a/rio-window/src/window.rs
+++ b/rio-window/src/window.rs
@@ -206,20 +206,8 @@ impl WindowAttributes {
     ///
     /// See [`Window::set_min_inner_size`] for details.
     #[inline]
-    pub fn with_min_inner_size<S: Into<Size>>(mut self, min_size: S) -> Self {
-        self.min_inner_size = Some(min_size.into());
-        self
-    }
-
-    /// Sets the maximum dimensions a window can have.
-    ///
-    /// If this is not set, the window will have no maximum or will be set to
-    /// the primary monitor's dimensions by the platform.
-    ///
-    /// See [`Window::set_max_inner_size`] for details.
-    #[inline]
-    pub fn with_max_inner_size<S: Into<Size>>(mut self, max_size: S) -> Self {
-        self.max_inner_size = Some(max_size.into());
+    pub fn with_min_inner_size<S: Into<Size>>(mut self, min_size: Option<S>) -> Self {
+        self.min_inner_size = min_size.map(|s| s.into());
         self
     }
 


### PR DESCRIPTION
This is a bit of an odd feature, but I like to have my terminals squished vertically for long running tasks

<img width="1288" height="2160" alt="image" src="https://github.com/user-attachments/assets/3474af23-2a8e-4d94-b2d8-11473b6c2382" />


However, `niri` does not squish windows if they set a minimum size which this addresses.

I was considering allowing a setting for the minimum size too, but since there is no canonical way to set `None` in `toml` I figured this is the least controversial way I could come up with