### PR TITLE
feat: add multiple shell profiles support

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -1374,6 +1374,64 @@ program = "/opt/homebrew/bin/tmux"
 args = ["new-session", "-c", "/var/www"]
 ```
 
+### Multiple Shell Profiles
+
+Rio supports multiple shell profiles, allowing you to quickly switch between different shells when creating new tabs.
+
+- `Ctrl+Shift+T` (or `Cmd+T` on macOS) creates a new tab with the default shell
+- `Ctrl+Shift+Y` (or `Cmd+Y` on macOS) opens a profile selector to choose which shell to use
+
+You can define additional shell profiles using `[[shells]]`:
+
+```toml
+# Default shell
+[shell]
+program = "/bin/zsh"
+args = ["--login"]
+
+# Additional shell profiles (uncomment to enable)
+# [[shells]]
+# name = "Fish"
+# program = "/bin/fish"
+# args = ["--login"]
+#
+# [[shells]]
+# name = "Bash"
+# program = "/bin/bash"
+# args = ["--login"]
+```
+
+#### Windows Example with WSL, PowerShell, and CMD
+
+```toml
+# Default shell (PowerShell)
+[shell]
+program = "pwsh"
+args = []
+
+# Additional shell profiles (uncomment to enable)
+# [[shells]]
+# name = "WSL"
+# program = "C:\\Windows\\System32\\wsl.exe"
+# args = []
+#
+# [[shells]]
+# name = "CMD"
+# program = "C:\\Windows\\System32\\cmd.exe"
+# args = []
+#
+# [[shells]]
+# name = "Git Bash"
+# program = "C:\\Program Files\\Git\\bin\\bash.exe"
+# args = ["--login"]
+```
+
+When you press `Ctrl+Shift+Y`, a selector overlay will appear showing all available profiles. Use:
+- `j`/`k` or arrow keys to navigate
+- `1-9` to directly select a profile by number
+- `Enter` to confirm selection
+- `Escape` to cancel
+
 ## theme
 
 The configuration property `theme` is used for specifying the theme. Rio will look in the `themes` folder for the theme.

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -388,7 +388,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     let new_font_library = rio_backend::sugarloaf::font::FontLibrary::new(
                         config.fonts.to_owned(),
                     );
-                    self.router.font_library = Box::new(new_font_library.0);
+                    *self.router.font_library = new_font_library.0;
                     new_font_library.1
                 } else {
                     None

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -236,6 +236,7 @@ impl From<String> for Action {
             "decreasefontsize" => Some(Action::DecreaseFontSize),
             "createwindow" => Some(Action::WindowCreateNew),
             "createtab" => Some(Action::TabCreateNew),
+            "shellprofileselector" => Some(Action::ShellProfileSelector),
             "movecurrenttabtoprev" => Some(Action::MoveCurrentTabToPrev),
             "movecurrenttabtonext" => Some(Action::MoveCurrentTabToNext),
             "closetab" => Some(Action::TabCloseCurrent),
@@ -416,6 +417,9 @@ pub enum Action {
 
     /// Create a new Rio tab.
     TabCreateNew,
+
+    /// Show shell profile selector overlay.
+    ShellProfileSelector,
 
     /// Move current tab to previous slot.
     MoveCurrentTabToPrev,
@@ -1018,6 +1022,7 @@ pub fn platform_key_bindings(
         key_bindings.extend(bindings!(
             KeyBinding;
             "t", ModifiersState::SUPER; Action::TabCreateNew;
+            "y", ModifiersState::SUPER; Action::ShellProfileSelector;
             Key::Named(Tab), ModifiersState::CONTROL; Action::SelectNextTab;
             Key::Named(Tab), ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SelectPrevTab;
             "w", ModifiersState::SUPER; Action::CloseCurrentSplitOrTab;
@@ -1101,6 +1106,7 @@ pub fn platform_key_bindings(
         key_bindings.extend(bindings!(
             KeyBinding;
             "t", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabCreateNew;
+            "y", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::ShellProfileSelector;
             Key::Named(Tab), ModifiersState::CONTROL; Action::SelectNextTab;
             Key::Named(Tab), ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SelectPrevTab;
             "[", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SelectPrevTab;
@@ -1170,6 +1176,7 @@ pub fn platform_key_bindings(
         key_bindings.extend(bindings!(
             KeyBinding;
             "t", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::TabCreateNew;
+            "y", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::ShellProfileSelector;
             Key::Named(Tab), ModifiersState::CONTROL; Action::SelectNextTab;
             Key::Named(Tab), ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SelectPrevTab;
             "w", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::CloseCurrentSplitOrTab;

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -57,6 +57,7 @@ impl TerminalOptions {
         }
 
         Some(Shell {
+            name: None,
             program: program.clone(),
             args: args.to_vec(),
         })

--- a/frontends/rioterm/src/context/grid.rs
+++ b/frontends/rioterm/src/context/grid.rs
@@ -5,7 +5,7 @@ use rio_backend::event::EventListener;
 use rio_backend::sugarloaf::{
     layout::SugarDimensions, Object, Quad, RichText, Sugarloaf,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 const MIN_COLS: usize = 2;
 const MIN_LINES: usize = 1;
@@ -203,7 +203,8 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
     pub fn get_ordered_keys(&self) -> Vec<usize> {
         let mut keys = Vec::new();
         if let Some(root) = self.root {
-            self.collect_keys_recursive(root, &mut keys);
+            let mut visited = HashSet::new();
+            self.collect_keys_recursive(root, &mut keys, &mut visited);
         }
         keys
     }
@@ -231,14 +232,27 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
         keys.iter().position(|&k| k == key)
     }
 
-    fn collect_keys_recursive(&self, key: usize, keys: &mut Vec<usize>) {
+    fn collect_keys_recursive(
+        &self,
+        key: usize,
+        keys: &mut Vec<usize>,
+        visited: &mut HashSet<usize>,
+    ) {
+        if !visited.insert(key) {
+            tracing::warn!(
+                "Detected cycle while collecting ordered keys at key {:?}",
+                key
+            );
+            return;
+        }
+
         if let Some(item) = self.inner.get(&key) {
             keys.push(key);
             if let Some(right_key) = item.right {
-                self.collect_keys_recursive(right_key, keys);
+                self.collect_keys_recursive(right_key, keys, visited);
             }
             if let Some(down_key) = item.down {
-                self.collect_keys_recursive(down_key, keys);
+                self.collect_keys_recursive(down_key, keys, visited);
             }
         }
     }
@@ -707,7 +721,8 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             return;
         }
         if let Some(root) = self.root {
-            self.calculate_positions_recursive(root, self.margin);
+            let mut visited = HashSet::new();
+            self.calculate_positions_recursive(root, self.margin, &mut visited);
         }
     }
 
@@ -722,7 +737,8 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             if self.inner.contains_key(&key) {
                 // Find the position this node should have based on its parent
                 let margin = self.find_node_margin(key);
-                self.calculate_positions_recursive(key, margin);
+                let mut visited = HashSet::new();
+                self.calculate_positions_recursive(key, margin, &mut visited);
             }
         }
     }
@@ -771,7 +787,20 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
     }
 
     /// Recursively calculate positions for grid items
-    fn calculate_positions_recursive(&mut self, key: usize, margin: Delta<f32>) {
+    fn calculate_positions_recursive(
+        &mut self,
+        key: usize,
+        margin: Delta<f32>,
+        visited: &mut HashSet<usize>,
+    ) {
+        if !visited.insert(key) {
+            tracing::warn!(
+                "Detected cycle while calculating grid positions at key {:?}",
+                key
+            );
+            return;
+        }
+
         if let Some(item) = self.inner.get_mut(&key) {
             // Set position for current item in the rich text object
             item.set_position([margin.x, margin.top_y]);
@@ -800,11 +829,11 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
             // Recursively calculate positions for child items
             if let Some(down_key) = down_key {
-                self.calculate_positions_recursive(down_key, down_margin);
+                self.calculate_positions_recursive(down_key, down_margin, visited);
             }
 
             if let Some(right_key) = right_key {
-                self.calculate_positions_recursive(right_key, right_margin);
+                self.calculate_positions_recursive(right_key, right_margin, visited);
             }
         }
     }
@@ -1130,9 +1159,18 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
         let mut last_right = None;
         let mut right_ptr = self.inner.get(&base_key).and_then(|item| item.right);
+        let mut visited = HashSet::new();
 
         // Find the last right item and resize all
         while let Some(right_key) = right_ptr {
+            if !visited.insert(right_key) {
+                tracing::warn!(
+                    "Detected cycle while inheriting right children at key {:?}",
+                    right_key
+                );
+                break;
+            }
+
             if !self.inner.contains_key(&right_key) {
                 break;
             }
@@ -1803,13 +1841,27 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
         // Find all down children and update their width
         if let Some(parent) = self.inner.get(&parent_key) {
             if let Some(down_key) = parent.down {
-                self.update_children_width_recursive(down_key, new_width);
+                let mut visited = HashSet::new();
+                self.update_children_width_recursive(down_key, new_width, &mut visited);
             }
         }
     }
 
     /// Recursively update width for all nodes in a vertical chain
-    fn update_children_width_recursive(&mut self, key: usize, new_width: f32) {
+    fn update_children_width_recursive(
+        &mut self,
+        key: usize,
+        new_width: f32,
+        visited: &mut HashSet<usize>,
+    ) {
+        if !visited.insert(key) {
+            tracing::warn!(
+                "Detected cycle while updating children width at key {:?}",
+                key
+            );
+            return;
+        }
+
         let down_key = if let Some(item) = self.inner.get_mut(&key) {
             item.val.dimension.update_width(new_width);
             item.down
@@ -1821,7 +1873,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
         // Continue down the chain
         if let Some(down_key) = down_key {
-            self.update_children_width_recursive(down_key, new_width);
+            self.update_children_width_recursive(down_key, new_width, visited);
         }
     }
 

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -940,7 +940,8 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
 
         let context_manager_config = ContextManagerConfig {
             cwd: config.navigation.current_working_directory,
-            shell,
+            shell: shell.clone(),
+            shells: config.shells.clone(),
             working_dir,
             spawn_performer: true,
             #[cfg(not(target_os = "windows"))]

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -111,7 +111,6 @@ impl<T: EventListener> Context<T> {
 #[derive(Clone, Default)]
 pub struct ContextManagerConfig {
     pub shell: Shell,
-    pub shells: Vec<Shell>,
     #[cfg(not(target_os = "windows"))]
     pub use_fork: bool,
     pub working_dir: Option<String>,
@@ -380,35 +379,23 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         event_proxy: T,
         window_id: WindowId,
     ) -> Result<Self, Box<dyn Error>> {
-        let config = ContextManagerConfig {
-            #[cfg(not(target_os = "windows"))]
-            use_fork: true,
-            working_dir: None,
-            shell: Shell {
-                name: None,
-                program: std::env::var("SHELL").unwrap_or("bash".to_string()),
-                args: vec![],
-            },
-            spawn_performer: false,
-            is_native: false,
-            should_update_title_extra: false,
-            cwd: false,
-            ..ContextManagerConfig::default()
-        };
-        let initial_context = ContextManager::create_context(
-            (&Cursor::default(), false),
+        let config = ContextManagerConfig::default();
+        let route_id = ROUTE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+        // Use create_dead_context to avoid forking real shell processes in tests
+        let initial_context = create_dead_context(
             event_proxy.clone(),
             window_id,
+            route_id,
             0,
             ContextDimension::default(),
-            &config,
-        )?;
+        );
 
         let titles = ContextManagerTitles::new(0, String::new(), None);
 
         Ok(ContextManager {
             current_index: 0,
-            current_route: 0,
+            current_route: route_id,
             contexts: smallvec![ContextGrid::new(
                 initial_context,
                 Delta::<f32>::default(),
@@ -919,7 +906,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         let context_manager_config = ContextManagerConfig {
             cwd: config.navigation.current_working_directory,
             shell: shell.clone(),
-            shells: config.shells.clone(),
             working_dir,
             spawn_performer: true,
             #[cfg(not(target_os = "windows"))]
@@ -960,9 +946,35 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
+    #[cfg(test)]
     #[inline]
     pub fn add_context(&mut self, redirect: bool, rich_text_id: usize) {
-        self.add_context_with_shell(redirect, rich_text_id, None)
+        // Use create_dead_context to avoid forking real shell processes in tests
+        let size = self.contexts.len();
+        if size < self.capacity {
+            let last_index = self.contexts.len();
+            let route_id = ROUTE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+            let dimension = self.current().dimension;
+            let new_context = create_dead_context(
+                self.event_proxy.clone(),
+                self.window_id,
+                route_id,
+                rich_text_id,
+                dimension,
+            );
+
+            let previous_margin = self.contexts[self.current_index].margin;
+            self.contexts.push(ContextGrid::new(
+                new_context,
+                previous_margin,
+                self.config.split_color,
+            ));
+
+            if redirect {
+                self.current_index = last_index;
+                self.current_route = route_id;
+            }
+        }
     }
 
     pub fn add_context_with_shell(

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -111,6 +111,7 @@ impl<T: EventListener> Context<T> {
 #[derive(Clone, Default)]
 pub struct ContextManagerConfig {
     pub shell: Shell,
+    pub shells: Vec<Shell>,
     #[cfg(not(target_os = "windows"))]
     pub use_fork: bool,
     pub working_dir: Option<String>,
@@ -184,6 +185,7 @@ pub fn create_mock_context<
         use_fork: true,
         working_dir: None,
         shell: Shell {
+            name: None,
             program: std::env::var("SHELL").unwrap_or("bash".to_string()),
             args: vec![],
         },
@@ -405,6 +407,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             use_fork: true,
             working_dir: None,
             shell: Shell {
+                name: None,
                 program: std::env::var("SHELL").unwrap_or("bash".to_string()),
                 args: vec![],
             },
@@ -980,6 +983,15 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
 
     #[inline]
     pub fn add_context(&mut self, redirect: bool, rich_text_id: usize) {
+        self.add_context_with_shell(redirect, rich_text_id, None)
+    }
+
+    pub fn add_context_with_shell(
+        &mut self,
+        redirect: bool,
+        rich_text_id: usize,
+        shell_override: Option<Shell>,
+    ) {
         let mut working_dir = self.config.working_dir.clone();
         if self.config.cwd {
             #[cfg(not(target_os = "windows"))]
@@ -1016,6 +1028,9 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             let mut cloned_config = self.config.clone();
             if working_dir.is_some() {
                 cloned_config.working_dir = working_dir;
+            }
+            if let Some(shell) = shell_override {
+                cloned_config.shell = shell;
             }
 
             let current = self.current();
@@ -1072,6 +1087,7 @@ pub fn process_open_url(
                     let mut args = editor.args;
                     args.push(path_buf.display().to_string());
                     shell = Shell {
+                        name: None,
                         program: editor.program,
                         args,
                     }

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -180,30 +180,8 @@ pub fn create_mock_context<
     rich_text_id: usize,
     dimension: ContextDimension,
 ) -> Context<T> {
-    let config = ContextManagerConfig {
-        #[cfg(not(target_os = "windows"))]
-        use_fork: true,
-        working_dir: None,
-        shell: Shell {
-            name: None,
-            program: std::env::var("SHELL").unwrap_or("bash".to_string()),
-            args: vec![],
-        },
-        spawn_performer: false,
-        is_native: false,
-        should_update_title_extra: false,
-        cwd: false,
-        ..ContextManagerConfig::default()
-    };
-    ContextManager::create_context(
-        (&Cursor::default(), false),
-        event_proxy.clone(),
-        window_id,
-        rich_text_id,
-        dimension,
-        &config,
-    )
-    .unwrap()
+    let route_id = ROUTE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+    create_dead_context(event_proxy, window_id, route_id, rich_text_id, dimension)
 }
 
 impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -20,6 +20,7 @@ mod renderer;
 mod router;
 mod scheduler;
 mod screen;
+mod shell_selector;
 mod watcher;
 
 use clap::Parser;

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -377,7 +377,7 @@ impl Renderer {
 
             if !is_active {
                 style.color[3] = self.unfocused_split_opacity;
-                if let Some(mut background_color) = style.background_color {
+                if let Some(background_color) = style.background_color.as_mut() {
                     background_color[3] = self.unfocused_split_opacity;
                 }
             }
@@ -830,6 +830,7 @@ impl Renderer {
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub fn run(
         &mut self,
         sugarloaf: &mut Sugarloaf,

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -2,6 +2,7 @@ mod char_cache;
 mod font_cache;
 pub mod navigation;
 mod search;
+pub mod shell_selector;
 pub mod utils;
 
 use crate::context::renderable::TerminalSnapshot;
@@ -835,6 +836,17 @@ impl Renderer {
         context_manager: &mut ContextManager<EventProxy>,
         focused_match: &Option<RangeInclusive<Pos>>,
     ) -> Option<crate::context::renderable::WindowUpdate> {
+        self.run_with_shell_selector(sugarloaf, context_manager, focused_match, None)
+    }
+
+    #[inline]
+    pub fn run_with_shell_selector(
+        &mut self,
+        sugarloaf: &mut Sugarloaf,
+        context_manager: &mut ContextManager<EventProxy>,
+        focused_match: &Option<RangeInclusive<Pos>>,
+        shell_selector: Option<&crate::shell_selector::ShellSelector>,
+    ) -> Option<crate::context::renderable::WindowUpdate> {
         // let start = std::time::Instant::now();
 
         // In case rich text for search was not created
@@ -1113,6 +1125,18 @@ impl Renderer {
         // let _duration = start.elapsed();
         context_manager.extend_with_grid_objects(&mut objects);
         // let _duration = start.elapsed();
+
+        // Render shell selector overlay if active
+        if let Some(selector) = shell_selector {
+            let dimensions = (window_size.width, window_size.height, scale_factor);
+            shell_selector::draw_shell_selector(
+                &mut objects,
+                sugarloaf,
+                selector,
+                &self.named_colors,
+                dimensions,
+            );
+        }
 
         // Update visual bell state and set overlay if needed
         let visual_bell_active = self.update_visual_bell();

--- a/frontends/rioterm/src/renderer/shell_selector.rs
+++ b/frontends/rioterm/src/renderer/shell_selector.rs
@@ -1,0 +1,266 @@
+//! Shell selector UI renderer
+//!
+//! This module renders the shell profile selector overlay that allows users
+//! to quickly switch between different shell configurations.
+
+use crate::shell_selector::ShellSelector;
+use rio_backend::config::colors::Colors;
+use rio_backend::sugarloaf::{FragmentStyle, Object, Quad, RichText};
+
+/// Width of the selector panel in pixels
+const PANEL_WIDTH: f32 = 300.0;
+
+/// Height of each item in the list in pixels
+const ITEM_HEIGHT: f32 = 28.0;
+
+/// Padding inside the panel in pixels
+const PANEL_PADDING: f32 = 12.0;
+
+/// Font size for the selector text
+const FONT_SIZE: f32 = 14.0;
+
+/// Alpha value for the backdrop overlay
+const BACKDROP_ALPHA: f32 = 0.5;
+
+/// Alpha value for the backdrop overlay
+const BORDER_RADIUS: f32 = 8.0;
+
+/// Draw the shell selector overlay
+///
+/// This renders:
+/// - A semi-transparent backdrop covering the terminal
+/// - A centered panel with the list of shell profiles
+/// - Each profile with a shortcut key, name, and selection highlight
+#[inline]
+pub fn draw_shell_selector(
+    objects: &mut Vec<Object>,
+    sugarloaf: &mut rio_backend::sugarloaf::Sugarloaf,
+    shell_selector: &ShellSelector,
+    colors: &Colors,
+    dimensions: (f32, f32, f32),
+) {
+    let (width, height, scale) = dimensions;
+
+    // Scale dimensions
+    let scaled_width = width / scale;
+    let scaled_height = height / scale;
+
+    let profiles = shell_selector.profiles_for_display();
+
+    // Calculate panel dimensions
+    let panel_height =
+        (profiles.len() as f32 * ITEM_HEIGHT) + (PANEL_PADDING * 2.0) + ITEM_HEIGHT;
+    let panel_x = (scaled_width - PANEL_WIDTH) / 2.0;
+    let panel_y = (scaled_height - panel_height) / 2.0;
+
+    // Draw semi-transparent backdrop
+    let backdrop_color = [
+        colors.background.0[0],
+        colors.background.0[1],
+        colors.background.0[2],
+        BACKDROP_ALPHA,
+    ];
+    objects.push(Object::Quad(Quad {
+        position: [0.0, 0.0],
+        size: [scaled_width, scaled_height],
+        color: backdrop_color,
+        ..Quad::default()
+    }));
+
+    // Draw panel background
+    objects.push(Object::Quad(Quad {
+        position: [panel_x, panel_y],
+        size: [PANEL_WIDTH, panel_height],
+        color: colors.bar,
+        border_radius: BORDER_RADIUS,
+        ..Quad::default()
+    }));
+
+    // Draw panel border (using a second quad with slightly larger size for border effect)
+    let border_color = colors.tabs;
+    let border_width = 1.0;
+    objects.push(Object::Quad(Quad {
+        position: [panel_x - border_width, panel_y - border_width],
+        size: [
+            PANEL_WIDTH + (border_width * 2.0),
+            panel_height + (border_width * 2.0),
+        ],
+        color: border_color,
+        border_radius: BORDER_RADIUS + border_width,
+        ..Quad::default()
+    }));
+
+    // Redraw panel background on top of border
+    objects.push(Object::Quad(Quad {
+        position: [panel_x, panel_y],
+        size: [PANEL_WIDTH, panel_height],
+        color: colors.bar,
+        border_radius: BORDER_RADIUS,
+        ..Quad::default()
+    }));
+
+    // Draw title
+    let title_rich_text = sugarloaf.create_temp_rich_text();
+    sugarloaf.set_rich_text_font_size(&title_rich_text, FONT_SIZE);
+
+    let content = sugarloaf.content();
+    let title_line = content.sel(title_rich_text);
+    title_line
+        .clear()
+        .new_line()
+        .add_text(
+            "Select Shell Profile",
+            FragmentStyle {
+                color: colors.foreground,
+                ..FragmentStyle::default()
+            },
+        )
+        .build();
+
+    objects.push(Object::RichText(RichText {
+        id: title_rich_text,
+        position: [panel_x + PANEL_PADDING, panel_y + PANEL_PADDING - 4.0],
+        lines: None,
+    }));
+
+    // Draw each profile item
+    let items_start_y = panel_y + PANEL_PADDING + ITEM_HEIGHT;
+    for (index, shell, is_selected) in &profiles {
+        let item_y = items_start_y + (*index as f32 * ITEM_HEIGHT);
+
+        // Draw selection highlight background
+        if *is_selected {
+            objects.push(Object::Quad(Quad {
+                position: [panel_x + 4.0, item_y],
+                size: [PANEL_WIDTH - 8.0, ITEM_HEIGHT - 4.0],
+                color: colors.tabs_active,
+                border_radius: 4.0,
+                ..Quad::default()
+            }));
+        }
+
+        // Create the display text with shortcut key
+        let shortcut = get_shortcut_key(*index);
+        let display_name = ShellSelector::display_name(shell);
+
+        // Create rich text for this item
+        let item_rich_text = sugarloaf.create_temp_rich_text();
+        sugarloaf.set_rich_text_font_size(&item_rich_text, FONT_SIZE);
+
+        let content = sugarloaf.content();
+        let item_line = content.sel(item_rich_text);
+
+        // Use different colors for selected item
+        let text_color = if *is_selected {
+            colors.tabs_active_foreground
+        } else {
+            colors.tabs_foreground
+        };
+
+        let shortcut_color = if *is_selected {
+            colors.tabs_active_highlight
+        } else {
+            colors.tabs
+        };
+
+        // Draw shortcut key with accent color
+        item_line.clear().new_line().add_text(
+            &format!("{} ", shortcut),
+            FragmentStyle {
+                color: shortcut_color,
+                ..FragmentStyle::default()
+            },
+        );
+
+        // Draw display name with regular color
+        item_line.add_text(
+            display_name,
+            FragmentStyle {
+                color: text_color,
+                ..FragmentStyle::default()
+            },
+        );
+
+        item_line.build();
+
+        objects.push(Object::RichText(RichText {
+            id: item_rich_text,
+            position: [panel_x + PANEL_PADDING, item_y + 4.0],
+            lines: None,
+        }));
+    }
+
+    // Draw help text at the bottom
+    let help_text = "Enter to select, Esc to cancel";
+    let help_rich_text = sugarloaf.create_temp_rich_text();
+    sugarloaf.set_rich_text_font_size(&help_rich_text, FONT_SIZE - 2.0);
+
+    let content = sugarloaf.content();
+    let help_line = content.sel(help_rich_text);
+    help_line
+        .clear()
+        .new_line()
+        .add_text(
+            help_text,
+            FragmentStyle {
+                color: [
+                    colors.foreground[0],
+                    colors.foreground[1],
+                    colors.foreground[2],
+                    colors.foreground[3] - 0.4, // Make it slightly dimmer
+                ],
+                ..FragmentStyle::default()
+            },
+        )
+        .build();
+
+    let help_y = panel_y + panel_height - PANEL_PADDING - 8.0;
+    objects.push(Object::RichText(RichText {
+        id: help_rich_text,
+        position: [panel_x + PANEL_PADDING, help_y],
+        lines: None,
+    }));
+}
+
+/// Get the shortcut key for a given index
+///
+/// Uses 1-9 for the first 9 items, then a-z for items 10+
+fn get_shortcut_key(index: usize) -> String {
+    if index < 9 {
+        // 1-9 for first 9 items (1-indexed for user friendliness)
+        format!("{}.", index + 1)
+    } else {
+        // a-z for items 10-35
+        let letter_index = index - 9;
+        if letter_index < 26 {
+            let c = (b'a' + letter_index as u8) as char;
+            format!("{}.", c)
+        } else {
+            // Fall back to number for items beyond 35
+            format!("{}.", index + 1)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_shortcut_key() {
+        // Test first 9 items (1-9)
+        assert_eq!(get_shortcut_key(0), "1.");
+        assert_eq!(get_shortcut_key(1), "2.");
+        assert_eq!(get_shortcut_key(8), "9.");
+
+        // Test items 10-35 (a-z)
+        assert_eq!(get_shortcut_key(9), "a.");
+        assert_eq!(get_shortcut_key(10), "b.");
+        assert_eq!(get_shortcut_key(34), "y.");
+        assert_eq!(get_shortcut_key(35), "z.");
+
+        // Test items beyond 35
+        assert_eq!(get_shortcut_key(36), "37.");
+        assert_eq!(get_shortcut_key(37), "38.");
+    }
+}

--- a/frontends/rioterm/src/renderer/shell_selector.rs
+++ b/frontends/rioterm/src/renderer/shell_selector.rs
@@ -22,8 +22,8 @@ const FONT_SIZE: f32 = 14.0;
 /// Alpha value for the backdrop overlay
 const BACKDROP_ALPHA: f32 = 0.5;
 
-/// Alpha value for the backdrop overlay
-const BORDER_RADIUS: f32 = 8.0;
+/// Border radius for all corners (uniform)
+const BORDER_RADIUS: [f32; 4] = [8.0, 8.0, 8.0, 8.0];
 
 /// Draw the shell selector overlay
 ///
@@ -86,7 +86,12 @@ pub fn draw_shell_selector(
             panel_height + (border_width * 2.0),
         ],
         color: border_color,
-        border_radius: BORDER_RADIUS + border_width,
+        border_radius: [
+            BORDER_RADIUS[0] + border_width,
+            BORDER_RADIUS[1] + border_width,
+            BORDER_RADIUS[2] + border_width,
+            BORDER_RADIUS[3] + border_width,
+        ],
         ..Quad::default()
     }));
 
@@ -126,7 +131,7 @@ pub fn draw_shell_selector(
     // Draw each profile item
     let items_start_y = panel_y + PANEL_PADDING + ITEM_HEIGHT;
     for (index, shell, is_selected) in &profiles {
-        let item_y = items_start_y + (*index as f32 * ITEM_HEIGHT);
+        let item_y = items_start_y + (index as f32 * ITEM_HEIGHT);
 
         // Draw selection highlight background
         if *is_selected {
@@ -134,13 +139,13 @@ pub fn draw_shell_selector(
                 position: [panel_x + 4.0, item_y],
                 size: [PANEL_WIDTH - 8.0, ITEM_HEIGHT - 4.0],
                 color: colors.tabs_active,
-                border_radius: 4.0,
+                border_radius: [4.0, 4.0, 4.0, 4.0],
                 ..Quad::default()
             }));
         }
 
         // Create the display text with shortcut key
-        let shortcut = get_shortcut_key(*index);
+        let shortcut = get_shortcut_key(index);
         let display_name = ShellSelector::display_name(shell);
 
         // Create rich text for this item
@@ -170,18 +175,13 @@ pub fn draw_shell_selector(
                 color: shortcut_color,
                 ..FragmentStyle::default()
             },
-        );
-
-        // Draw display name with regular color
-        item_line.add_text(
+        ).add_text(
             display_name,
             FragmentStyle {
                 color: text_color,
                 ..FragmentStyle::default()
             },
-        );
-
-        item_line.build();
+        ).build();
 
         objects.push(Object::RichText(RichText {
             id: item_rich_text,
@@ -191,9 +191,8 @@ pub fn draw_shell_selector(
     }
 
     // Draw help text at the bottom
-    let help_text = "Enter to select, Esc to cancel";
     let help_rich_text = sugarloaf.create_temp_rich_text();
-    sugarloaf.set_rich_text_font_size(&help_rich_text, FONT_SIZE - 2.0);
+    sugarloaf.set_rich_text_font_size(&help_rich_text, 12.0);
 
     let content = sugarloaf.content();
     let help_line = content.sel(help_rich_text);
@@ -201,23 +200,22 @@ pub fn draw_shell_selector(
         .clear()
         .new_line()
         .add_text(
-            help_text,
+            "Enter to select, Esc to cancel",
             FragmentStyle {
                 color: [
                     colors.foreground[0],
                     colors.foreground[1],
                     colors.foreground[2],
-                    colors.foreground[3] - 0.4, // Make it slightly dimmer
+                    0.6, // Slightly dimmed
                 ],
                 ..FragmentStyle::default()
             },
         )
         .build();
 
-    let help_y = panel_y + panel_height - PANEL_PADDING - 8.0;
     objects.push(Object::RichText(RichText {
         id: help_rich_text,
-        position: [panel_x + PANEL_PADDING, help_y],
+        position: [panel_x + PANEL_PADDING, panel_y + panel_height - PANEL_PADDING - 8.0],
         lines: None,
     }));
 }

--- a/frontends/rioterm/src/renderer/shell_selector.rs
+++ b/frontends/rioterm/src/renderer/shell_selector.rs
@@ -259,13 +259,15 @@ mod tests {
         assert_eq!(get_shortcut_key(1), "2.");
         assert_eq!(get_shortcut_key(8), "9.");
 
-        // Test items 10-35 (a-z)
-        assert_eq!(get_shortcut_key(9), "a.");
-        assert_eq!(get_shortcut_key(10), "b.");
-        assert_eq!(get_shortcut_key(34), "y.");
-        assert_eq!(get_shortcut_key(35), "z.");
+        // Test items 9-34 (a-z, 26 letters total)
+        // letter_index = index - 9
+        assert_eq!(get_shortcut_key(9), "a."); // letter_index 0
+        assert_eq!(get_shortcut_key(10), "b."); // letter_index 1
+        assert_eq!(get_shortcut_key(33), "y."); // letter_index 24
+        assert_eq!(get_shortcut_key(34), "z."); // letter_index 25
 
-        // Test items beyond 35
+        // Test items beyond 35 (fallback to numbers)
+        assert_eq!(get_shortcut_key(35), "36."); // letter_index 26 >= 26, fallback
         assert_eq!(get_shortcut_key(36), "37.");
         assert_eq!(get_shortcut_key(37), "38.");
     }

--- a/frontends/rioterm/src/renderer/shell_selector.rs
+++ b/frontends/rioterm/src/renderer/shell_selector.rs
@@ -131,7 +131,7 @@ pub fn draw_shell_selector(
     // Draw each profile item
     let items_start_y = panel_y + PANEL_PADDING + ITEM_HEIGHT;
     for (index, shell, is_selected) in &profiles {
-        let item_y = items_start_y + (index as f32 * ITEM_HEIGHT);
+        let item_y = items_start_y + (*index as f32 * ITEM_HEIGHT);
 
         // Draw selection highlight background
         if *is_selected {
@@ -145,7 +145,7 @@ pub fn draw_shell_selector(
         }
 
         // Create the display text with shortcut key
-        let shortcut = get_shortcut_key(index);
+        let shortcut = get_shortcut_key(*index);
         let display_name = ShellSelector::display_name(shell);
 
         // Create rich text for this item

--- a/frontends/rioterm/src/renderer/shell_selector.rs
+++ b/frontends/rioterm/src/renderer/shell_selector.rs
@@ -169,19 +169,24 @@ pub fn draw_shell_selector(
         };
 
         // Draw shortcut key with accent color
-        item_line.clear().new_line().add_text(
-            &format!("{} ", shortcut),
-            FragmentStyle {
-                color: shortcut_color,
-                ..FragmentStyle::default()
-            },
-        ).add_text(
-            display_name,
-            FragmentStyle {
-                color: text_color,
-                ..FragmentStyle::default()
-            },
-        ).build();
+        item_line
+            .clear()
+            .new_line()
+            .add_text(
+                &format!("{} ", shortcut),
+                FragmentStyle {
+                    color: shortcut_color,
+                    ..FragmentStyle::default()
+                },
+            )
+            .add_text(
+                display_name,
+                FragmentStyle {
+                    color: text_color,
+                    ..FragmentStyle::default()
+                },
+            )
+            .build();
 
         objects.push(Object::RichText(RichText {
             id: item_rich_text,
@@ -215,7 +220,10 @@ pub fn draw_shell_selector(
 
     objects.push(Object::RichText(RichText {
         id: help_rich_text,
-        position: [panel_x + PANEL_PADDING, panel_y + panel_height - PANEL_PADDING - 8.0],
+        position: [
+            panel_x + PANEL_PADDING,
+            panel_y + panel_height - PANEL_PADDING - 8.0,
+        ],
         lines: None,
     }));
 }

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -360,6 +360,7 @@ impl Router<'_> {
         );
         let new_config = RioConfig {
             shell: rio_backend::config::Shell {
+                name: None,
                 program: editor.program,
                 args,
             },
@@ -394,6 +395,7 @@ impl Router<'_> {
         );
         let new_config = RioConfig {
             shell: rio_backend::config::Shell {
+                name: None,
                 program: editor.program,
                 args,
             },

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -196,7 +196,6 @@ impl Screen<'_> {
         let context_manager_config = context::ContextManagerConfig {
             cwd: config.navigation.current_working_directory,
             shell: shell.clone(),
-            shells: config.shells.clone(),
             working_dir,
             spawn_performer: true,
             #[cfg(not(target_os = "windows"))]
@@ -424,6 +423,12 @@ impl Screen<'_> {
 
         // Update keyboard config in context manager
         self.context_manager.config.keyboard = config.keyboard;
+
+        // Update shell selector with potentially new shells list
+        self.shell_selector = crate::shell_selector::ShellSelector::new(
+            config.shell.clone(),
+            config.shells.clone(),
+        );
 
         if cfg!(target_os = "macos") {
             self.sugarloaf.set_background_color(None);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -677,7 +677,8 @@ impl Screen<'_> {
                     let ch_str = ch.as_str();
                     if let Ok(index) = ch_str.parse::<usize>() {
                         if index > 0 && self.shell_selector.select_by_index(index - 1) {
-                            if let Some(shell) = self.shell_selector.selected_profile().cloned()
+                            if let Some(shell) =
+                                self.shell_selector.selected_profile().cloned()
                             {
                                 self.shell_selector.stop();
                                 self.create_tab_with_shell(Some(shell));

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -88,6 +88,7 @@ pub struct Screen<'screen> {
     pub clipboard: Rc<RefCell<Clipboard>>,
     last_ime_cursor_pos: Option<(f32, f32)>,
     hints_config: Vec<std::rc::Rc<rio_backend::config::hints::Hint>>,
+    pub shell_selector: crate::shell_selector::ShellSelector,
 }
 
 pub struct ScreenWindowProperties {
@@ -194,7 +195,8 @@ impl Screen<'_> {
 
         let context_manager_config = context::ContextManagerConfig {
             cwd: config.navigation.current_working_directory,
-            shell,
+            shell: shell.clone(),
+            shells: config.shells.clone(),
             working_dir,
             spawn_performer: true,
             #[cfg(not(target_os = "windows"))]
@@ -273,6 +275,10 @@ impl Screen<'_> {
             bindings,
             clipboard,
             last_ime_cursor_pos: None,
+            shell_selector: crate::shell_selector::ShellSelector::new(
+                config.shell.clone(),
+                config.shells.clone(),
+            ),
         })
     }
 
@@ -637,6 +643,67 @@ impl Screen<'_> {
             return;
         }
 
+        // Handle shell selector navigation when active
+        if self.shell_selector.is_active() {
+            match key.logical_key {
+                // Escape: close selector
+                Key::Named(NamedKey::Escape) => {
+                    self.shell_selector.stop();
+                    self.render();
+                    return;
+                }
+                // Enter: select current profile and create tab
+                Key::Named(NamedKey::Enter) => {
+                    if let Some(shell) = self.shell_selector.selected_profile().cloned() {
+                        self.shell_selector.stop();
+                        self.create_tab_with_shell(Some(shell));
+                    }
+                    return;
+                }
+                // j or Down arrow: select next profile
+                Key::Named(NamedKey::ArrowDown) => {
+                    self.shell_selector.select_next();
+                    self.render();
+                    return;
+                }
+                // k or Up arrow: select previous profile
+                Key::Named(NamedKey::ArrowUp) => {
+                    self.shell_selector.select_previous();
+                    self.render();
+                    return;
+                }
+                // Number keys 1-9: select profile by index
+                Key::Character(ref ch) => {
+                    let ch_str = ch.as_str();
+                    if let Ok(index) = ch_str.parse::<usize>() {
+                        if index > 0 && self.shell_selector.select_by_index(index - 1) {
+                            if let Some(shell) = self.shell_selector.selected_profile().cloned()
+                            {
+                                self.shell_selector.stop();
+                                self.create_tab_with_shell(Some(shell));
+                            }
+                        }
+                        return;
+                    }
+                    // Handle j/k for vim-style navigation
+                    match ch_str {
+                        "j" => {
+                            self.shell_selector.select_next();
+                            self.render();
+                            return;
+                        }
+                        "k" => {
+                            self.shell_selector.select_previous();
+                            self.render();
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+
         let ignore_chars = self.process_key_bindings(key, &mode, mods);
         if ignore_chars {
             return;
@@ -982,6 +1049,14 @@ impl Screen<'_> {
                     Act::TabCreateNew => {
                         self.create_tab();
                     }
+                    Act::ShellProfileSelector => {
+                        if self.shell_selector.is_active() {
+                            self.shell_selector.stop();
+                        } else {
+                            self.shell_selector.start();
+                        }
+                        self.render();
+                    }
                     Act::TabCloseCurrent => {
                         self.close_tab();
                     }
@@ -1223,6 +1298,10 @@ impl Screen<'_> {
     }
 
     pub fn create_tab(&mut self) {
+        self.create_tab_with_shell(None);
+    }
+
+    pub fn create_tab_with_shell(&mut self, shell: Option<rio_backend::config::Shell>) {
         let redirect = true;
 
         // We resize the current tab ahead to prepare the
@@ -1231,7 +1310,8 @@ impl Screen<'_> {
         self.resize_top_or_bottom_line(num_tabs + 1);
 
         let rich_text_id = self.sugarloaf.create_rich_text();
-        self.context_manager.add_context(redirect, rich_text_id);
+        self.context_manager
+            .add_context_with_shell(redirect, rich_text_id, shell);
 
         self.cancel_search();
         self.render();
@@ -2577,12 +2657,21 @@ impl Screen<'_> {
             }
         }
 
+        // Determine if shell selector should be rendered
+        let shell_selector = if self.shell_selector.is_active() {
+            Some(&self.shell_selector)
+        } else {
+            None
+        };
+
         // let renderer_run_start = std::time::Instant::now();
-        let window_update = self.renderer.run(
+        let window_update = self.renderer.run_with_shell_selector(
             &mut self.sugarloaf,
             &mut self.context_manager,
             &self.search_state.focused_match,
+            shell_selector,
         );
+
         // In case the configuration of blinking cursor is enabled
         // and the terminal also have instructions of blinking enabled
         // TODO: enable blinking for selection after adding debounce (https://github.com/raphamorim/rio/issues/437)

--- a/frontends/rioterm/src/shell_selector.rs
+++ b/frontends/rioterm/src/shell_selector.rs
@@ -1,0 +1,91 @@
+use rio_backend::config::Shell;
+
+/// State for shell profile selection mode
+pub struct ShellSelector {
+    /// Whether the selector is active
+    active: bool,
+    /// Available shell profiles (default shell + additional shells)
+    profiles: Vec<Shell>,
+    /// Currently selected index
+    selected_index: usize,
+}
+
+impl ShellSelector {
+    /// Create a new shell selector with the default shell and additional profiles
+    pub fn new(default_shell: Shell, additional_shells: Vec<Shell>) -> Self {
+        let mut profiles = vec![default_shell];
+        profiles.extend(additional_shells);
+
+        Self {
+            active: false,
+            profiles,
+            selected_index: 0,
+        }
+    }
+
+    /// Check if the selector is currently active
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Start the selector (show overlay)
+    pub fn start(&mut self) {
+        self.active = true;
+        self.selected_index = 0;
+    }
+
+    /// Stop the selector (hide overlay)
+    pub fn stop(&mut self) {
+        self.active = false;
+    }
+
+    /// Navigate to the next profile in the list
+    pub fn select_next(&mut self) {
+        if self.profiles.is_empty() {
+            return;
+        }
+        self.selected_index = (self.selected_index + 1) % self.profiles.len();
+    }
+
+    /// Navigate to the previous profile in the list
+    pub fn select_previous(&mut self) {
+        if self.profiles.is_empty() {
+            return;
+        }
+        if self.selected_index > 0 {
+            self.selected_index -= 1;
+        } else {
+            self.selected_index = self.profiles.len() - 1;
+        }
+    }
+
+    /// Select a profile by index directly
+    pub fn select_by_index(&mut self, index: usize) -> bool {
+        if index < self.profiles.len() {
+            self.selected_index = index;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get the currently selected shell profile
+    pub fn selected_profile(&self) -> Option<&Shell> {
+        self.profiles.get(self.selected_index)
+    }
+
+    /// Get all profiles with their display info
+    /// Returns (index, shell_ref, is_selected)
+    pub fn profiles_for_display(&self) -> Vec<(usize, &Shell, bool)> {
+        self.profiles
+            .iter()
+            .enumerate()
+            .map(|(i, shell)| (i, shell, i == self.selected_index))
+            .collect()
+    }
+
+    /// Get the display name for a shell (uses name field if present, otherwise program path)
+    pub fn display_name(shell: &Shell) -> &str {
+        shell.name.as_deref().unwrap_or(&shell.program)
+    }
+}

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -35,6 +35,7 @@ pub fn default_shell() -> crate::config::Shell {
     #[cfg(not(target_os = "windows"))]
     {
         crate::config::Shell {
+            name: None,
             program: String::from(""),
             args: vec![String::from("--login")],
         }
@@ -43,6 +44,7 @@ pub fn default_shell() -> crate::config::Shell {
     #[cfg(target_os = "windows")]
     {
         crate::config::Shell {
+            name: None,
             program: String::from("powershell"),
             args: vec![],
         }
@@ -97,6 +99,7 @@ pub fn default_editor() -> Shell {
     #[cfg(not(target_os = "windows"))]
     {
         Shell {
+            name: None,
             program: String::from("vi"),
             args: vec![],
         }
@@ -105,6 +108,7 @@ pub fn default_editor() -> Shell {
     #[cfg(target_os = "windows")]
     {
         Shell {
+            name: None,
             program: String::from("notepad"),
             args: vec![],
         }

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -40,6 +40,8 @@ pub enum ConfigError {
 
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Shell {
+    #[serde(default)]
+    pub name: Option<String>,
     pub program: String,
     #[serde(default)]
     pub args: Vec<String>,
@@ -90,6 +92,8 @@ pub struct Config {
     pub window: Window,
     #[serde(default = "default_shell")]
     pub shell: Shell,
+    #[serde(default, rename = "shells")]
+    pub shells: Vec<Shell>,
     #[serde(default = "Platform::default")]
     pub platform: Platform,
     #[serde(default = "default_use_fork", rename = "use-fork")]

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -616,6 +616,7 @@ impl Default for Config {
             padding_y: default_padding_y(),
             renderer: Renderer::default(),
             shell: default_shell(),
+            shells: vec![],
             platform: Platform::default(),
             theme: String::default(),
             use_fork: default_use_fork(),


### PR DESCRIPTION
Closes #622

## Summary

This PR adds support for multiple shell profiles in Rio terminal, allowing users to:
1. Define a default shell via `[shell]` (existing behavior)
2. Define additional shell profiles via `[[shells]]` array
3. Use `Ctrl+Shift+T` to create tabs with the default profile (unchanged)
4. Use `Ctrl+Shift+Y` to open a profile selector to choose which shell to use

## Configuration Example

```toml
# Default shell
[shell]
program = "pwsh"
args = []

# Additional shell profiles
[[shells]]
name = "WSL"
program = "C:\\Windows\\System32\\wsl.exe"
args = []

[[shells]]
name = "CMD"
program = "C:\\Windows\\System32\\cmd.exe"
args = []
```

## Profile Selector

When you press `Ctrl+Shift+Y` (or `Cmd+Y` on macOS), a selector overlay appears:
- Use `j`/`k` or arrow keys to navigate
- Press `1-9` to directly select a profile
- Press `Enter` to confirm selection
- Press `Escape` to cancel

## Changes

- Extended `Shell` struct with optional `name` field
- Added `shells: Vec<Shell>` field to `Config`
- Added `ShellProfileSelector` action with keybinding
- Created `ShellSelector` state module for managing selector UI
- Added `create_tab_with_shell()` method for creating tabs with specific shells
- Created shell selector UI renderer
- Integrated keyboard navigation and rendering
- Updated documentation with examples

## Testing

1. Add shell profiles to your config
2. Press `Ctrl+Shift+Y` to open selector
3. Navigate and select a profile
4. Verify a new tab opens with the selected shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)