### PR TITLE
fix: panic on window resize from cols mismatch

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3702,11 +3702,15 @@ impl Screen<'_> {
                 let cursor_color = term_colors
                     [rio_backend::config::colors::NamedColor::Cursor as usize]
                     .unwrap_or(self.renderer.named_colors.cursor);
+                // `dim` can race ahead of the terminal during resize;
+                // the snapshot was captured under the same lock as
+                // `visible_rows` / `cell_styles`, so use it to keep
+                // row widths consistent with the painted data.
                 panels.push(PanelFrame {
                     route_id: ctx.route_id,
                     layout_rect: item.layout_rect,
-                    cols: dim.columns.max(1) as u32,
-                    rows: dim.lines.max(1) as u32,
+                    cols: ctx.renderable_content.columns.max(1) as u32,
+                    rows: ctx.renderable_content.screen_lines.max(1) as u32,
                     cell_w,
                     cell_h,
                     font_px,


### PR DESCRIPTION
Fixes #1593.

Rio panics on window resize:

```
thread 'main' panicked at frontends/rioterm/src/grid_emit.rs:965:25:
index out of bounds: the len is 88 but the index is 88
```

`PanelFrame` read `cols` / `rows` from the live `ContextDimension`, while
`visible_rows` and `cell_styles` were sized from the snapshot taken under
the terminal lock. A resize landing between the snapshot and the paint
pass left the row loop walking past the row's storage.

Source the dims from `renderable_content.columns` / `screen_lines` instead, which is captured under the same lock as the row data, so the loop bound and
the row Vec agree.

Tested in niri (built using flake): resize cycles no longer panic, no visible rendering issues, might not tested all the edge cases tho.