### PR TITLE
fix: window.opacity transparency on Windows (wgpu + cpu backends)

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -152,16 +152,36 @@ impl Screen<'_> {
         let backend = if config.renderer.use_cpu {
             SugarloafBackend::Cpu
         } else {
+            // `feature = "wgpu"` here gates rioterm's own dep feature,
+            // which is OFF in the default `cargo build` profile. On
+            // Windows the wgpu code is still compiled into sugarloaf +
+            // rio-backend via the target-specific dependency override
+            // (`[target.'cfg(windows)'.dependencies.sugarloaf] features
+            // = ["wgpu"]`), so we can — and must — take the wgpu code
+            // path on Windows even when rioterm's own `wgpu` feature
+            // isn't on. Without this OS override, default Windows
+            // builds silently fall back to the CPU rasterizer, which
+            // doesn't write per-pixel alpha and therefore renders the
+            // entire window fully transparent under the
+            // `with_transparent(true)` + `DwmEnableBlurBehindWindow`
+            // path that `window.opacity < 1` engages.
             match config.renderer.backend {
                 // `Backend::Vulkan` from the user config means the
                 // native ash backend on Linux. Other OSes fall through
-                // to the wgpu Vulkan path when the `wgpu` feature is
-                // on; otherwise we degrade to CPU rasterizer.
+                // to the wgpu Vulkan path when wgpu is available;
+                // otherwise we degrade to CPU rasterizer.
                 #[cfg(target_os = "linux")]
                 Backend::Vulkan => SugarloafBackend::Vulkan,
-                #[cfg(all(not(target_os = "linux"), feature = "wgpu"))]
+                #[cfg(all(
+                    not(target_os = "linux"),
+                    any(feature = "wgpu", target_os = "windows")
+                ))]
                 Backend::Vulkan => SugarloafBackend::Wgpu(wgpu::Backends::VULKAN),
-                #[cfg(all(not(target_os = "linux"), not(feature = "wgpu")))]
+                #[cfg(all(
+                    not(target_os = "linux"),
+                    not(feature = "wgpu"),
+                    not(target_os = "windows")
+                ))]
                 Backend::Vulkan => SugarloafBackend::Cpu,
                 #[cfg(target_os = "macos")]
                 Backend::Metal => SugarloafBackend::Metal,
@@ -169,9 +189,12 @@ impl Screen<'_> {
                 Backend::Webgpu => SugarloafBackend::Wgpu(
                     wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
                 ),
-                #[cfg(all(feature = "wgpu", not(target_arch = "wasm32")))]
+                #[cfg(all(
+                    any(feature = "wgpu", target_os = "windows"),
+                    not(target_arch = "wasm32")
+                ))]
                 Backend::Webgpu => SugarloafBackend::Wgpu(wgpu::Backends::all()),
-                #[cfg(not(feature = "wgpu"))]
+                #[cfg(all(not(feature = "wgpu"), not(target_os = "windows")))]
                 Backend::Webgpu => SugarloafBackend::Cpu,
             }
         };
@@ -195,7 +218,7 @@ impl Screen<'_> {
             }
         };
 
-        #[cfg(feature = "wgpu")]
+        #[cfg(any(feature = "wgpu", target_os = "windows"))]
         sugarloaf.update_filters(config.renderer.filters.as_slice());
 
         let mut renderer = Renderer::new(config);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -165,16 +165,36 @@ impl Screen<'_> {
         let backend = if config.renderer.use_cpu {
             SugarloafBackend::Cpu
         } else {
+            // `feature = "wgpu"` here gates rioterm's own dep feature,
+            // which is OFF in the default `cargo build` profile. On
+            // Windows the wgpu code is still compiled into sugarloaf +
+            // rio-backend via the target-specific dependency override
+            // (`[target.'cfg(windows)'.dependencies.sugarloaf] features
+            // = ["wgpu"]`), so we can — and must — take the wgpu code
+            // path on Windows even when rioterm's own `wgpu` feature
+            // isn't on. Without this OS override, default Windows
+            // builds silently fall back to the CPU rasterizer, which
+            // doesn't write per-pixel alpha and therefore renders the
+            // entire window fully transparent under the
+            // `with_transparent(true)` + `DwmEnableBlurBehindWindow`
+            // path that `window.opacity < 1` engages.
             match config.renderer.backend {
                 // `Backend::Vulkan` from the user config means the
                 // native ash backend on Linux. Other OSes fall through
-                // to the wgpu Vulkan path when the `wgpu` feature is
-                // on; otherwise we degrade to CPU rasterizer.
+                // to the wgpu Vulkan path when wgpu is available;
+                // otherwise we degrade to CPU rasterizer.
                 #[cfg(target_os = "linux")]
                 Backend::Vulkan => SugarloafBackend::Vulkan,
-                #[cfg(all(not(target_os = "linux"), feature = "wgpu"))]
+                #[cfg(all(
+                    not(target_os = "linux"),
+                    any(feature = "wgpu", target_os = "windows")
+                ))]
                 Backend::Vulkan => SugarloafBackend::Wgpu(wgpu::Backends::VULKAN),
