### PR TITLE
feat(scroll): add opt-in smooth pixel scrolling

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1564,6 +1564,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                                 // Reset offset to zero.
                                 route.window.screen.mouse.accumulated_scroll =
                                     Default::default();
+                                if route.window.screen.renderer.smooth_scroll_enabled {
+                                    route
+                                        .window
+                                        .screen
+                                        .renderer
+                                        .smooth_scroll
+                                        .trackpad_started();
+                                }
                             }
                             TouchPhase::Moved => {
                                 // When the angle between (x, 0) and (x, y) is lower than ~25 degrees
@@ -1576,7 +1584,16 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                                 route.window.screen.scroll(lpos.x, lpos.y);
                             }
-                            _ => (),
+                            TouchPhase::Ended | TouchPhase::Cancelled => {
+                                if route.window.screen.renderer.smooth_scroll_enabled {
+                                    route
+                                        .window
+                                        .screen
+                                        .renderer
+                                        .smooth_scroll
+                                        .trackpad_ended();
+                                }
+                            }
                         }
                     }
                 }

--- a/frontends/rioterm/src/context/renderable.rs
+++ b/frontends/rioterm/src/context/renderable.rs
@@ -104,6 +104,10 @@ pub struct RenderableContent {
     pub kitty_images: FxHashMap<u32, StoredImage>,
     pub kitty_placements: Vec<KittyPlacement>,
     pub kitty_graphics_dirty: bool,
+    /// Number of extra rows fetched above the viewport for smooth scroll
+    /// partial reveal. 0 when not animating, 1 when a fractional scroll
+    /// offset is active.
+    pub extra_rows: usize,
 }
 
 impl RenderableContent {
@@ -135,6 +139,7 @@ impl RenderableContent {
             kitty_images: FxHashMap::default(),
             kitty_placements: Vec::new(),
             kitty_graphics_dirty: false,
+            extra_rows: 0,
         }
     }
 

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -4,6 +4,7 @@ pub mod custom_cursor;
 pub mod island;
 pub mod scrollbar;
 pub mod search;
+pub mod smooth_scroll;
 pub mod trail_cursor;
 pub mod utils;
 
@@ -87,6 +88,8 @@ pub struct Renderer {
     pub custom_mouse_cursor: bool,
     pub trail_cursor_enabled: bool,
     pub trail_cursor: trail_cursor::TrailCursor,
+    pub smooth_scroll_enabled: bool,
+    pub smooth_scroll: smooth_scroll::SmoothScroll,
 }
 
 impl Renderer {
@@ -158,6 +161,8 @@ impl Renderer {
             custom_mouse_cursor: config.effects.custom_mouse_cursor,
             trail_cursor_enabled: config.effects.trail_cursor,
             trail_cursor: trail_cursor::TrailCursor::new(),
+            smooth_scroll_enabled: config.scroll.smooth,
+            smooth_scroll: smooth_scroll::SmoothScroll::new(),
         }
     }
 
@@ -289,6 +294,7 @@ impl Renderer {
                         display_offset: terminal.display_offset(),
                         history_size: terminal.history_size(),
                         screen_lines: terminal.screen_lines(),
+                        scroll_sub_offset: self.smooth_scroll.offset_y(),
                     });
             }
         }
