### PR TITLE
ci: drop --release from cargo test to avoid OOM on ubuntu runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - run: cargo fetch
       - run: cargo fmt -- --check --color always
       - run: cargo clippy --all-targets --all-features
-      - run: cargo test --release --features wgpu
+      - run: cargo test --features wgpu
   msys2-build-test: #cargo test doesn't necessarily build the exec we want
     strategy:
       matrix:


### PR DESCRIPTION
The `test-native (ubuntu-latest)` job has been failing with `exit code 143` (SIGTERM) on every PR. The runner is killed during the link step of `rioterm` due to memory exhaustion, not a CI timeout.

This drops `--release` from the test command so `cargo test --features wgpu` runs in the dev profile, which compiles with parallel codegen and no LTO.