-                #[cfg(all(not(target_os = "linux"), not(feature = "wgpu")))]
+                #[cfg(all(
+                    not(target_os = "linux"),
+                    not(feature = "wgpu"),
+                    not(target_os = "windows")
+                ))]
                 Backend::Vulkan => SugarloafBackend::Cpu,
                 #[cfg(target_os = "macos")]
                 Backend::Metal => SugarloafBackend::Metal,
@@ -182,9 +202,12 @@ impl Screen<'_> {
                 Backend::Webgpu => SugarloafBackend::Wgpu(
                     wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
                 ),
-                #[cfg(all(feature = "wgpu", not(target_arch = "wasm32")))]
+                #[cfg(all(
+                    any(feature = "wgpu", target_os = "windows"),
+                    not(target_arch = "wasm32")
+                ))]
                 Backend::Webgpu => SugarloafBackend::Wgpu(wgpu::Backends::all()),
-                #[cfg(not(feature = "wgpu"))]
+                #[cfg(all(not(feature = "wgpu"), not(target_os = "windows")))]
                 Backend::Webgpu => SugarloafBackend::Cpu,
             }
         };
@@ -208,7 +231,7 @@ impl Screen<'_> {
             }
         };
 
-        #[cfg(feature = "wgpu")]
+        #[cfg(any(feature = "wgpu", target_os = "windows"))]
         sugarloaf.update_filters(config.renderer.filters.as_slice());
 
         let mut renderer = Renderer::new(config);

--- a/sugarloaf/src/context/webgpu.rs
+++ b/sugarloaf/src/context/webgpu.rs
@@ -6,7 +6,7 @@ pub struct WgpuContext<'a> {
     pub surface: wgpu::Surface<'a>,
     pub queue: wgpu::Queue,
     pub format: wgpu::TextureFormat,
-    alpha_mode: wgpu::CompositeAlphaMode,
+    pub alpha_mode: wgpu::CompositeAlphaMode,
     pub adapter_info: wgpu::AdapterInfo,
     surface_caps: wgpu::SurfaceCapabilities,
     pub size: SugarloafWindowSize,

