### PR TITLE
add support to manage window size with columns and rows

### DIFF
--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -1568,6 +1568,8 @@ height = 400
 Define the initial number of columns. When set, this takes precedence over `window.width`.
 
 - Default: not set
+- Works independently from `window.rows` (you can set only columns).
+- Invalid value `0` is ignored and Rio falls back to `window.width`.
 
 Example:
 
@@ -1581,6 +1583,8 @@ columns = 80
 Define the initial number of rows. When set, this takes precedence over `window.height`.
 
 - Default: not set
+- Works independently from `window.columns` (you can set only rows).
+- Invalid value `0` is ignored and Rio falls back to `window.height`.
 
 Example:
 

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -1563,6 +1563,32 @@ Example:
 height = 400
 ```
 
+## window.columns
+
+Define the initial number of columns. When set, this takes precedence over `window.width`.
+
+- Default: not set
+
+Example:
+
+```toml
+[window]
+columns = 80
+```
+
+## window.rows
+
+Define the initial number of rows. When set, this takes precedence over `window.height`.
+
+- Default: not set
+
+Example:
+
+```toml
+[window]
+rows = 24
+```
+
 ## window.mode
 
 Define how the window will be created

--- a/docs/src/pages/changelog.mdx
+++ b/docs/src/pages/changelog.mdx
@@ -7,7 +7,7 @@ language: 'en'
 
 ## 0.3.2 (unreleased)
 
-- TBD.
+- Add support for `window.columns` and `window.rows` for window sizing. Ignores invalid `0` values with fallback to `window.width`/`window.height`, and guarantees a minimum startup size of `300x200` logical pixels.
 
 ## 0.3.1
 

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -867,7 +867,7 @@ fn startup_window_size_applies_only_rows_override() {
 
     assert_eq!(
         compute_startup_window_physical_size(&config, dim),
-        Some((1000, 960))
+        Some((1000, 480))
     );
 }
 

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -1,7 +1,10 @@
 pub mod routes;
 mod window;
 use crate::event::EventProxy;
-use crate::router::window::{configure_window, create_window_builder};
+use crate::router::window::{
+    configure_window, create_window_builder, DEFAULT_MINIMUM_WINDOW_HEIGHT,
+    DEFAULT_MINIMUM_WINDOW_WIDTH,
+};
 use crate::screen::{Screen, ScreenWindowProperties};
 use assistant::Assistant;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
@@ -665,61 +668,9 @@ impl<'a> RouteWindow<'a> {
         )
         .expect("Screen not created");
 
-        if config.window.columns.is_some() || config.window.rows.is_some() {
-            let dim = screen.ctx().current().dimension;
-            let scale = dim.dimension.scale;
-
-            // On Retina (HiDPI) displays, macOS snaps window sizes to multiples of
-            // the scale factor (e.g. 2 on 2x displays). Using PhysicalSize and
-            // rounding up to the nearest multiple of scale ensures we never end up
-            // one physical pixel short, which would cause the renderer to truncate
-            // one column or row.
-            let scale_u32 = scale.round() as u32;
-
-            let mut physical_width = (config.window.width as f32 * scale).round() as u32;
-            let mut physical_height =
-                (config.window.height as f32 * scale).round() as u32;
-
-            // Taffy reserves `config.panel` padding and margin inside the window margin.
-            // Startup sizing must include that frame or the first layout reports fewer
-            // cols/rows than requested.
-            let panel_horizontal = scaled_panel_edge(
-                config.panel.padding.left,
-                config.panel.padding.right,
-                config.panel.margin.left,
-                config.panel.margin.right,
-                scale,
-            );
-            let panel_vertical = scaled_panel_edge(
-                config.panel.padding.top,
-                config.panel.padding.bottom,
-                config.panel.margin.top,
-                config.panel.margin.bottom,
-                scale,
-            );
-
-            if let Some(columns) = config.window.columns {
-                let cell_width = dim.dimension.width;
-                let margin_physical = (dim.margin.left + dim.margin.right) * scale;
-                let raw = (columns as f32 * cell_width).ceil() as u32
-                    + margin_physical as u32
-                    + panel_horizontal as u32;
-
-                // Round up to nearest multiple of scale factor so macOS Retina
-                // snapping never drops us below the target column count.
-                physical_width = raw.next_multiple_of(scale_u32);
-            }
-
-            if let Some(rows) = config.window.rows {
-                let cell_height = dim.dimension.height;
-                let margin_physical = (dim.margin.top + dim.margin.bottom) * scale;
-                let raw = (rows as f32 * cell_height).ceil() as u32
-                    + margin_physical as u32
-                    + panel_vertical as u32;
-
-                physical_height = raw.next_multiple_of(scale_u32);
-            }
-
+        if let Some((physical_width, physical_height)) =
+            compute_startup_window_physical_size(config, screen.ctx().current().dimension)
+        {
             let _ = winit_window.request_inner_size(PhysicalSize {
                 width: physical_width,
                 height: physical_height,
@@ -774,4 +725,277 @@ fn scaled_panel_edge(
     scale: f32,
 ) -> f32 {
     (padding_start + padding_end + margin_start + margin_end) * scale
+}
+
+fn compute_startup_window_physical_size(
+    config: &RioConfig,
+    dim: crate::layout::ContextDimension,
+) -> Option<(u32, u32)> {
+    if config.window.columns.is_none() && config.window.rows.is_none() {
+        return None;
+    }
+
+    let scale = dim.dimension.scale;
+
+    // On Retina (HiDPI) displays, macOS snaps window sizes to multiples of
+    // the scale factor (e.g. 2 on 2x displays). Using PhysicalSize and
+    // rounding up to the nearest multiple of scale ensures we never end up
+    // one physical pixel short, which would cause the renderer to truncate
+    // one column or row.
+    let scale_u32 = scale.round().max(1.0) as u32;
+
+    let mut physical_width = (config.window.width as f32 * scale).round() as u32;
+    let mut physical_height = (config.window.height as f32 * scale).round() as u32;
+
+    // Taffy reserves `config.panel` padding and margin inside the window margin.
+    // Startup sizing must include that frame or the first layout reports fewer
+    // cols/rows than requested.
+    let panel_horizontal = scaled_panel_edge(
+        config.panel.padding.left,
+        config.panel.padding.right,
+        config.panel.margin.left,
+        config.panel.margin.right,
+        scale,
+    );
+    let panel_vertical = scaled_panel_edge(
+        config.panel.padding.top,
+        config.panel.padding.bottom,
+        config.panel.margin.top,
+        config.panel.margin.bottom,
+        scale,
+    );
+
+    if let Some(columns) = config.window.columns.filter(|columns| *columns > 0) {
+        let margin_horizontal = (dim.margin.left + dim.margin.right) * scale;
+        let raw = (columns as f32 * dim.dimension.width).ceil() as u32
+            + margin_horizontal as u32
+            + panel_horizontal as u32;
+        // Round up to nearest multiple of scale factor so macOS Retina
+        // snapping never drops us below the target column count.
+        physical_width = raw.next_multiple_of(scale_u32);
+    }
+
+    if let Some(rows) = config.window.rows.filter(|rows| *rows > 0) {
+        let margin_vertical = (dim.margin.top + dim.margin.bottom) * scale;
+        let raw = (rows as f32 * dim.dimension.height).ceil() as u32
+            + margin_vertical as u32
+            + panel_vertical as u32;
+        physical_height = raw.next_multiple_of(scale_u32);
+    }
+
+    // Keep startup sizing aligned with the global minimum window constraints.
+    // These constants are defined in logical pixels, so we convert them to
+    // physical pixels using the current scale before clamping.
+    let minimum_physical_width =
+        (DEFAULT_MINIMUM_WINDOW_WIDTH as f32 * scale).ceil() as u32;
+    let minimum_physical_height =
+        (DEFAULT_MINIMUM_WINDOW_HEIGHT as f32 * scale).ceil() as u32;
+
+    physical_width = physical_width.max(minimum_physical_width);
+    physical_height = physical_height.max(minimum_physical_height);
+
+    Some((physical_width, physical_height))
+}
+
+#[test]
+fn startup_window_size_returns_none_without_overrides() {
+    use rio_backend::config::layout::Margin;
+    use rio_backend::sugarloaf::layout::TextDimensions;
+
+    let mut config = RioConfig::default();
+    config.window.columns = None;
+    config.window.rows = None;
+
+    let mut dim = crate::layout::ContextDimension::default();
+    dim.dimension = TextDimensions {
+        width: 10.0,
+        height: 20.0,
+        scale: 2.0,
+    };
+    dim.margin = Margin::all(0.0);
+
+    assert_eq!(compute_startup_window_physical_size(&config, dim), None);
+}
+
+#[test]
+fn startup_window_size_applies_only_columns_override() {
+    use rio_backend::config::layout::Margin;
+    use rio_backend::sugarloaf::layout::TextDimensions;
+
+    let mut config = RioConfig::default();
+    config.window.width = 500;
+    config.window.height = 300;
+    config.window.columns = Some(80);
+    config.window.rows = None;
+    config.panel.padding = Margin::all(0.0);
+    config.panel.margin = Margin::all(0.0);
+
+    let mut dim = crate::layout::ContextDimension::default();
+    dim.dimension = TextDimensions {
+        width: 10.0,
+        height: 20.0,
+        scale: 2.0,
+    };
+    dim.margin = Margin::all(0.0);
+
+    assert_eq!(
+        compute_startup_window_physical_size(&config, dim),
+        Some((800, 600))
+    );
+}
+
+#[test]
+fn startup_window_size_applies_only_rows_override() {
+    use rio_backend::config::layout::Margin;
+    use rio_backend::sugarloaf::layout::TextDimensions;
+
+    let mut config = RioConfig::default();
+    config.window.width = 500;
+    config.window.height = 300;
+    config.window.columns = None;
+    config.window.rows = Some(24);
+    config.panel.padding = Margin::all(0.0);
+    config.panel.margin = Margin::all(0.0);
+
+    let mut dim = crate::layout::ContextDimension::default();
+    dim.dimension = TextDimensions {
+        width: 10.0,
+        height: 20.0,
+        scale: 2.0,
+    };
+    dim.margin = Margin::all(0.0);
+
+    assert_eq!(
+        compute_startup_window_physical_size(&config, dim),
+        Some((1000, 960))
+    );
+}
+
+#[test]
+fn startup_window_size_applies_both_overrides() {
+    use rio_backend::config::layout::Margin;
+    use rio_backend::sugarloaf::layout::TextDimensions;
+
+    let mut config = RioConfig::default();
+    config.window.columns = Some(100);
+    config.window.rows = Some(40);
+    config.panel.padding = Margin::all(0.0);
+    config.panel.margin = Margin::all(0.0);
+
+    let mut dim = crate::layout::ContextDimension::default();
+    dim.dimension = TextDimensions {
+        width: 10.0,
+        height: 20.0,
+        scale: 1.0,
+    };
+    dim.margin = Margin::all(0.0);
+
+    assert_eq!(
+        compute_startup_window_physical_size(&config, dim),
+        Some((1000, 800))
+    );
+}
+
+#[test]
+fn startup_window_size_ignores_zero_overrides_and_falls_back() {
+    use rio_backend::config::layout::Margin;
+    use rio_backend::sugarloaf::layout::TextDimensions;
+
+    let mut config = RioConfig::default();
+    config.window.width = 500;
+    config.window.height = 300;
+    config.window.columns = Some(0);
+    config.window.rows = Some(0);
+    config.panel.padding = Margin::all(0.0);
+    config.panel.margin = Margin::all(0.0);
+
+    let mut dim = crate::layout::ContextDimension::default();
+    dim.dimension = TextDimensions {
+        width: 10.0,
+        height: 20.0,
+        scale: 2.0,
+    };
+    dim.margin = Margin::all(0.0);
+
+    assert_eq!(
+        compute_startup_window_physical_size(&config, dim),
+        Some((1000, 600))
+    );
+}
+
+#[test]
+fn startup_window_size_rounds_up_on_hidpi() {
+    use rio_backend::config::layout::Margin;
+    use rio_backend::sugarloaf::layout::TextDimensions;
+
+    let mut config = RioConfig::default();
+    config.window.columns = Some(80);
+    config.window.rows = Some(24);
+    config.panel.padding = Margin::all(0.0);
+    config.panel.margin = Margin::all(0.0);
+
+    let mut dim = crate::layout::ContextDimension::default();
+    dim.dimension = TextDimensions {
+        width: 16.41,
+        height: 33.0,
+        scale: 2.0,
+    };
+    dim.margin = Margin::all(0.0);
+
+    assert_eq!(
+        compute_startup_window_physical_size(&config, dim),
+        Some((1314, 792))
+    );
+}
+
+#[test]
+fn startup_window_size_includes_terminal_and_panel_margins() {
+    use rio_backend::config::layout::Margin;
+    use rio_backend::sugarloaf::layout::TextDimensions;
+
+    let mut config = RioConfig::default();
+    config.window.columns = Some(10);
+    config.window.rows = Some(5);
+    config.panel.padding = Margin::new(3.0, 2.0, 4.0, 1.0);
+    config.panel.margin = Margin::new(7.0, 6.0, 8.0, 5.0);
+
+    let mut dim = crate::layout::ContextDimension::default();
+    dim.dimension = TextDimensions {
+        width: 10.0,
+        height: 20.0,
+        scale: 1.0,
+    };
+    dim.margin = Margin::new(4.0, 3.0, 5.0, 2.0);
+
+    assert_eq!(
+        compute_startup_window_physical_size(&config, dim),
+        Some((300, 200))
+    );
+}
+
+#[test]
+fn startup_window_size_never_goes_under_minimum() {
+    use rio_backend::config::layout::Margin;
+    use rio_backend::sugarloaf::layout::TextDimensions;
+
+    let mut config = RioConfig::default();
+    config.window.width = 50;
+    config.window.height = 50;
+    config.window.columns = Some(1);
+    config.window.rows = Some(1);
+    config.panel.padding = Margin::all(0.0);
+    config.panel.margin = Margin::all(0.0);
+
+    let mut dim = crate::layout::ContextDimension::default();
+    dim.dimension = TextDimensions {
+        width: 1.0,
+        height: 1.0,
+        scale: 1.0,
+    };
+    dim.margin = Margin::all(0.0);
+
+    assert_eq!(
+        compute_startup_window_physical_size(&config, dim),
+        Some((300, 200))
+    );
 }

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -9,6 +9,7 @@ use rio_backend::clipboard::Clipboard;
 use rio_backend::config::Config as RioConfig;
 use rio_backend::error::{RioError, RioErrorLevel, RioErrorType};
 
+use rio_window::dpi::PhysicalSize;
 use rio_window::event_loop::ActiveEventLoop;
 use rio_window::keyboard::{Key, NamedKey};
 #[cfg(not(any(target_os = "macos", windows)))]
@@ -664,6 +665,67 @@ impl<'a> RouteWindow<'a> {
         )
         .expect("Screen not created");
 
+        if config.window.columns.is_some() || config.window.rows.is_some() {
+            let dim = screen.ctx().current().dimension;
+            let scale = dim.dimension.scale;
+
+            // On Retina (HiDPI) displays, macOS snaps window sizes to multiples of
+            // the scale factor (e.g. 2 on 2x displays). Using PhysicalSize and
+            // rounding up to the nearest multiple of scale ensures we never end up
+            // one physical pixel short, which would cause the renderer to truncate
+            // one column or row.
+            let scale_u32 = scale.round() as u32;
+
+            let mut physical_width = (config.window.width as f32 * scale).round() as u32;
+            let mut physical_height =
+                (config.window.height as f32 * scale).round() as u32;
+
+            // Taffy reserves `config.panel` padding and margin inside the window margin.
+            // Startup sizing must include that frame or the first layout reports fewer
+            // cols/rows than requested.
+            let panel_horizontal = scaled_panel_edge(
+                config.panel.padding.left,
+                config.panel.padding.right,
+                config.panel.margin.left,
+                config.panel.margin.right,
+                scale,
+            );
+            let panel_vertical = scaled_panel_edge(
+                config.panel.padding.top,
+                config.panel.padding.bottom,
+                config.panel.margin.top,
+                config.panel.margin.bottom,
+                scale,
+            );
+
+            if let Some(columns) = config.window.columns {
+                let cell_width = dim.dimension.width;
+                let margin_physical = (dim.margin.left + dim.margin.right) * scale;
+                let raw = (columns as f32 * cell_width).ceil() as u32
+                    + margin_physical as u32
+                    + panel_horizontal as u32;
+
+                // Round up to nearest multiple of scale factor so macOS Retina
+                // snapping never drops us below the target column count.
+                physical_width = raw.next_multiple_of(scale_u32);
+            }
+
+            if let Some(rows) = config.window.rows {
+                let cell_height = dim.dimension.height;
+                let margin_physical = (dim.margin.top + dim.margin.bottom) * scale;
+                let raw = (rows as f32 * cell_height).ceil() as u32
+                    + margin_physical as u32
+                    + panel_vertical as u32;
+
+                physical_height = raw.next_multiple_of(scale_u32);
+            }
+
+            let _ = winit_window.request_inner_size(PhysicalSize {
+                width: physical_width,
+                height: physical_height,
+            });
+        }
+
         #[cfg(target_os = "windows")]
         {
             // On windows cloak (hide) the window initially, we later reveal it after the first draw.
@@ -701,4 +763,15 @@ impl<'a> RouteWindow<'a> {
             screen,
         }
     }
+}
+
+/// Sum of logical padding and margin on one axis, scaled to physical pixels.
+fn scaled_panel_edge(
+    padding_start: f32,
+    padding_end: f32,
+    margin_start: f32,
+    margin_end: f32,
+    scale: f32,
+) -> f32 {
+    (padding_start + padding_end + margin_start + margin_end) * scale
 }

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -497,6 +497,12 @@ impl Config {
             if let Some(height) = window_overwrite.height {
                 self.window.height = height;
             }
+            if let Some(columns) = window_overwrite.columns {
+                self.window.columns = Some(columns);
+            }
+            if let Some(rows) = window_overwrite.rows {
+                self.window.rows = Some(rows);
+            }
             if let Some(mode) = window_overwrite.mode {
                 self.window.mode = mode;
             }

--- a/rio-backend/src/config/platform.rs
+++ b/rio-backend/src/config/platform.rs
@@ -76,9 +76,9 @@ pub struct PlatformWindow {
     pub windows_corner_preference: Option<window::WindowsCornerPreference>,
     #[serde(default = "Option::default")]
     pub colorspace: Option<window::Colorspace>,
-    #[serde(default = "Option::default", rename = "columns")]
+    #[serde(default = "Option::default")]
     pub columns: Option<u16>,
-    #[serde(default = "Option::default", rename = "rows")]
+    #[serde(default = "Option::default")]
     pub rows: Option<u16>,
 }
 

--- a/rio-backend/src/config/platform.rs
+++ b/rio-backend/src/config/platform.rs
@@ -76,6 +76,10 @@ pub struct PlatformWindow {
     pub windows_corner_preference: Option<window::WindowsCornerPreference>,
     #[serde(default = "Option::default")]
     pub colorspace: Option<window::Colorspace>,
+    #[serde(default = "Option::default", rename = "columns")]
+    pub columns: Option<i32>,
+    #[serde(default = "Option::default", rename = "rows")]
+    pub rows: Option<i32>,
 }
 
 /// Platform-specific navigation config with optional fields for selective override

--- a/rio-backend/src/config/platform.rs
+++ b/rio-backend/src/config/platform.rs
@@ -77,9 +77,9 @@ pub struct PlatformWindow {
     #[serde(default = "Option::default")]
     pub colorspace: Option<window::Colorspace>,
     #[serde(default = "Option::default", rename = "columns")]
-    pub columns: Option<i32>,
+    pub columns: Option<u16>,
     #[serde(default = "Option::default", rename = "rows")]
-    pub rows: Option<i32>,
+    pub rows: Option<u16>,
 }
 
 /// Platform-specific navigation config with optional fields for selective override

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -120,9 +120,9 @@ pub struct Window {
     #[serde(default = "Colorspace::default")]
     pub colorspace: Colorspace,
     #[serde(rename = "columns", default = "Option::default")]
-    pub columns: Option<i32>,
+    pub columns: Option<u16>,
     #[serde(rename = "rows", default = "Option::default")]
-    pub rows: Option<i32>,
+    pub rows: Option<u16>,
 }
 
 impl Default for Window {

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -119,6 +119,10 @@ pub struct Window {
     pub windows_corner_preference: Option<WindowsCornerPreference>,
     #[serde(default = "Colorspace::default")]
     pub colorspace: Colorspace,
+    #[serde(rename = "columns", default = "Option::default")]
+    pub columns: Option<i32>,
+    #[serde(rename = "rows", default = "Option::default")]
+    pub rows: Option<i32>,
 }
 
 impl Default for Window {
@@ -141,6 +145,8 @@ impl Default for Window {
             windows_use_no_redirection_bitmap: None,
             windows_corner_preference: None,
             colorspace: Colorspace::default(),
+            columns: None,
+            rows: None,
         }
     }
 }

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -119,9 +119,9 @@ pub struct Window {
     pub windows_corner_preference: Option<WindowsCornerPreference>,
     #[serde(default = "Colorspace::default")]
     pub colorspace: Colorspace,
-    #[serde(rename = "columns", default = "Option::default")]
+    #[serde(default = "Option::default")]
     pub columns: Option<u16>,
-    #[serde(rename = "rows", default = "Option::default")]
+    #[serde(default = "Option::default")]
     pub rows: Option<u16>,
 }
 


### PR DESCRIPTION
Adds support for sizing the initial window by terminal grid (columns / rows in window config), not only by logical width/height (as currently implemented).

When either is set, startup requests an inner size that matches the current font metrics, margins, and panel chrome so the first layout matches the requested grid. 

Some terminal users (me included) think in cells for terminal sizing. Lots of scripts, tutorials, and tools assume a fixed character grid (e.g. 80×24, 120×40). Pixel or logical window size does not map 1:1 to that grid because cell size depends on font, DPI, and UI chrome.

With that in mind, I added support for columns and rows to the Rio terminal. In the config, if both set,`columns/rows` will take precedence over `window.width` and `window.height`.
```toml
[window]
width = 600
height= 400
columns = 80
rows = 24
```

