### PR TITLE
chore: fix metainfo screenshot URLs

### DIFF
--- a/misc/com.rioterm.Rio.metainfo.xml
+++ b/misc/com.rioterm.Rio.metainfo.xml
@@ -41,23 +41,23 @@
   <screenshots>
     <screenshot type="default">
       <caption>Terminal view running fastfetch</caption>
-      <image>https://raw.githubusercontent.com/raphamorim/rio/refs/heads/main/docs/static/assets/appstream/default.png</image>
+      <image>https://rioterm.com/assets/appstream/default.png</image>
     </screenshot>
     <screenshot>
       <caption>Split panel showing parallel workflows</caption>
-      <image>https://raw.githubusercontent.com/raphamorim/rio/refs/heads/main/docs/static/assets/appstream/split-panels.png</image>
+      <image>https://rioterm.com/assets/appstream/split-panels.png</image>
     </screenshot>
     <screenshot>
       <caption>Transparency support with adjustable opacity</caption>
-      <image>https://raw.githubusercontent.com/raphamorim/rio/refs/heads/main/docs/static/assets/appstream/transparency.png</image>
+      <image>https://rioterm.com/assets/appstream/transparency.png</image>
     </screenshot>
     <screenshot>
       <caption>Rendering ligatures with a supported font</caption>
-      <image>https://raw.githubusercontent.com/raphamorim/rio/refs/heads/main/docs/static/assets/appstream/ligatures.png</image>
+      <image>https://rioterm.com/assets/appstream/ligatures.png</image>
     </screenshot>
     <screenshot>
       <caption>Image display using Sixel protocol</caption>
-      <image>https://raw.githubusercontent.com/raphamorim/rio/refs/heads/main/docs/static/assets/appstream/sixel.png</image>
+      <image>https://rioterm.com/assets/appstream/sixel.png</image>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
Since the docs folder was removed, these files are not served anymore from this repo raw content, but they are now served from the website