--- a/sugarloaf/src/grid/cpu.rs
+++ b/sugarloaf/src/grid/cpu.rs
@@ -518,10 +518,19 @@ fn premul(c: [u8; 4]) -> [u8; 4] {
 
 #[inline]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors treat it as opaque
+    // (DWM under `DwmEnableBlurBehindWindow`, Wayland surfaces).
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
-/// Premultiplied source-over against a 0x00RRGGBB destination.
+#[inline]
+fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
+    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+/// Premultiplied source-over against a premultiplied destination.
+/// Preserves the dst alpha channel through the blend so
+/// `window.opacity < 1` survives across overlapping cell paints.
 #[inline]
 fn blend_over(src: [u8; 4], dst: u32) -> u32 {
     let sa = src[3] as u32;
@@ -535,11 +544,18 @@ fn blend_over(src: [u8; 4], dst: u32) -> u32 {
     let dr = (dst >> 16) & 0xff;
     let dg = (dst >> 8) & 0xff;
     let db = dst & 0xff;
+    let da = (dst >> 24) & 0xff;
     // src is already premultiplied — add to attenuated dst.
     let or = src[0] as u32 + (dr * inv + 127) / 255;
     let og = src[1] as u32 + (dg * inv + 127) / 255;
     let ob = src[2] as u32 + (db * inv + 127) / 255;
-    pack_opaque(or.min(255) as u8, og.min(255) as u8, ob.min(255) as u8)
+    let oa = sa + (da * inv + 127) / 255;
+    pack_premul(
+        or.min(255) as u8,
+        og.min(255) as u8,
+        ob.min(255) as u8,
+        oa.min(255) as u8,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/sugarloaf/src/grid/cpu.rs
+++ b/sugarloaf/src/grid/cpu.rs
@@ -542,10 +542,19 @@ fn premul(c: [u8; 4]) -> [u8; 4] {
 
 #[inline]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors treat it as opaque
+    // (DWM under `DwmEnableBlurBehindWindow`, Wayland surfaces).
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
-/// Premultiplied source-over against a 0x00RRGGBB destination.
+#[inline]
+fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
+    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+/// Premultiplied source-over against a premultiplied destination.
+/// Preserves the dst alpha channel through the blend so
+/// `window.opacity < 1` survives across overlapping cell paints.
 #[inline]
 fn blend_over(src: [u8; 4], dst: u32) -> u32 {
     let sa = src[3] as u32;
@@ -559,11 +568,18 @@ fn blend_over(src: [u8; 4], dst: u32) -> u32 {
     let dr = (dst >> 16) & 0xff;
     let dg = (dst >> 8) & 0xff;
     let db = dst & 0xff;
+    let da = (dst >> 24) & 0xff;
     // src is already premultiplied — add to attenuated dst.
     let or = src[0] as u32 + (dr * inv + 127) / 255;
     let og = src[1] as u32 + (dg * inv + 127) / 255;
     let ob = src[2] as u32 + (db * inv + 127) / 255;
-    pack_opaque(or.min(255) as u8, og.min(255) as u8, ob.min(255) as u8)
+    let oa = sa + (da * inv + 127) / 255;
+    pack_premul(
+        or.min(255) as u8,
+        og.min(255) as u8,
+        ob.min(255) as u8,
+        oa.min(255) as u8,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -57,12 +57,18 @@ fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
 
 #[inline(always)]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors (Windows DWM under
+    // `DwmEnableBlurBehindWindow`) treat the pixel as fully opaque.
+    // For non-transparent windows the OS ignores this byte, so writing
+    // 0xff is a no-op there.
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
-/// Scalar SWAR Porter-Duff source-over with premultiplied source against
-/// opaque dest. Computes channels of R+B together in one multiply, G in
-/// another. ~30% faster than the naive 3-multiply scalar form.
+/// Scalar SWAR premultiplied source-over for all four channels (RGBA).
+/// Pairs R+B in a single u32 lane (`00RR00BB`), then G and A each on
+/// their own. Result preserves the premultiplied invariant so chained
+/// blends stay valid, which lets `window.opacity < 1` survive into the
+/// final framebuffer instead of getting masked back to alpha = 0.
 #[inline(always)]
 fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
     let sa = (src_premul >> 24) & 0xff;
@@ -70,7 +76,7 @@ fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
         return dst;
     }
     if sa == 255 {
-        return src_premul & 0x00ff_ffff;
+        return src_premul;
     }
     let inv = 255 - sa;
     // R and B share a u32: 00RR00BB.
@@ -79,33 +85,43 @@ fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
     // G alone.
     let g = ((dst >> 8) & 0xff) * inv;
     let g = ((g + 0x80 + (g >> 8)) >> 8) & 0xff;
-    let dst_blended = rb | (g << 8);
-    let src_rgb = src_premul & 0x00ff_ffff;
-    // Premultiplied src guarantees src.rgb <= src.a, so adding to the
-    // attenuated dst can't carry into the next channel.
-    let out_rb = ((src_rgb & 0x00ff_00ff) + (dst_blended & 0x00ff_00ff)) & 0x00ff_00ff;
-    let out_g = (((src_rgb >> 8) & 0xff) + ((dst_blended >> 8) & 0xff)) & 0xff;
-    out_rb | (out_g << 8)
+    // A alone — same `(x*inv) / 255` SWAR trick.
+    let da = (dst >> 24) & 0xff;
+    let a = da * inv;
+    let a = ((a + 0x80 + (a >> 8)) >> 8) & 0xff;
+    let dst_blended = rb | (g << 8) | (a << 24);
+    // Premultiplied src guarantees src.rgb <= src.a (and src.a <= 0xff),
+    // so adding to the attenuated dst can't carry into the next channel.
+    let out_rb = ((src_premul & 0x00ff_00ff) + (dst_blended & 0x00ff_00ff)) & 0x00ff_00ff;
+    let out_g = (((src_premul >> 8) & 0xff) + ((dst_blended >> 8) & 0xff)) & 0xff;
+    let out_a = (((src_premul >> 24) & 0xff) + ((dst_blended >> 24) & 0xff)) & 0xff;
+    out_rb | (out_g << 8) | (out_a << 24)
 }
 
 /// SWAR source-over with constant src across all lanes (translucent rect).
-/// `src_v` is splat of `(src_premul & 0x00ff_ffff)`; `inv_v` is splat of
-/// `(255 - src.a)`. 4 dst pixels per call.
+/// `src_v` is splat of the full premultiplied src (RGBA, alpha in upper
+/// byte); `inv_v` is splat of `(255 - src.a)`. 4 dst pixels per call.
 #[inline(always)]
 fn blend_over_simd_const_src_x4(src_v: u32x4, inv_v: u32x4, dst: u32x4) -> u32x4 {
     let mask_rb = u32x4::splat(0x00ff_00ff);
     let half_rb = u32x4::splat(0x0080_0080);
-    let mask_g = u32x4::splat(0xff);
+    let mask_byte = u32x4::splat(0xff);
+    let half_byte = u32x4::splat(0x80);
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_g;
+    let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x4::splat(0x80) + (dg >> 8)) >> 8) & mask_g;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_v + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src_v + drb + dg + da
 }
 
 /// 256-bit version of `blend_over_simd_const_src_x4` — 8 dst pixels per call.
@@ -115,17 +131,23 @@ fn blend_over_simd_const_src_x4(src_v: u32x4, inv_v: u32x4, dst: u32x4) -> u32x4
 fn blend_over_simd_const_src_x8(src_v: u32x8, inv_v: u32x8, dst: u32x8) -> u32x8 {
     let mask_rb = u32x8::splat(0x00ff_00ff);
     let half_rb = u32x8::splat(0x0080_0080);
-    let mask_g = u32x8::splat(0xff);
+    let mask_byte = u32x8::splat(0xff);
+    let half_byte = u32x8::splat(0x80);
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_g;
+    let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x8::splat(0x80) + (dg >> 8)) >> 8) & mask_g;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_v + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src_v + drb + dg + da
 }
 
 /// SWAR source-over with **per-lane** src and inv_a — used by glyph blit
@@ -137,21 +159,25 @@ fn blend_over_simd_var_src_x4(src: u32x4, dst: u32x4) -> u32x4 {
     let mask_byte = u32x4::splat(0xff);
     let mask_rb = u32x4::splat(0x00ff_00ff);
     let half_rb = u32x4::splat(0x0080_0080);
-    let mask_rgb = u32x4::splat(0x00ff_ffff);
+    let half_byte = u32x4::splat(0x80);
 
     let sa = (src >> 24) & mask_byte;
     let inv_v = u32x4::splat(255) - sa;
-    let src_rgb = src & mask_rgb;
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
     let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x4::splat(0x80) + (dg >> 8)) >> 8) & mask_byte;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_rgb + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src + drb + dg + da
 }
 
 #[derive(Clone, Copy)]