@@ -371,13 +377,23 @@ impl Renderer {
                 terminal.reset_damage();
 
                 let snapshot_cols = terminal.columns();
+                // Fetch one extra row above the viewport when smooth scroll
+                // has a fractional offset, so the partial row is available
+                // for the GPU to reveal.
+                let extra_rows = if self.smooth_scroll.needs_extra_row() {
+                    1
+                } else {
+                    0
+                };
                 terminal.snapshot_visible(
                     &damage,
                     snapshot_cols,
                     &mut context.renderable_content.visible_rows,
                     &mut context.renderable_content.cell_styles,
                     &mut context.renderable_content.extras,
+                    extra_rows,
                 );
+                context.renderable_content.extra_rows = extra_rows;
                 context.renderable_content.term_colors = terminal.colors;
                 context.renderable_content.display_offset = terminal.display_offset();
                 context.renderable_content.columns = snapshot_cols;
@@ -664,6 +680,9 @@ impl Renderer {
     #[inline]
     pub fn needs_redraw(&mut self) -> bool {
         if self.trail_cursor_enabled && self.trail_cursor.is_animating() {
+            return true;
+        }
+        if self.smooth_scroll.is_animating() {
             return true;
         }
         if self.scrollbar.needs_redraw() {

--- a/frontends/rioterm/src/renderer/scrollbar.rs
+++ b/frontends/rioterm/src/renderer/scrollbar.rs
@@ -153,6 +153,8 @@ pub struct PanelScrollState {
     pub display_offset: usize,
     pub history_size: usize,
     pub screen_lines: usize,
+    /// Fractional scroll offset in pixels for smooth scrollbar positioning.
+    pub scroll_sub_offset: f32,
 }
 
 pub struct Scrollbar {

--- a/frontends/rioterm/src/renderer/smooth_scroll.rs
+++ b/frontends/rioterm/src/renderer/smooth_scroll.rs
@@ -1,0 +1,126 @@
+// Sub-pixel scroll offset for smooth scrolling.
+//
+// Manages a fractional vertical offset that shifts the terminal grid
+// visually between integer scroll positions. The integer `display_offset`
+// is updated immediately; this module handles only the fractional
+// remainder.
+//
+// Sign convention:
+//   - Positive delta_y = user scrolls to see older content (scroll up)
+//   - Positive offset_y = content should slide DOWN to reveal older rows
+//   - In the shader, offset_y is ADDED to grid_padding.x so the grid
+//     origin moves down, causing content to slide down.
+
+/// Threshold below which the offset is snapped to zero (physical pixels).
+const SETTLE_THRESHOLD: f32 = 0.5;
+
+pub struct SmoothScroll {
+    /// Current sub-pixel offset in physical pixels.
+    /// Positive = content shifted downward (revealing older content at top).
+    offset_y: f32,
+    /// Whether we're in trackpad direct-drive mode (true between
+    /// TouchPhase::Started and TouchPhase::Ended).
+    trackpad_active: bool,
+    /// Accumulated pixel delta for the current event batch.
+    accumulated: f64,
+}
+
+impl SmoothScroll {
+    pub fn new() -> Self {
+        Self {
+            offset_y: 0.0,
+            trackpad_active: false,
+            accumulated: 0.0,
+        }
+    }
+
+    /// Feed a sub-pixel scroll delta (from trackpad or accumulated mouse
+    /// wheel pixels). Returns the integer line count that should be applied
+    /// to `display_offset`, and stores the fractional remainder internally.
+    ///
+    /// `delta_y` is in physical pixels after multiplier/divider.
+    /// `cell_height` is one row height in physical pixels.
+    pub fn feed_pixel_delta(&mut self, delta_y: f64, cell_height: f32) -> i32 {
+        self.accumulated += delta_y;
+
+        let total_offset = self.offset_y + self.accumulated as f32;
+        self.accumulated = 0.0;
+
+        // Truncate toward zero — matches the original `as i32` cast used
+        // by the old scroll code and handles negative deltas correctly.
+        let lines = (total_offset / cell_height) as i32;
+
+        // Keep the fractional remainder.
+        self.offset_y = total_offset - lines as f32 * cell_height;
+
+        lines
+    }
+
+    /// Called when trackpad TouchPhase::Started.
+    pub fn trackpad_started(&mut self) {
+        self.trackpad_active = true;
+    }
+
+    /// Called when trackpad TouchPhase::Ended or Cancelled.
+    /// macOS continues sending momentum events via Moved, so we just
+    /// leave the offset as-is. No spring animation needed.
+    pub fn trackpad_ended(&mut self) {
+        self.trackpad_active = false;
+        // Snap tiny residuals to zero to avoid a persistent sub-pixel
+        // offset when the user is done scrolling.
+        if self.offset_y.abs() < SETTLE_THRESHOLD {
+            self.offset_y = 0.0;
+        }
+    }
+
+    /// No-op — the offset is driven purely by scroll events, not by
+    /// spring animation. Kept as a no-op so the call site doesn't need
+    /// to change.
+    pub fn update(&mut self) -> bool {
+        false
+    }
+
+    /// Current sub-pixel offset for the shader uniform (physical pixels).
+    #[inline]
+    pub fn offset_y(&self) -> f32 {
+        self.offset_y
+    }
+
+    /// Whether an extra row should be fetched for partial reveal.
+    /// Only true for positive offsets (scrolling up / revealing history).
+    #[inline]
+    pub fn needs_extra_row(&self) -> bool {
+        self.offset_y > 0.01
+    }
+
+    /// Whether the animation loop should keep requesting redraws.
+    /// Always false — redraws are triggered by set_dirty() in scroll().
+    #[inline]
+    pub fn is_animating(&self) -> bool {
+        false
+    }
+
+    /// Reset all state. Called on PageUp/PageDown, resize, terminal output
+    /// while scrolled up, etc.
+    pub fn reset(&mut self) {
+        self.offset_y = 0.0;
+        self.trackpad_active = false;
+        self.accumulated = 0.0;
+    }
+
+    /// Clamp the offset so it doesn't try to reveal content past the
+    /// scrollback boundaries.
+    ///
+    /// - `at_bottom`: display_offset == 0 → can't scroll further down,
+    ///   so negative offset (revealing content below) is clamped to 0.
+    /// - `at_top`: display_offset == history_size → can't scroll further
+    ///   up, so positive offset (revealing content above) is clamped to 0.
+    pub fn clamp_at_boundary(&mut self, at_bottom: bool, at_top: bool) {
+        if at_bottom && self.offset_y < 0.0 {
+            self.offset_y = 0.0;
+        }
+        if at_top && self.offset_y > 0.0 {
+            self.offset_y = 0.0;
+        }
+    }
+}

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -662,8 +662,11 @@ impl Screen<'_> {
         let mut terminal = self.ctx_mut().current_mut().terminal.lock();
         if terminal.display_offset() != 0 {
             terminal.scroll_display(Scroll::Bottom);
+            drop(terminal);
+            self.renderer.smooth_scroll.reset();
+        } else {
+            drop(terminal);
         }
-        drop(terminal);
     }
 
     #[inline]
@@ -1185,6 +1188,7 @@ impl Screen<'_> {
                         self.change_font_size(FontSizeAction::Reset);
                     }
                     Act::ScrollPageUp => {
+                        self.renderer.smooth_scroll.reset();
                         // Move vi mode cursor.
                         let current = self.context_manager.current_mut();
                         let rtid = current.rich_text_id;
@@ -1198,6 +1202,7 @@ impl Screen<'_> {
                         self.mark_dirty();
                     }
                     Act::ScrollPageDown => {
+                        self.renderer.smooth_scroll.reset();
                         // Move vi mode cursor.
                         let current = self.context_manager.current_mut();
                         let rtid = current.rich_text_id;
@@ -1243,6 +1248,7 @@ impl Screen<'_> {
                         self.mark_dirty();
                     }
                     Act::ScrollToTop => {
+                        self.renderer.smooth_scroll.reset();
                         let current = self.context_manager.current_mut();
                         let rtid = current.rich_text_id;
                         let mut terminal = current.terminal.lock();
@@ -1256,6 +1262,7 @@ impl Screen<'_> {
                         self.mark_dirty();
                     }
                     Act::ScrollToBottom => {
+                        self.renderer.smooth_scroll.reset();
                         let current = self.context_manager.current_mut();
                         let rtid = current.rich_text_id;
                         let mut terminal = current.terminal.lock();
@@ -3213,7 +3220,47 @@ impl Screen<'_> {
             if !content.is_empty() {
                 self.ctx_mut().current_mut().messenger.send_write(content);
             }
+        } else if self.renderer.smooth_scroll_enabled {
+            // Smooth scroll: feed pixel delta through SmoothScroll for
+            // sub-line animation.
+            let pixel_y = (new_scroll_y_px * self.mouse.multiplier) / self.mouse.divider;
+            let lines = self
+                .renderer
+                .smooth_scroll
+                .feed_pixel_delta(pixel_y, height as f32);
+
+            if lines != 0 {
+                let current = self.context_manager.current_mut();
+                let rich_text_id = current.rich_text_id;
+                let mut terminal = current.terminal.lock();
+                terminal.scroll_display(Scroll::Delta(lines));
+                self.renderer.smooth_scroll.clamp_at_boundary(
+                    terminal.display_offset() == 0,
+                    terminal.display_offset() == terminal.history_size(),
+                );
+                drop(terminal);
+                self.renderer.scrollbar.notify_scroll(rich_text_id);
+            } else {
+                // No integer scroll, but still check boundaries to prevent
+                // the fractional offset from accumulating past the edges.
+                let terminal = self.context_manager.current().terminal.lock();
+                self.renderer.smooth_scroll.clamp_at_boundary(
+                    terminal.display_offset() == 0,
+                    terminal.display_offset() == terminal.history_size(),
+                );
+            }
+            // Mark dirty so the render loop picks up the smooth scroll offset.
+            if self.renderer.smooth_scroll.is_animating()
+                || self.renderer.smooth_scroll.needs_extra_row()
+            {
+                self.context_manager
+                    .current_mut()
+                    .renderable_content
+                    .pending_update
+                    .set_dirty();
+            }
         } else {
+            // Original direct scroll (no smooth animation).
             self.mouse.accumulated_scroll.y +=
                 (new_scroll_y_px * self.mouse.multiplier) / self.mouse.divider;
             let lines = (self.mouse.accumulated_scroll.y / height) as i32;
@@ -3226,10 +3273,14 @@ impl Screen<'_> {
                 drop(terminal);
                 self.renderer.scrollbar.notify_scroll(rich_text_id);
             }
+
+            self.mouse.accumulated_scroll.x %= width;
+            self.mouse.accumulated_scroll.y %= height;
+            return;
         }
 
         self.mouse.accumulated_scroll.x %= width;
-        self.mouse.accumulated_scroll.y %= height;
+        // Y scroll remainder is managed by SmoothScroll now.
     }
 
     #[inline]
@@ -3427,6 +3478,18 @@ impl Screen<'_> {
             self.ensure_grid(current_route, grid_cols, grid_rows);
         }
 
