### PR TITLE
fix: nix flake builds

### DIFF
--- a/pkgRio.nix
+++ b/pkgRio.nix
@@ -23,6 +23,7 @@
   libxcb,
   withWayland ? !stdenv.isDarwin,
   wayland,
+  shaderc,
   ...
 }: let
   readTOML = f: builtins.fromTOML (builtins.readFile f);
@@ -76,6 +77,7 @@ in
       [
         rustPlatform.bindgenHook
         ncurses
+        shaderc
       ]
       ++ lib.optionals stdenv.isLinux [
         cmake


### PR DESCRIPTION
Nix flake builds seem to have been broken for some time now with this error:

```
       > error: failed to run custom build command for `sugarloaf v0.4.2 (/build/source/sugarloaf)`
       >
       > Caused by:
       >   process didn't exit successfully: `/build/source/target/release/build/sugarloaf-1779d1526d1da7f6/build-script-build` (exit status: 101)
       >   --- stdout
       >   cargo:rerun-if-env-changed=GLSLC
       >   cargo:rerun-if-env-changed=GLSLANG_VALIDATOR
       >   cargo:rerun-if-changed=build.rs
       >
       >   --- stderr
       >
       >   thread 'main' (8106) panicked at sugarloaf/build.rs:169:5:
       >
       >   sugarloaf: no GLSL → SPIR-V compiler found.
       >   Install one of:
       >     * Debian: `apt install glslang-tools` (provides glslangValidator)
       >     *         or `apt install glslc` (Google's glslc, Bookworm+)
       >     * Arch:   `pacman -S shaderc` (provides glslc)
       >     * Or set GLSLC=/path/to/binary or GLSLANG_VALIDATOR=/path/to/binary.
       >
       >   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run:
``` 

thankfully, the fix was a 1-line change, tested locally, builds and runs fine