### PR TITLE
docs: fix links

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -929,7 +929,7 @@ mode = "NativeTab"
 
 Note: `BottomTab` does not support click mode yet.
 
-<img alt="Demo BottomTab" src="/rio/assets/features/demo-bottom-tab.png" width="58%"/>
+<img alt="Demo BottomTab" src="/assets/features/demo-bottom-tab.png" width="58%"/>
 
 Usage:
 
@@ -945,7 +945,7 @@ mode = "BottomTab"
 
 Note: `TopTab` does not support click mode yet.
 
-<img alt="Demo TopTab" src="/rio/assets/features/demo-top-tab.png" width="70%"/>
+<img alt="Demo TopTab" src="/assets/features/demo-top-tab.png" width="70%"/>
 
 Usage:
 
@@ -1014,9 +1014,9 @@ color-automation = [
 The example below sets `#FFFF00` as color background whenever `nvim` is running.
 
 <p>
-<img alt="example navigation with program color automation using BottomTab" src="/rio/assets/features/demo-colorized-navigation.png" width="48%"/>
+<img alt="example navigation with program color automation using BottomTab" src="/assets/features/demo-colorized-navigation.png" width="48%"/>
 
-<img alt="example navigation with program color automation using Bookmark" src="/rio/assets/features/demo-colorized-navigation-2.png" width="48%"/>
+<img alt="example navigation with program color automation using Bookmark" src="/assets/features/demo-colorized-navigation-2.png" width="48%"/>
 </p>
 
 The configuration would be like:
@@ -1044,9 +1044,9 @@ color-automation = [
 ```
 
 <p>
-<img alt="example navigation with path color automation using TopTab" src="/rio/assets/features/demo-colorized-navigation-path-1.png" width="48%"/>
+<img alt="example navigation with path color automation using TopTab" src="/assets/features/demo-colorized-navigation-path-1.png" width="48%"/>
 
-<img alt="example navigation with path color automation using Bookmark" src="/rio/assets/features/demo-colorized-navigation-path-2.png" width="48%"/>
+<img alt="example navigation with path color automation using Bookmark" src="/assets/features/demo-colorized-navigation-path-2.png" width="48%"/>
 </p>
 
 #### Program and path
@@ -1067,9 +1067,9 @@ color-automation = [
 ```
 
 <p>
-<img alt="example navigation with program and path color automation using TopTab" src="/rio/assets/features/demo-colorized-navigation-program-and-path-1.png" width="48%"/>
+<img alt="example navigation with program and path color automation using TopTab" src="/assets/features/demo-colorized-navigation-program-and-path-1.png" width="48%"/>
 
-<img alt="example navigation with program and path color automation using Bookmark" src="/rio/assets/features/demo-colorized-navigation-program-and-path-2.png" width="48%"/>
+<img alt="example navigation with program and path color automation using Bookmark" src="/assets/features/demo-colorized-navigation-program-and-path-2.png" width="48%"/>
 </p>
 
 ## navigation.hide-if-single

--- a/docs/docs/features/color-automation-for-navigation.md
+++ b/docs/docs/features/color-automation-for-navigation.md
@@ -14,9 +14,9 @@ Note: `path` is only available for MacOS, BSD and Linux.
 The example below sets `#FFFF00` as color background whenever `nvim` is running.
 
 <p>
-<img alt="example navigation with program color automation using TopTab" src="/rio/assets/features/demo-colorized-navigation.png" width="48%"/>
+<img alt="example navigation with program color automation using TopTab" src="/assets/features/demo-colorized-navigation.png" width="48%"/>
 
-<img alt="example navigation with program color automation using CollapsedTab" src="/rio/assets/features/demo-colorized-navigation-2.png" width="48%"/>
+<img alt="example navigation with program color automation using CollapsedTab" src="/assets/features/demo-colorized-navigation-2.png" width="48%"/>
 </p>
 
 The configuration would be like:
@@ -44,9 +44,9 @@ color-automation = [
 ```
 
 <p>
-<img alt="example navigation with path color automation using TopTab" src="/rio/assets/features/demo-colorized-navigation-path-1.png" width="48%"/>
+<img alt="example navigation with path color automation using TopTab" src="/assets/features/demo-colorized-navigation-path-1.png" width="48%"/>
 
-<img alt="example navigation with path color automation using CollapsedTab" src="/rio/assets/features/demo-colorized-navigation-path-2.png" width="48%"/>
+<img alt="example navigation with path color automation using CollapsedTab" src="/assets/features/demo-colorized-navigation-path-2.png" width="48%"/>
 </p>
 
 #### Program and path
@@ -67,7 +67,7 @@ color-automation = [
 ```
 
 <p>
-<img alt="example navigation with program and path color automation using TopTab" src="/rio/assets/features/demo-colorized-navigation-program-and-path-1.png" width="48%"/>
+<img alt="example navigation with program and path color automation using TopTab" src="/assets/features/demo-colorized-navigation-program-and-path-1.png" width="48%"/>
 
-<img alt="example navigation with program and path color automation using CollapsedTab" src="/rio/assets/features/demo-colorized-navigation-program-and-path-2.png" width="48%"/>
+<img alt="example navigation with program and path color automation using CollapsedTab" src="/assets/features/demo-colorized-navigation-program-and-path-2.png" width="48%"/>
 </p>

--- a/docs/docs/features/navigation.md
+++ b/docs/docs/features/navigation.md
@@ -6,13 +6,13 @@ language: 'en'
 Rio support different types of navigation modes:
 
 <p>
-<img alt="Demo TopTab" src="/rio/assets/features/demo-top-tab.png" width="48%"/>
+<img alt="Demo TopTab" src="/assets/features/demo-top-tab.png" width="48%"/>
 <img alt="Demo native tabs" src="/rio/assets/posts/0.0.17/demo-native-tabs.png" width="48%"/>
 </p>
 
 <p>
 <img alt="Demo Bookmark" src="https://miro.medium.com/v2/resize:fit:1400/format:webp/1*gMLWcZkniSHUT6Cb7L06Gg.png" width="48%" />
-<img alt="Demo BottomTab" src="/rio/assets/features/demo-bottom-tab.png" width="48%"/>
+<img alt="Demo BottomTab" src="/assets/features/demo-bottom-tab.png" width="48%"/>
 </p>
 
 See more about it [here](/docs/config#navigation).


### PR DESCRIPTION
Noticed several broken image links across the documentation. This PR updates the paths/URLs to restore the missing visuals.

Example before/after screenshots attached below.
Thank you!

<img width="1220" height="472" alt="Screenshot 2026-03-02 at 02 04 11" src="https://github.com/user-attachments/assets/72d5854b-ed68-43c4-85c0-cdb6bf841fea" />