### PR TITLE
fix: mark tab dirty after shell exit

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -497,8 +497,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             event_loop.exit();
                         }
                     } else {
-                        let size = route.window.screen.context_manager.len();
-                        route.window.screen.resize_top_or_bottom_line(size);
+                        let screen = &mut route.window.screen;
+                        let size = screen.context_manager.len();
+                        screen.resize_top_or_bottom_line(size);
+                        screen.mark_dirty();
                     }
                 }
             }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -500,6 +500,13 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         let screen = &mut route.window.screen;
                         let size = screen.context_manager.len();
                         screen.resize_top_or_bottom_line(size);
+                        #[cfg(not(target_os = "macos"))]
+                        if size == 1 {
+                            screen
+                                .context_manager
+                                .current_grid_mut()
+                                .update_dimensions(&mut screen.sugarloaf);
+                        }
                         screen.mark_dirty();
                     }
                 }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -501,7 +501,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         let size = screen.context_manager.len();
                         screen.resize_top_or_bottom_line(size);
                         screen.mark_dirty();
-                        route.request_redraw();
                     }
                 }
             }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -501,6 +501,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         let size = screen.context_manager.len();
                         screen.resize_top_or_bottom_line(size);
                         screen.mark_dirty();
+                        route.request_redraw();
                     }
                 }
             }


### PR DESCRIPTION
Closing a tab by exiting its shell removes the context in the CloseTerminal handler, but that path left the newly active tab with no pending update. The PTY performer already sends a follow-up RioEvent::Render, so a redraw is queued. However, Renderer::run still gates each panel on is_dirty or force_full_damage. When neither flag is set, the frame is discarded and the closed tab remains visible until another action dirties the screen.

Mark the new active screen dirty after resizing the tab line. This keeps the shell-exit path aligned with other UI mutation paths without adding another redraw request; the existing Render event supplies that.