### PR TITLE
Fix text selection at top of terminal with hide-if-single

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1332,13 +1332,16 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
 
-                // Check if mouse is over island and set cursor to default
+                // Check if mouse is over island and set cursor to default.
+                // Skip guard when island is hidden (hide_if_single + single tab).
                 use crate::renderer::island::ISLAND_HEIGHT;
                 let scale_factor = route.window.screen.sugarloaf.scale_factor();
                 let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
-                if route.window.screen.renderer.navigation.is_enabled()
-                    && y <= island_height_px
-                {
+                let num_tabs = route.window.screen.ctx().len();
+                let nav = &route.window.screen.renderer.navigation;
+                let island_is_visible =
+                    nav.is_enabled() && !(nav.hide_if_single && num_tabs <= 1);
+                if island_is_visible && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
                 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2618,6 +2618,11 @@ impl Screen<'_> {
         let window_width = self.sugarloaf.window_size().width;
         let num_tabs = self.context_manager.len();
 
+        // Island is hidden when hide_if_single is set with a single tab.
+        if self.renderer.navigation.hide_if_single && num_tabs <= 1 {
+            return false;
+        }
+
         // Check if the color picker is open and the click hits a swatch
         if let Some(ref mut island) = self.renderer.island {
             if island.is_color_picker_open() {


### PR DESCRIPTION
## Summary

Fixes #1512 — text selection is broken at the top of the terminal when `navigation.hide_if_single` is set and only one tab is open.

Reproduced on Arch Linux / Sway (Wayland), matching the environment in the linked issue. I don't have a macOS or Windows machine to verify there, but the affected code paths in `screen/mod.rs` and `application.rs` are platform-independent, so the fix should apply equally across platforms.

## The bug

When `hide_if_single` is enabled with a single tab, the island (tab bar) is rendered invisible, but the click and cursor handlers still reserved the top ~26 px as island territory:

- Clicks in that strip were routed to `handle_island_click` instead of the terminal grid, so drags starting at or crossing the top got interrupted.
- `CursorMoved` forced the cursor to `CursorIcon::Default` whenever `y <= island_height_px`, causing the I-beam to flicker to an arrow mid-selection.

## The fix

Short-circuit both handlers when the island is hidden (`hide_if_single && num_tabs <= 1`):

- `screen/mod.rs`: `handle_island_click` returns early so clicks fall through to normal terminal input.
- `application.rs`: the cursor-override guard only runs when the island is actually visible.

## Test plan

- [ ] With `navigation.hide_if_single = true` and one tab: select text starting at the very top of the terminal — selection should track the drag without interruption and the cursor stays as an I-beam.
- [ ] With multiple tabs open: clicking the tab bar still works (switching tabs, close button, color picker swatches).
- [ ] With `hide_if_single = false`: behavior unchanged — clicks in the tab bar area are still handled by the island.

> Debugging and the proposed fix were generated with the assistance of Claude — please review critically.
