### PR TITLE
[doc] Fixed broken links

### DIFF
--- a/copa/src/lib.rs
+++ b/copa/src/lib.rs
@@ -135,8 +135,6 @@ impl<const OSC_RAW_BUF_SIZE: usize> Parser<OSC_RAW_BUF_SIZE> {
     /// [`Perform::terminated`] is true after reading a byte.
     ///
     /// Returns the number of bytes read before termination.
-    ///
-    /// See [`Perform::advance`] for more details.
     #[inline]
     #[must_use = "Returned value should be used to processs the remaining bytes"]
     pub fn advance_until_terminated<P: Perform>(

--- a/corcovado/src/sys/windows/from_raw_arc.rs
+++ b/corcovado/src/sys/windows/from_raw_arc.rs
@@ -17,7 +17,7 @@
 //!
 //! * The size of `FromRawArc` is actually two words because of the drop flag
 //! * The compiler doesn't understand that the pointer in `FromRawArc` is never
-//!   null, so Option<FromRawArc<T>> is not a nullable pointer.
+//!   null, so `Option<FromRawArc<T>>` is not a nullable pointer.
 
 use std::mem;
 use std::ops::Deref;

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -12,7 +12,7 @@ pub struct HintState {
     /// Visible matches for the current hint
     matches: Vec<HintMatch>,
 
-    /// Labels for each match (as Vec<char>)
+    /// Labels for each match (as `Vec<char>`)
     labels: Vec<Vec<char>>,
 
     /// Keys pressed so far for hint selection

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -687,7 +687,7 @@ impl Screen<'_> {
         }
     }
 
-    /// Check whether we should try to build escape sequence for the [`KeyEvent`].
+    /// Check whether we should try to build escape sequence for the [`KeyEvent`](rio_window::event::KeyEvent).
     fn should_build_sequence(
         key: &rio_window::event::KeyEvent,
         text: &str,

--- a/rio-backend/src/ansi/mode.rs
+++ b/rio-backend/src/ansi/mode.rs
@@ -118,7 +118,7 @@ pub enum NamedPrivateMode {
     UrgencyHints = 1042,
     SwapScreenAndSetRestoreCursor = 1049,
     BracketedPaste = 2004,
-    /// The mode is handled automatically by [`Processor`].
+    /// The mode is handled automatically by [`Processor`](crate::performer::handler::Processor).
     SyncUpdate = 2026,
 }
 

--- a/rio-backend/src/config/platform.rs
+++ b/rio-backend/src/config/platform.rs
@@ -13,7 +13,7 @@ pub struct Platform {
 
 /// Other platform specific configuration options can be added here.
 ///
-/// When deserializing, each field is Option<T> to distinguish between
+/// When deserializing, each field is `Option<T>` to distinguish between
 /// "not specified" vs "specified with value". During merge, we recursively
 /// merge individual fields rather than replacing entire structures.
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/rio-backend/src/crosswords/grid/storage.rs
+++ b/rio-backend/src/crosswords/grid/storage.rs
@@ -152,9 +152,9 @@ impl<T> Storage<T> {
         self.len == 0
     }
 
-    /// Swap implementation for Row<T>.
+    /// Swap implementation for `Row<T>`.
     ///
-    /// Exploits the known size of Row<T> to produce a slightly more efficient
+    /// Exploits the known size of `Row<T>` to produce a slightly more efficient
     /// swap than going through slice::swap.
     ///
     /// The default implementation from swap generates 8 movups and 4 movaps

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -170,7 +170,7 @@ impl From<KeyboardModes> for Mode {
     }
 }
 
-/// Terminal damage information collected since the last [`Term::reset_damage`] call.
+/// Terminal damage information collected since the last [`Crosswords::reset_damage`] call.
 #[derive(Debug)]
 pub enum TermDamage<'a> {
     /// The entire terminal is damaged.

--- a/rio-backend/src/selection.rs
+++ b/rio-backend/src/selection.rs
@@ -111,17 +111,17 @@ pub enum SelectionType {
 /// Describes a region of a 2-dimensional area.
 ///
 /// Used to track a text selection. There are four supported modes, each with its own constructor:
-/// [`simple`], [`block`], [`semantic`], and [`lines`]. The [`simple`] mode precisely tracks which
+/// [`simple`], [`block`], [`semantic`], and [`semantic`]. The [`simple`] mode precisely tracks which
 /// cells are selected without any expansion. [`block`] will select rectangular regions.
-/// [`lines`] will always select entire lines.
+/// [`semantic`] will always select entire lines.
 ///
 /// Calls to [`update`] operate different based on the selection kind. The [`simple`] and [`block`]
 /// mode do nothing special, simply track points and sides.
 ///
-/// [`simple`]: enum.Selection.html#method.simple
-/// [`block`]: enum.Selection.html#method.block
-/// [`lines`]: enum.Selection.html#method.rows
-/// [`update`]: enum.Selection.html#method.update
+/// [`simple`]: enum.SelectionType.html#variant.Simple
+/// [`block`]: enum.SelectionType.html#variant.Block
+/// [`semantic`]: enum.SelectionType.html#variant.Semantic
+/// [`update`]: enum.SelectionType.html#variant.Update
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Selection {
     pub ty: SelectionType,

--- a/rio-window/src/lib.rs
+++ b/rio-window/src/lib.rs
@@ -152,7 +152,7 @@
 //! [`Window`]: window::Window
 //! [`WindowId`]: window::WindowId
 //! [`WindowAttributes`]: window::WindowAttributes
-//! [window_new]: window::Window::new
+//! [window_new]: event_loop::ActiveEventLoop::create_window
 //! [`create_window`]: event_loop::ActiveEventLoop::create_window
 //! [`Window::id()`]: window::Window::id
 //! [`WindowEvent`]: event::WindowEvent

--- a/rio-window/src/platform/windows.rs
+++ b/rio-window/src/platform/windows.rs
@@ -454,12 +454,12 @@ impl WindowExtWindows for Window {
 pub trait WindowBorrowExtWindows: Borrow<Window> + Sized {
     /// Create an object that allows accessing the inner window handle in a thread-unsafe way.
     ///
-    /// It is possible to call [`window_handle_any_thread`] to get around Windows's thread
+    /// It is possible to call [`window_handle_any_thread`](WindowExtWindows::window_handle_any_thread) to get around Windows's thread
     /// affinity limitations. However, it may be desired to pass the [`Window`] into something
-    /// that requires the [`HasWindowHandle`] trait, while ignoring thread affinity limitations.
+    /// that requires the [`HasWindowHandle`](raw_window_handle::HasWindowHandle) trait, while ignoring thread affinity limitations.
     ///
     /// This function wraps anything that implements `Borrow<Window>` into a structure that
-    /// uses the inner window handle as a mean of implementing [`HasWindowHandle`]. It wraps
+    /// uses the inner window handle as a mean of implementing [`HasWindowHandle`](raw_window_handle::HasWindowHandle). It wraps
     /// `Window`, `&Window`, `Arc<Window>`, and other reference types.
     ///
     /// # Safety

--- a/sugarloaf/src/font_introspector/scale/mod.rs
+++ b/sugarloaf/src/font_introspector/scale/mod.rs
@@ -58,11 +58,7 @@ that yields [`NormalizedCoord`]s (a type alias for `i16` which is a fixed point 
 in 2.14 format). This method is faster than specifying variations by tag and value, but
 the difference is likely negligible outside of microbenchmarks. The real advantage
 is that a sequence of `i16` is more compact and easier to fold into a key in a glyph
-cache. You can compute these normalized coordinates by using the
-[`Variation::normalize`](crate::Variation::normalize) method for each available axis in
-the font. The best strategy, however, is to simply capture these during shaping with
-the [`Shaper::normalized_coords`](crate::shape::Shaper::normalized_coords) method which
-will have already computed them for you.
+cache.
 
 See [`ScalerBuilder`] for available options and default values.
 
@@ -108,10 +104,6 @@ Similar to outlines, bitmaps can be retrieved with the [`scale_bitmap`](Scaler::
 and [`scale_color_bitmap`](Scaler::scale_color_bitmap) for alpha and color bitmaps,
 respectively. These methods return an [`Image`] wrapped in an option. The associated
 `_into` variants are also available.
-
-Unlike outlines, bitmaps are available in [`strike`](crate::BitmapStrike)s of various sizes.
-When requesting a bitmap, you specify the strategy for strike selection using the
-[`StrikeWith`] enum.
 
 For example, if we want the largest available unscaled image for the fire emoji:
 ```ignore
@@ -807,7 +799,7 @@ impl<'a> Render<'a> {
     }
 
     /// Specifies the target format for rasterizing an outline. Default is
-    /// [`Format::Alpha`](zeno::Format::Alpha).
+    /// [`Format::Alpha`].
     pub fn format(&mut self, format: Format) -> &mut Self {
         self.format = format;
         self


### PR DESCRIPTION
Intuitively fixed the broken doc links.
This is mostly for me to have a clean local copy of the documentations.

Since it is based on my intuitions, it *may* be wrong at times. If so, i'd like to know, so i can fix it.

I have also removed some lines from the documentation, cause i was unaware of how to fix it. 🥲

*Also, i guess it only includes Windows (Cause i code from windows)*