+        // Advance smooth scroll animation for this frame.
+        if self.renderer.smooth_scroll_enabled {
+            self.renderer.smooth_scroll.update();
+            if self.renderer.smooth_scroll.is_animating() {
+                self.context_manager
+                    .current_mut()
+                    .renderable_content
+                    .pending_update
+                    .set_dirty();
+            }
+        }
+
         let is_search_active = self.search_active();
         if is_search_active {
             if let Some(history_index) = self.search_state.history_index {
@@ -3614,6 +3677,9 @@ impl Screen<'_> {
                     rio_backend::crosswords::pos::Pos,
                     rio_backend::crosswords::pos::Pos,
                 )>,
+                /// Number of extra rows fetched above the viewport for
+                /// smooth scroll partial reveal.
+                extra_rows: u32,
             }
 
             let (active_key, scaled_margin) = {
@@ -3669,6 +3735,15 @@ impl Screen<'_> {
                 let extras = std::mem::take(&mut ctx.renderable_content.extras);
                 let term_colors = ctx.renderable_content.term_colors;
                 let display_offset = ctx.renderable_content.display_offset as i32;
+                // When extra rows are fetched above the viewport (for smooth
+                // scroll), adjust display_offset so that row_selection_for
+                // and other y-indexed math still maps correctly. The extra
+                // row is at y=0, so the viewport starts at y=extra_rows.
+                let extra_rows_count = ctx.renderable_content.extra_rows;
+                let adjusted_display_offset = display_offset + extra_rows_count as i32;
+                // Cursor row is relative to the viewport start. With extra
+                // rows at the top, the cursor shifts down by extra_rows_count.
+                let cursor_row_offset = extra_rows_count as u16;
                 let selection = ctx.renderable_content.selection_range;
                 let cursor = &ctx.renderable_content.cursor;
                 // Take + reset so next frame sees fresh damage only
@@ -3735,7 +3810,7 @@ impl Screen<'_> {
                     extras,
                     term_colors,
                     cursor_col: cursor.state.pos.col.0 as u16,
-                    cursor_row: cursor.state.pos.row.0 as u16,
+                    cursor_row: cursor.state.pos.row.0 as u16 + cursor_row_offset,
                     cursor_visible: cursor.state.is_visible(),
                     cursor_shape,
                     cursor_blinking,
@@ -3745,16 +3820,17 @@ impl Screen<'_> {
                     is_active,
                     damage,
                     selection,
-                    display_offset,
+                    display_offset: adjusted_display_offset,
                     hint_matches,
                     focused_match,
                     hovered_hyperlink,
+                    extra_rows: ctx.renderable_content.extra_rows as u32,
                 });
             }
 
             // --- ensure every panel has a matching GridRenderer ---
             for p in &panels {
-                self.ensure_grid(p.route_id, p.cols, p.rows);
+                self.ensure_grid(p.route_id, p.cols, p.rows + p.extra_rows);
             }
 
             // --- emit cells + build uniforms per panel ---
