### PR TITLE
fix: respect hide_if_single across layout and input handlers

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1362,13 +1362,16 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
 
-                // Check if mouse is over island and set cursor to default
+                // Check if mouse is over island and set cursor to default.
+                // Skip guard when island is hidden (hide_if_single + single tab).
                 use crate::renderer::island::ISLAND_HEIGHT;
                 let scale_factor = route.window.screen.sugarloaf.scale_factor();
                 let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
-                if route.window.screen.renderer.navigation.is_enabled()
-                    && y <= island_height_px
-                {
+                let num_tabs = route.window.screen.ctx().len();
+                let nav = &route.window.screen.renderer.navigation;
+                let island_is_visible =
+                    nav.is_enabled() && !(nav.hide_if_single && num_tabs <= 1);
+                if island_is_visible && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
                 }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -499,6 +499,21 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     } else {
                         let size = route.window.screen.context_manager.len();
                         route.window.screen.resize_top_or_bottom_line(size);
+                        // Re-apply taffy layout so sugarloaf.set_position reflects the
+                        // updated scaled_margin (e.g. when hide_if_single transitions
+                        // from 2 tabs to 1 tab via shell exit rather than close-tab action).
+                        route
+                            .window
+                            .screen
+                            .context_manager
+                            .current_grid_mut()
+                            .update_dimensions(&mut route.window.screen.sugarloaf);
+                        // Mark the surviving tab dirty so Renderer::run's
+                        // is_dirty / force_full_damage gate lets it through.
+                        // The PTY performer follows up with a RioEvent::Render,
+                        // so the queued redraw paints the new layout — no need
+                        // to force a synchronous render from this handler.
+                        route.window.screen.mark_dirty();
                     }
                 }
             }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2599,6 +2599,11 @@ impl Screen<'_> {
         let window_width = self.sugarloaf.window_size().width;
         let num_tabs = self.context_manager.len();
 
+        // Island is hidden when hide_if_single is set with a single tab.
+        if self.renderer.navigation.hide_if_single && num_tabs <= 1 {
+            return false;
+        }
+
         // Check if the color picker is open and the click hits a swatch
         if let Some(ref mut island) = self.renderer.island {
             if island.is_color_picker_open() {

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1553,8 +1553,6 @@ impl Screen<'_> {
     }
 
     pub fn resize_top_or_bottom_line(&mut self, num_tabs: usize) {
-        let layout = self.context_manager.current().dimension;
-        let previous_margin = layout.margin;
         let padding_y_top = padding_top_from_config(
             &self.renderer.navigation,
             self.renderer.margin.top,
@@ -1563,8 +1561,16 @@ impl Screen<'_> {
         );
         let padding_y_bottom = self.renderer.margin.bottom;
 
-        if previous_margin.top != padding_y_top
-            || previous_margin.bottom != padding_y_bottom
+        // Compare against the grid's scaled_margin (the actual current margin)
+        // rather than dimension.margin, which apply_taffy_layout zeroes out and
+        // therefore cannot tell us whether the top-bar margin changed.
+        let scale = self.sugarloaf.scale_factor();
+        let current_scaled_margin = self.context_manager.current_grid().scaled_margin;
+        let previous_margin_top = current_scaled_margin.top / scale;
+        let previous_margin_bottom = current_scaled_margin.bottom / scale;
+
+        if previous_margin_top != padding_y_top
+            || previous_margin_bottom != padding_y_bottom
         {
             let current_dim = self.context_manager.current().dimension;
             if current_dim.font_size > 0.0 {
@@ -1572,7 +1578,6 @@ impl Screen<'_> {
                 s.font_size = current_dim.font_size;
                 s.line_height = current_dim.line_height;
 
-                let scale = self.sugarloaf.scale_factor();
                 let d = self.context_manager.current_grid_mut();
                 d.update_scaled_margin(Margin::new(
                     padding_y_top * scale,


### PR DESCRIPTION
Follow-up to #1518 (extending #1516), rebased onto `main` to resolve conflicts. Adds further fixes uncovered while testing the original
change:

- **Keep tab-bar margin transitions in sync with `hide_if_single`** (110b1c356a) — `resize_top_or_bottom_line` compared
the new padding against `dimension.margin`, which `apply_taffy_layout` zeroes on every run, so the `hide_if_single`
transition was missed and `update_scaled_margin` never fired. Now compares against the grid's authoritative
`scaled_margin`, and `update_scaled_margin` also resyncs Taffy's root size so panels reflow into the freed area. Without
this, closing the second tab left the tab-bar strip reserved at the top; spawning a new tab pushed the bottom row past the
 window.
