### PR TITLE
Fix kevent compilation on FreeBSD

### DIFF
--- a/corcovado/src/sys/unix/kqueue.rs
+++ b/corcovado/src/sys/unix/kqueue.rs
@@ -36,6 +36,22 @@ type UData = ::libc::intptr_t;
 #[cfg(target_os = "netbsd")]
 type Count = usize;
 
+#[cfg(target_os = "freebsd")]
+macro_rules! kevent {
+    ($id: expr, $filter: expr, $flags: expr, $data: expr) => {
+        libc::kevent {
+            ident: $id as ::libc::uintptr_t,
+            filter: $filter as Filter,
+            flags: $flags,
+            fflags: 0,
+            data: 0,
+            udata: $data as UData,
+            ext: [0; 4],
+        }
+    };
+}
+
+#[cfg(not(target_os = "freebsd"))]
 macro_rules! kevent {
     ($id: expr, $filter: expr, $flags: expr, $data: expr) => {
         libc::kevent {


### PR DESCRIPTION
Rio doesn't compile on FreeBSD because the `libc::kevent` struct has an `ext: [u64; 4]` field that the `kevent!` macro doesn't initialize.

This adds a FreeBSD-specific variant of the macro that includes `ext: [0; 4]`. The non-FreeBSD variant is unchanged so macOS, DragonFlyBSD, etc. are not affected.

Tested on FreeBSD 15.0-RELEASE with libc 0.2.174.