@@ -367,12 +393,21 @@ pub fn render_cpu(
         }
     };
 
+    // Bg fill writes premultiplied RGBA. The alpha byte carries
+    // `window.opacity`; on alpha-respecting compositors (Windows DWM
+    // under `DwmEnableBlurBehindWindow`, Wayland surfaces) that's what
+    // makes the window translucent. For fully opaque windows the OS
+    // ignores the alpha byte, so writing `(rgb*1, 1)` is a no-op there.
     let bg_u32 = match background {
-        Some(c) => pack_opaque(
-            (c.r.clamp(0.0, 1.0) * 255.0) as u8,
-            (c.g.clamp(0.0, 1.0) * 255.0) as u8,
-            (c.b.clamp(0.0, 1.0) * 255.0) as u8,
-        ),
+        Some(c) => {
+            let a = c.a.clamp(0.0, 1.0);
+            pack_premul(
+                (c.r.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (c.g.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (c.b.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (a * 255.0) as u8,
+            )
+        }
         None => 0,
     };
     buffer.fill(bg_u32);
@@ -522,14 +557,11 @@ fn fill_translucent_simd(
     let pg = (g as u32 * a_u + 127) / 255;
     let pb = (b as u32 * a_u + 127) / 255;
     let src_premul = pack_premul(pr as u8, pg as u8, pb as u8, a);
-    let src_rgb = src_premul & 0x00ff_ffff;
     let inv = 255 - a_u;
-    let src_v8 = u32x8::splat(src_rgb);
+    let src_v8 = u32x8::splat(src_premul);
     let inv_v8 = u32x8::splat(inv);
-    let src_v4 = u32x4::splat(src_rgb);
+    let src_v4 = u32x4::splat(src_premul);
     let inv_v4 = u32x4::splat(inv);
-    let mask_rgb_x8 = u32x8::splat(0x00ff_ffff);
-    let mask_rgb_x4 = u32x4::splat(0x00ff_ffff);
 
     let buf_w_us = buf_w as usize;
     for y in y0..y1 {
@@ -544,7 +576,7 @@ fn fill_translucent_simd(
                 chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6],
                 chunk[7],
             ]);
-            let out = blend_over_simd_const_src_x8(src_v8, inv_v8, dst) & mask_rgb_x8;
+            let out = blend_over_simd_const_src_x8(src_v8, inv_v8, dst);
             let arr = out.to_array();
             chunk.copy_from_slice(&arr);
         }
@@ -554,7 +586,7 @@ fn fill_translucent_simd(
         let mut chunks4 = tail.chunks_exact_mut(4);
         for chunk in &mut chunks4 {
             let dst = u32x4::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
-            let out = blend_over_simd_const_src_x4(src_v4, inv_v4, dst) & mask_rgb_x4;
+            let out = blend_over_simd_const_src_x4(src_v4, inv_v4, dst);
             let arr = out.to_array();
             chunk.copy_from_slice(&arr);
         }
@@ -657,8 +689,6 @@ fn draw_glyph(
     let buf_w_us = buf_w as usize;
     let g_w_us = glyph.w as usize;
 
-    let mask_rgb_x4 = u32x4::splat(0x00ff_ffff);
-
     for yy in 0..glyph.h as usize {
         let dst_y = y0 as usize + yy;
         let dst_row_off = dst_y * buf_w_us + x0 as usize;
@@ -673,7 +703,7 @@ fn draw_glyph(
         for (dchunk, schunk) in (&mut dst_chunks).zip(&mut src_chunks) {
             let dst = u32x4::new([dchunk[0], dchunk[1], dchunk[2], dchunk[3]]);
             let src = u32x4::new([schunk[0], schunk[1], schunk[2], schunk[3]]);
-            let out = blend_over_simd_var_src_x4(src, dst) & mask_rgb_x4;
+            let out = blend_over_simd_var_src_x4(src, dst);
             let arr = out.to_array();
             dchunk.copy_from_slice(&arr);
         }

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -65,12 +65,18 @@ fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
 
 #[inline(always)]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors (Windows DWM under
+    // `DwmEnableBlurBehindWindow`) treat the pixel as fully opaque.
+    // For non-transparent windows the OS ignores this byte, so writing
+    // 0xff is a no-op there.
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
-/// Scalar SWAR Porter-Duff source-over with premultiplied source against
-/// opaque dest. Computes channels of R+B together in one multiply, G in
-/// another. ~30% faster than the naive 3-multiply scalar form.
+/// Scalar SWAR premultiplied source-over for all four channels (RGBA).
+/// Pairs R+B in a single u32 lane (`00RR00BB`), then G and A each on
+/// their own. Result preserves the premultiplied invariant so chained
+/// blends stay valid, which lets `window.opacity < 1` survive into the
+/// final framebuffer instead of getting masked back to alpha = 0.
 #[inline(always)]
 fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
     let sa = (src_premul >> 24) & 0xff;
@@ -78,7 +84,7 @@ fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
         return dst;
     }
     if sa == 255 {
-        return src_premul & 0x00ff_ffff;
+        return src_premul;
     }
     let inv = 255 - sa;
     // R and B share a u32: 00RR00BB.
@@ -87,33 +93,43 @@ fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
     // G alone.
     let g = ((dst >> 8) & 0xff) * inv;
     let g = ((g + 0x80 + (g >> 8)) >> 8) & 0xff;
-    let dst_blended = rb | (g << 8);
-    let src_rgb = src_premul & 0x00ff_ffff;
-    // Premultiplied src guarantees src.rgb <= src.a, so adding to the
-    // attenuated dst can't carry into the next channel.
-    let out_rb = ((src_rgb & 0x00ff_00ff) + (dst_blended & 0x00ff_00ff)) & 0x00ff_00ff;
-    let out_g = (((src_rgb >> 8) & 0xff) + ((dst_blended >> 8) & 0xff)) & 0xff;
-    out_rb | (out_g << 8)
+    // A alone — same `(x*inv) / 255` SWAR trick.
+    let da = (dst >> 24) & 0xff;
+    let a = da * inv;
+    let a = ((a + 0x80 + (a >> 8)) >> 8) & 0xff;
+    let dst_blended = rb | (g << 8) | (a << 24);
+    // Premultiplied src guarantees src.rgb <= src.a (and src.a <= 0xff),
+    // so adding to the attenuated dst can't carry into the next channel.
+    let out_rb = ((src_premul & 0x00ff_00ff) + (dst_blended & 0x00ff_00ff)) & 0x00ff_00ff;
+    let out_g = (((src_premul >> 8) & 0xff) + ((dst_blended >> 8) & 0xff)) & 0xff;
+    let out_a = (((src_premul >> 24) & 0xff) + ((dst_blended >> 24) & 0xff)) & 0xff;
+    out_rb | (out_g << 8) | (out_a << 24)
 }
 
 /// SWAR source-over with constant src across all lanes (translucent rect).
-/// `src_v` is splat of `(src_premul & 0x00ff_ffff)`; `inv_v` is splat of
-/// `(255 - src.a)`. 4 dst pixels per call.
+/// `src_v` is splat of the full premultiplied src (RGBA, alpha in upper
+/// byte); `inv_v` is splat of `(255 - src.a)`. 4 dst pixels per call.
 #[inline(always)]
 fn blend_over_simd_const_src_x4(src_v: u32x4, inv_v: u32x4, dst: u32x4) -> u32x4 {
     let mask_rb = u32x4::splat(0x00ff_00ff);
     let half_rb = u32x4::splat(0x0080_0080);
-    let mask_g = u32x4::splat(0xff);
+    let mask_byte = u32x4::splat(0xff);
+    let half_byte = u32x4::splat(0x80);
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_g;
+    let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x4::splat(0x80) + (dg >> 8)) >> 8) & mask_g;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_v + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src_v + drb + dg + da
 }
 
 /// 256-bit version of `blend_over_simd_const_src_x4` — 8 dst pixels per call.
@@ -123,17 +139,23 @@ fn blend_over_simd_const_src_x4(src_v: u32x4, inv_v: u32x4, dst: u32x4) -> u32x4
 fn blend_over_simd_const_src_x8(src_v: u32x8, inv_v: u32x8, dst: u32x8) -> u32x8 {
     let mask_rb = u32x8::splat(0x00ff_00ff);
     let half_rb = u32x8::splat(0x0080_0080);
-    let mask_g = u32x8::splat(0xff);
+    let mask_byte = u32x8::splat(0xff);
+    let half_byte = u32x8::splat(0x80);
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_g;
+    let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x8::splat(0x80) + (dg >> 8)) >> 8) & mask_g;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_v + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src_v + drb + dg + da
 }
 
 /// SWAR source-over with **per-lane** src and inv_a — used by glyph blit