@@ -4022,17 +4098,31 @@ impl Screen<'_> {
                     // painted by this grid. The full-window bg fill
                     // (re-enabled in sugarloaf's render_metal) now
                     // handles the space outside all panels.
-                    grid_padding: [panel_top, 0.0, 0.0, panel_left],
+                    // When an extra row is fetched for smooth scroll, shift
+                    // the grid origin UP by one cell so the extra row peeks
+                    // into the viewport from above. Without this the grid
+                    // starts at panel_top + offset_y, leaving a gap at the
+                    // top instead of showing the partially-visible history row.
+                    grid_padding: [
+                        panel_top - p.extra_rows as f32 * p.cell_h,
+                        0.0,
+                        0.0,
+                        panel_left,
+                    ],
                     cursor_color: cursor_col_u,
                     cursor_bg_color: cursor_bg_u,
                     cell_size: [p.cell_w, p.cell_h],
-                    grid_size: [p.cols, p.rows],
+                    // Include extra rows for smooth scroll partial reveal.
+                    grid_size: [p.cols, p.rows + p.extra_rows],
                     cursor_pos,
                     _pad_cursor: [0; 2],
                     min_contrast: 0.0,
                     flags: 0,
                     padding_extend: 0,
                     input_colorspace,
+                    // Smooth scroll sub-pixel offset (physical pixels).
+                    scroll_offset_y: self.renderer.smooth_scroll.offset_y(),
+                    _pad_scroll: [0.0; 3],
                 };
 
                 frame_grids.push((grid, uniforms));

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -52,6 +52,8 @@ pub struct Shell {
 pub struct Scroll {
     pub multiplier: f64,
     pub divider: f64,
+    #[serde(default)]
+    pub smooth: bool,
 }
 
 impl Default for Scroll {
@@ -59,6 +61,7 @@ impl Default for Scroll {
         Scroll {
             multiplier: 3.0,
             divider: 1.0,
+            smooth: false,
         }
     }
 }

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -1430,6 +1430,7 @@ impl<U: EventListener> Crosswords<U> {
         dst: &mut Vec<Row<Square>>,
         cell_styles: &mut Vec<crate::crosswords::style::Style>,
         extras: &mut rustc_hash::FxHashMap<u16, crate::crosswords::square::Extras>,
+        extra_rows: usize,
     ) {
         use crate::event::TerminalDamage;
         let mut start = self.scroll_region.start.0;
@@ -1438,6 +1439,14 @@ impl<U: EventListener> Crosswords<U> {
         if scroll != 0 {
             start -= scroll;
             end -= scroll;
+        }
+        // Extend range upward by extra_rows to fetch the partially-visible
+        // row above the viewport during smooth scroll animation. Clamp to
+        // the grid's topmost line to avoid out-of-bounds access when
+        // display_offset is 0 and there is no scrollback history.
+        if extra_rows > 0 {
+            let topmost = self.grid.topmost_line().0;
+            start = (start - extra_rows as i32).max(topmost);
         }
         let count = (end - start) as usize;
         let total = count * cols;

--- a/sugarloaf/src/grid/cell.rs
+++ b/sugarloaf/src/grid/cell.rs
@@ -102,7 +102,7 @@ const _: () = {
 /// - Group scalars into 16-byte blocks or add explicit `_pad` fields.
 /// - Struct size must be a multiple of 16 bytes.
 ///
-/// Current layout: 144 bytes, 16-byte aligned.
+/// Current layout: 176 bytes, 16-byte aligned.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct GridUniforms {
@@ -160,6 +160,14 @@ pub struct GridUniforms {
     /// `Uniforms.use_display_p3` + `load_color` pair at
     /// `ghostty/src/renderer/shaders/shaders.metal:224`.
     pub input_colorspace: u32,
+    // --- 16-byte block at offset 160 ---
+    /// Fractional vertical scroll offset in physical pixels. Positive values
+    /// shift the grid content upward (revealing older content at the top).
+    /// The integer part is baked into `display_offset` on the CPU; this
+    /// carries only the sub-pixel remainder for smooth scrolling.
+    pub scroll_offset_y: f32,
+    /// Explicit padding to maintain 16-byte alignment.
+    pub _pad_scroll: [f32; 3],
 }
 
 impl GridUniforms {

--- a/sugarloaf/src/grid/cpu.rs
+++ b/sugarloaf/src/grid/cpu.rs
@@ -359,7 +359,7 @@ impl CpuGridRenderer {
         if cols == 0 || rows == 0 {
             return;
         }
-        let pad_top = uniforms.grid_padding[0];
+        let pad_top = uniforms.grid_padding[0] + uniforms.scroll_offset_y;
         let pad_left = uniforms.grid_padding[3];
 
         let buf_w_i = buf_w as i32;
@@ -412,7 +412,7 @@ impl CpuGridRenderer {
         if cols == 0 || rows == 0 {
             return;
         }
-        let pad_top = uniforms.grid_padding[0];
+        let pad_top = uniforms.grid_padding[0] + uniforms.scroll_offset_y;
         let pad_left = uniforms.grid_padding[3];
 
         let buf_w_i = buf_w as i32;

--- a/sugarloaf/src/grid/shaders/grid.metal
+++ b/sugarloaf/src/grid/shaders/grid.metal
@@ -36,7 +36,9 @@ struct Uniforms {
     float    min_contrast;     //       144
     uint     flags;            //       148
     uint     padding_extend;   //       152
-    uint     input_colorspace; //       156 → total 160
+    uint     input_colorspace; //       156
+    float    scroll_offset_y;  //       160
+    uint3    _pad_scroll;      //       164 → total 176
 };
 
 //-------------------------------------------------------------------
@@ -142,7 +144,7 @@ fragment float4 grid_bg_fragment(
  // `grid_padding` is (top, right, bottom, left) — we only need
  // left (.w) and top (.x) to locate the grid origin.
     int2 orig_grid_pos = int2(
-        floor((in.position.xy - uniforms.grid_padding.wx) / uniforms.cell_size)
+        floor((in.position.xy - float2(uniforms.grid_padding.w, uniforms.grid_padding.x + uniforms.scroll_offset_y)) / uniforms.cell_size)
     );
     int2 grid_pos = orig_grid_pos;
 
@@ -272,8 +274,9 @@ vertex CellTextVertexOut grid_text_vertex(
 
  // Also shift by grid_padding (top/left) to position the whole grid
  // inside the drawable — `grid_padding` is (top, right, bottom, left).
+ // Subtract scroll_offset_y for smooth scrolling (shifts grid upward).
     quad.x += uniforms.grid_padding.w;
-    quad.y += uniforms.grid_padding.x;
+    quad.y += uniforms.grid_padding.x + uniforms.scroll_offset_y;
 
     CellTextVertexOut out;
     out.position = uniforms.projection * float4(quad.x, quad.y, 0.0, 1.0);

--- a/sugarloaf/src/grid/shaders/grid.wgsl
+++ b/sugarloaf/src/grid/shaders/grid.wgsl
@@ -33,6 +33,8 @@ struct Uniforms {
     flags:            u32,           //       148
     padding_extend:   u32,           //       152
     input_colorspace: u32,           //       156
+    scroll_offset_y:  f32,           //       160
+    _pad_scroll:      vec3<u32>,     //       164
 };
 
 // Color space / transfer curve helpers. Matrices match the Metal
@@ -126,7 +128,7 @@ fn load_cell_bg(idx: u32) -> vec4<f32> {
 fn grid_bg_fragment(in: VsOut) -> @location(0) vec4<f32> {
  // `grid_padding` is (top, right, bottom, left).
  // Use .w (left) + .x (top) to find the grid origin, same as Metal port.
-    let cell_fx = (in.position.xy - vec2<f32>(uniforms.grid_padding.w, uniforms.grid_padding.x))
+    let cell_fx = (in.position.xy - vec2<f32>(uniforms.grid_padding.w, uniforms.grid_padding.x + uniforms.scroll_offset_y))
                     / uniforms.cell_size;
     let orig_grid_pos = vec2<i32>(floor(cell_fx));
     var grid_pos = orig_grid_pos;
@@ -257,9 +259,9 @@ fn grid_text_vertex(
 
     var quad = cell_pos + size * corner + offset;
 
- // Shift by grid_padding (top/left).
+ // Shift by grid_padding (top/left). Subtract scroll_offset_y for smooth scroll.
     quad.x += uniforms.grid_padding.w;
-    quad.y += uniforms.grid_padding.x;
+    quad.y += uniforms.grid_padding.x + uniforms.scroll_offset_y;
 
     var out: TextVsOut;
     out.position = uniforms.projection * vec4<f32>(quad, 0.0, 1.0);

--- a/sugarloaf/src/grid/shaders/grid_bg.frag.glsl
+++ b/sugarloaf/src/grid/shaders/grid_bg.frag.glsl
@@ -27,6 +27,8 @@ layout(set = 0, binding = 0, std140) uniform Uniforms {
     uint flags;             // offset 148
     uint padding_extend;    // offset 152
     uint input_colorspace;  // offset 156
+    float scroll_offset_y;  // offset 160
+    uvec3 _pad_scroll;      // offset 164
 } uniforms;
 
 // `CellBg` is 4 bytes (uchar4 rgba) in cell.rs. We expose the storage
@@ -89,7 +91,7 @@ void main() {
     // Locate the owning grid cell relative to the grid origin
     // (top-left = grid_padding.w / .x).
     ivec2 orig_grid_pos = ivec2(
-        floor((gl_FragCoord.xy - uniforms.grid_padding.wx) / uniforms.cell_size)
+        floor((gl_FragCoord.xy - vec2(uniforms.grid_padding.w, uniforms.grid_padding.x + uniforms.scroll_offset_y)) / uniforms.cell_size)
     );
     ivec2 grid_pos = orig_grid_pos;
 

--- a/sugarloaf/src/grid/shaders/grid_text.vert.glsl
+++ b/sugarloaf/src/grid/shaders/grid_text.vert.glsl
@@ -36,6 +36,8 @@ layout(set = 0, binding = 0, std140) uniform Uniforms {
     uint flags;
     uint padding_extend;
     uint input_colorspace;
+    float scroll_offset_y;
+    uvec3 _pad_scroll;
 } uniforms;
 
 layout(location = 0) in uvec2 in_glyph_pos;
@@ -106,7 +108,7 @@ void main() {
 
     vec2 quad = cell_pos + size * corner + offset;
     quad.x += uniforms.grid_padding.w; // left
-    quad.y += uniforms.grid_padding.x; // top
+    quad.y += uniforms.grid_padding.x + uniforms.scroll_offset_y; // top + smooth scroll
 
     gl_Position = uniforms.projection * vec4(quad, 0.0, 1.0);
 


### PR DESCRIPTION
## Summary
- Adds an opt-in `scroll.smooth` setting for pixel-level trackpad scrolling while keeping the existing line-based behavior as the default.
- Carries fractional scroll offset through the terminal renderer and grid shaders so scroll movement can render between row boundaries.
- Fetches an extra visible row during smooth scrolling to avoid gaps, resets smooth offset on jump-style scroll commands, and clamps offset at scrollback boundaries.

## Validation
- `cargo fmt --check`