@@ -145,21 +167,25 @@ fn blend_over_simd_var_src_x4(src: u32x4, dst: u32x4) -> u32x4 {
     let mask_byte = u32x4::splat(0xff);
     let mask_rb = u32x4::splat(0x00ff_00ff);
     let half_rb = u32x4::splat(0x0080_0080);
-    let mask_rgb = u32x4::splat(0x00ff_ffff);
+    let half_byte = u32x4::splat(0x80);
 
     let sa = (src >> 24) & mask_byte;
     let inv_v = u32x4::splat(255) - sa;
-    let src_rgb = src & mask_rgb;
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
     let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x4::splat(0x80) + (dg >> 8)) >> 8) & mask_byte;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_rgb + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src + drb + dg + da
 }
 
 #[derive(Clone, Copy)]
@@ -402,12 +428,21 @@ pub fn render_cpu(
         }
     };
 
+    // Bg fill writes premultiplied RGBA. The alpha byte carries
+    // `window.opacity`; on alpha-respecting compositors (Windows DWM
+    // under `DwmEnableBlurBehindWindow`, Wayland surfaces) that's what
+    // makes the window translucent. For fully opaque windows the OS
+    // ignores the alpha byte, so writing `(rgb*1, 1)` is a no-op there.
     let bg_u32 = match background {
-        Some(c) => pack_opaque(
-            (c.r.clamp(0.0, 1.0) * 255.0) as u8,
-            (c.g.clamp(0.0, 1.0) * 255.0) as u8,
-            (c.b.clamp(0.0, 1.0) * 255.0) as u8,
-        ),
+        Some(c) => {
+            let a = c.a.clamp(0.0, 1.0);
+            pack_premul(
+                (c.r.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (c.g.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (c.b.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (a * 255.0) as u8,
+            )
+        }
         None => 0,
     };
     buffer.fill(bg_u32);
@@ -675,14 +710,11 @@ fn fill_translucent_simd(
     let pg = (g as u32 * a_u + 127) / 255;
     let pb = (b as u32 * a_u + 127) / 255;
     let src_premul = pack_premul(pr as u8, pg as u8, pb as u8, a);
-    let src_rgb = src_premul & 0x00ff_ffff;
     let inv = 255 - a_u;
-    let src_v8 = u32x8::splat(src_rgb);
+    let src_v8 = u32x8::splat(src_premul);
     let inv_v8 = u32x8::splat(inv);
-    let src_v4 = u32x4::splat(src_rgb);
+    let src_v4 = u32x4::splat(src_premul);
     let inv_v4 = u32x4::splat(inv);
-    let mask_rgb_x8 = u32x8::splat(0x00ff_ffff);
-    let mask_rgb_x4 = u32x4::splat(0x00ff_ffff);
 
     let buf_w_us = buf_w as usize;
     for y in y0..y1 {
@@ -697,7 +729,7 @@ fn fill_translucent_simd(
                 chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6],
                 chunk[7],
             ]);
-            let out = blend_over_simd_const_src_x8(src_v8, inv_v8, dst) & mask_rgb_x8;
+            let out = blend_over_simd_const_src_x8(src_v8, inv_v8, dst);
             let arr = out.to_array();
             chunk.copy_from_slice(&arr);
         }
@@ -707,7 +739,7 @@ fn fill_translucent_simd(
         let mut chunks4 = tail.chunks_exact_mut(4);
         for chunk in &mut chunks4 {
             let dst = u32x4::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
-            let out = blend_over_simd_const_src_x4(src_v4, inv_v4, dst) & mask_rgb_x4;
+            let out = blend_over_simd_const_src_x4(src_v4, inv_v4, dst);
             let arr = out.to_array();
             chunk.copy_from_slice(&arr);
         }
@@ -810,8 +842,6 @@ fn draw_glyph(
     let buf_w_us = buf_w as usize;
     let g_w_us = glyph.w as usize;
 
-    let mask_rgb_x4 = u32x4::splat(0x00ff_ffff);
-
     for yy in 0..glyph.h as usize {
         let dst_y = y0 as usize + yy;
         let dst_row_off = dst_y * buf_w_us + x0 as usize;
@@ -826,7 +856,7 @@ fn draw_glyph(
         for (dchunk, schunk) in (&mut dst_chunks).zip(&mut src_chunks) {
             let dst = u32x4::new([dchunk[0], dchunk[1], dchunk[2], dchunk[3]]);
             let src = u32x4::new([schunk[0], schunk[1], schunk[2], schunk[3]]);
-            let out = blend_over_simd_var_src_x4(src, dst) & mask_rgb_x4;
+            let out = blend_over_simd_var_src_x4(src, dst);
             let arr = out.to_array();
             dchunk.copy_from_slice(&arr);
         }
@@ -1025,8 +1055,11 @@ mod image_overlay_tests {
         vec![0u32; w * h]
     }
 
-    const RED_PX: u32 = 0x00ff_0000;
-    const BLUE_PX: u32 = 0x0000_00ff;
+    // Opaque source pixels land premultiplied with alpha = 0xff: the
+    // framebuffer carries per-pixel alpha so `window.opacity` survives
+    // to the compositor.
+    const RED_PX: u32 = 0xffff_0000;
+    const BLUE_PX: u32 = 0xff00_00ff;
 
     #[test]
     fn one_to_one_blit_lands_on_exact_pixels() {

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -1153,7 +1153,39 @@ impl Sugarloaf<'_> {
 
                 {
                     let load = if let Some(background_color) = self.background_color {
-                        wgpu::LoadOp::Clear(background_color.into())
+                        // The grid bg pass emits `(0,0,0,0)` for
+                        // default-bg cells (see `cell_bg` in
+                        // `frontends/rioterm/src/grid_emit.rs`) and
+                        // blends premultiplied-over the cleared color,
+                        // so the framebuffer alpha for any cell that
+                        // didn't get an explicit bg ends up = the clear
+                        // alpha. When the user sets `window.opacity <
+                        // 1` we want the compositor to treat that
+                        // cleared color as a translucent overlay over
+                        // the desktop. DWM (Windows DX12 / wgpu Vulkan
+                        // path) and wayland compositors interpret the
+                        // framebuffer RGB as **already** multiplied by
+                        // alpha when the surface is in PreMultiplied
+                        // mode. wgpu's Auto / Inherit modes also map
+                        // to that interpretation when transparency is
+                        // engaged (no platform we ship to picks
+                        // straight-alpha by default). Only
+                        // `PostMultiplied` wants the straight value.
+                        // Pre-multiply here so a translucent bg doesn't
+                        // come out as a near-fully-transparent window
+                        // on those backends.
+                        let clear = match ctx.alpha_mode {
+                            wgpu::CompositeAlphaMode::PostMultiplied => {
+                                background_color.into()
+                            }
+                            _ => wgpu::Color {
+                                r: background_color.r * background_color.a,
+                                g: background_color.g * background_color.a,
+                                b: background_color.b * background_color.a,
+                                a: background_color.a,
+                            },
+                        };
+                        wgpu::LoadOp::Clear(clear)
                     } else {
                         wgpu::LoadOp::Load
                     };

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -1144,7 +1144,30 @@ impl Sugarloaf<'_> {
 
         {
             let load = if let Some(background_color) = self.background_color {
-                wgpu::LoadOp::Clear(background_color.into())
+                // The grid bg pass emits `(0,0,0,0)` for default-bg cells (see
+                // `cell_bg` in `frontends/rioterm/src/grid_emit.rs`) and blends
+                // premultiplied-over the cleared color, so the framebuffer alpha
+                // for any cell that didn't get an explicit bg ends up = the clear
+                // alpha. When the user sets `window.opacity < 1` we want the
+                // compositor to treat that cleared color as a translucent overlay
+                // over the desktop. DWM (Windows DX12 / wgpu Vulkan path) and
+                // wayland compositors interpret the framebuffer RGB as **already**
+                // multiplied by alpha when the surface is in PreMultiplied mode.
+                // wgpu's Auto / Inherit modes also map to that interpretation when
+                // transparency is engaged (no platform we ship to picks
+                // straight-alpha by default). Only `PostMultiplied` wants the
+                // straight value. Pre-multiply here so a translucent bg doesn't
+                // come out as a near-fully-transparent window on those backends.
+                let clear = match ctx.alpha_mode {
+                    wgpu::CompositeAlphaMode::PostMultiplied => background_color.into(),
+                    _ => wgpu::Color {
+                        r: background_color.r * background_color.a,
+                        g: background_color.g * background_color.a,
+                        b: background_color.b * background_color.a,
+                        a: background_color.a,
+                    },
+                };
+                wgpu::LoadOp::Clear(clear)
             } else {
                 wgpu::LoadOp::Load
             };

--- a/sugarloaf/src/text.rs
+++ b/sugarloaf/src/text.rs
@@ -1979,7 +1979,14 @@ impl Drop for TextVulkanState {
 
 #[inline]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors treat it as opaque
+    // (DWM under `DwmEnableBlurBehindWindow`, Wayland surfaces).
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+#[inline]
+fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
+    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
 #[inline]
@@ -1995,10 +2002,21 @@ fn blend_premul_over(src: [u8; 4], dst: u32) -> u32 {
     let dr = (dst >> 16) & 0xff;
     let dg = (dst >> 8) & 0xff;
     let db = dst & 0xff;
+    let da = (dst >> 24) & 0xff;
     let or = src[0] as u32 + (dr * inv + 127) / 255;
     let og = src[1] as u32 + (dg * inv + 127) / 255;
     let ob = src[2] as u32 + (db * inv + 127) / 255;
-    pack_opaque(or.min(255) as u8, og.min(255) as u8, ob.min(255) as u8)
+    // Alpha follows the same Porter-Duff source-over so the
+    // framebuffer alpha — which controls window translucency on
+    // alpha-respecting compositors — composes correctly across
+    // overlapping draws.
+    let oa = sa + (da * inv + 127) / 255;
+    pack_premul(
+        or.min(255) as u8,
+        og.min(255) as u8,
+        ob.min(255) as u8,
+        oa.min(255) as u8,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/sugarloaf/src/text.rs
+++ b/sugarloaf/src/text.rs
@@ -1903,7 +1903,14 @@ impl Drop for TextVulkanState {
 
 #[inline]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors treat it as opaque
+    // (DWM under `DwmEnableBlurBehindWindow`, Wayland surfaces).
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+#[inline]
+fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
+    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
 #[inline]
@@ -1919,10 +1926,21 @@ fn blend_premul_over(src: [u8; 4], dst: u32) -> u32 {
     let dr = (dst >> 16) & 0xff;
     let dg = (dst >> 8) & 0xff;
     let db = dst & 0xff;
+    let da = (dst >> 24) & 0xff;
     let or = src[0] as u32 + (dr * inv + 127) / 255;
     let og = src[1] as u32 + (dg * inv + 127) / 255;
     let ob = src[2] as u32 + (db * inv + 127) / 255;
-    pack_opaque(or.min(255) as u8, og.min(255) as u8, ob.min(255) as u8)
+    // Alpha follows the same Porter-Duff source-over so the
+    // framebuffer alpha — which controls window translucency on
+    // alpha-respecting compositors — composes correctly across
+    // overlapping draws.
+    let oa = sa + (da * inv + 127) / 255;
+    pack_premul(
+        or.min(255) as u8,
+        og.min(255) as u8,
+        ob.min(255) as u8,
+        oa.min(255) as u8,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Problem

On Windows, `[window] opacity < 1` rendered the window almost entirely see-through instead of partially translucent.
Reproducible with the default `cargo build` (wgpu backend) and with `[renderer] use-cpu = true` (cpu backend).

## Root cause

`with_transparent(opacity < 1.)` triggers `DwmEnableBlurBehindWindow`, after which DWM uses the framebuffer alpha for per-pixel compositing.
Both backends were producing the wrong alpha:

**wgpu backend** had two independent issues:

1. `frontends/rioterm/src/screen/mod.rs` gates the wgpu code path on rioterm's own `wgpu` feature, which is **off** in default `cargo build`.
Default Windows builds therefore fell into the CPU rasterizer, even though `sugarloaf` and `rio-backend` already get `features = ["wgpu"]` via the `[target.'cfg(windows)']` dep override, so the wgpu code is in the binary.
2. `Sugarloaf::render_wgpu` wrote `LoadOp::Clear((bg_r, bg_g, bg_b, opacity))` raw.
wgpu picks `PreMultiplied` alpha mode on Windows (the only non-Opaque option DX12 / Vulkan WSI offer), so DWM read the dark bg as if it were already-multiplied — the implied "straight" RGB came out near-fully transparent.

**cpu backend** wrote `0x00RRGGBB` pixels (`α = 0`) and every blend function masked the alpha byte out (`pack_opaque` omits it, SIMD results post-masked with `& 0x00ff_ffff`).
Harmless on platforms that ignore swap-chain alpha; with DWM reading the alpha byte, every pixel came out fully transparent.

## Fix

**wgpu**:

- Allow the wgpu dispatch on Windows even without rioterm's own feature flag: `cfg(any(feature = "wgpu", target_os = "windows"))`.
- Premultiply the `LoadOp::Clear` color in `render_wgpu` for any alpha mode that isn't `PostMultiplied`.
Promote `WgpuContext::alpha_mode` to `pub` so the renderer can branch on it.

**cpu** — switch the softbuffer framebuffer to **premultiplied RGBA** end-to-end:

- `pack_opaque` writes `α = 0xff` (no-op on OSes that ignore the byte).
- bg fill in `render_cpu` uses `pack_premul((R,G,B)·a, a)`.
- All four blend variants in `renderer/cpu.rs` (scalar SWAR + x4/x8 SIMD const-src + var-src) gain an A-channel computation via the same `(x · inv) / 255` SWAR trick as G, and stop stripping alpha from the source / result.
- The two scalar blend paths in `grid/cpu.rs` and `text.rs` (grid cells and UI text overlays) get the same A-channel fix, with a new `pack_premul` helper next to each `pack_opaque`.
- Caller sites that splatted `(src_premul & 0x00ff_ffff)` and post-masked SIMD results are updated to splat the full premultiplied src and drop the post-mask.

The premultiplied invariant (RGB ≤ A) keeps byte-wise channel adds safe from inter-channel carry.
Default-bg cells continue to emit `(0, 0, 0, 0)`; the `sa == 0` early-out returns `dst` unchanged, so the cleared bg's alpha bleeds through.

## Tested

Windows 11 / NVIDIA RTX 5070, `opacity = 0.6`:

- wgpu (Vulkan, `Bgra8Unorm`, `PreMultiplied` surface) — renders as ~60% bg + ~40% desktop.
- cpu (`use-cpu = true`) — renders translucent; tabs, prompt text, glyph AA edges, command palette overlay all composite correctly.

`opacity = 1.0` (default) unaffected on both paths.
