### PR TITLE
fix(windows): ignore in-band KKP mode requests to avoid ConPTY ESC loss

### DIFF
--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -5710,6 +5710,7 @@ mod tests {
     /// - test_keyboard_mode_reset: Terminal reset behavior on keyboard stack
     /// - test_keyboard_mode_stack_underflow_protection: Stack underflow protection
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_push_pop() {
         let size = CrosswordsSize::new(10, 10);
@@ -5757,6 +5758,7 @@ mod tests {
         assert_eq!(term.keyboard_mode_stack[1], KeyboardModes::NO_MODE.bits()); // Should be cleared
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_stack_wraparound() {
         let size = CrosswordsSize::new(10, 10);
@@ -5816,6 +5818,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_set_replace() {
         let size = CrosswordsSize::new(10, 10);
@@ -5852,6 +5855,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_set_union() {
         let size = CrosswordsSize::new(10, 10);
@@ -5884,6 +5888,7 @@ mod tests {
         assert_eq!(term.keyboard_mode_stack[term.keyboard_mode_idx], expected);
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_set_difference() {
         let size = CrosswordsSize::new(10, 10);
@@ -5919,6 +5924,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_report() {
         let size = CrosswordsSize::new(10, 10);
@@ -5967,6 +5973,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_stack_underflow_protection() {
         let size = CrosswordsSize::new(10, 10);
@@ -6051,6 +6058,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_syncs_with_mode() {
         let size = CrosswordsSize::new(10, 10);

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -1742,19 +1742,26 @@ impl<U: EventListener> Crosswords<U> {
 
     #[inline]
     fn set_keyboard_mode(&mut self, mode: u8, apply: KeyboardModesApplyBehavior) {
-        // println!("{:?}", mode);
-        let active_mode = self.keyboard_mode_stack[self.keyboard_mode_idx];
-        let new_mode = match apply {
-            KeyboardModesApplyBehavior::Replace => mode,
-            KeyboardModesApplyBehavior::Union => active_mode | mode,
-            KeyboardModesApplyBehavior::Difference => active_mode & !mode,
-        };
-        info!("Setting keyboard mode to {new_mode:?}");
-        self.keyboard_mode_stack[self.keyboard_mode_idx] = new_mode;
+        // ConPTY cannot pass KKP input sequences intact — ESC is consumed before
+        // reaching the child process, producing mangled output like `[103;5u`.
+        #[cfg(not(target_os = "windows"))]
+        {
+            // println!("{:?}", mode);
+            let active_mode = self.keyboard_mode_stack[self.keyboard_mode_idx];
+            let new_mode = match apply {
+                KeyboardModesApplyBehavior::Replace => mode,
+                KeyboardModesApplyBehavior::Union => active_mode | mode,
+                KeyboardModesApplyBehavior::Difference => active_mode & !mode,
+            };
+            info!("Setting keyboard mode to {new_mode:?}");
+            self.keyboard_mode_stack[self.keyboard_mode_idx] = new_mode;
 
-        // Sync self.mode with keyboard_mode_stack
-        self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
-        self.mode |= Mode::from(KeyboardModes::from_bits_truncate(new_mode));
+            // Sync self.mode with keyboard_mode_stack
+            self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
+            self.mode |= Mode::from(KeyboardModes::from_bits_truncate(new_mode));
+        }
+        #[cfg(target_os = "windows")]
+        let _ = (mode, apply);
     }
 
     /// Find the beginning of the current line across linewraps.
@@ -2906,39 +2913,51 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
     #[inline]
     fn push_keyboard_mode(&mut self, mode: KeyboardModes) {
-        self.keyboard_mode_idx = self.keyboard_mode_idx.wrapping_add(1);
-        if self.keyboard_mode_idx >= KEYBOARD_MODE_STACK_MAX_DEPTH {
-            self.keyboard_mode_idx %= KEYBOARD_MODE_STACK_MAX_DEPTH;
-        }
-        self.keyboard_mode_stack[self.keyboard_mode_idx] = mode.bits();
+        // ConPTY cannot pass KKP input sequences intact on Windows — no-op here.
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.keyboard_mode_idx = self.keyboard_mode_idx.wrapping_add(1);
+            if self.keyboard_mode_idx >= KEYBOARD_MODE_STACK_MAX_DEPTH {
+                self.keyboard_mode_idx %= KEYBOARD_MODE_STACK_MAX_DEPTH;
+            }
+            self.keyboard_mode_stack[self.keyboard_mode_idx] = mode.bits();
 
-        // Sync self.mode with keyboard_mode_stack
-        self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
-        self.mode |= Mode::from(mode);
+            // Sync self.mode with keyboard_mode_stack
+            self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
+            self.mode |= Mode::from(mode);
+        }
+        #[cfg(target_os = "windows")]
+        let _ = mode;
     }
 
     #[inline]
     fn pop_keyboard_modes(&mut self, to_pop: u16) {
-        // If popping more modes than we have, just clear the stack.
-        if usize::from(to_pop) >= KEYBOARD_MODE_STACK_MAX_DEPTH {
-            self.keyboard_mode_stack.fill(KeyboardModes::NO_MODE.bits());
-            self.keyboard_mode_idx = 0;
-            self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
-            return;
-        }
-        for _ in 0..to_pop {
-            self.keyboard_mode_stack[self.keyboard_mode_idx] =
-                KeyboardModes::NO_MODE.bits();
-            self.keyboard_mode_idx = self.keyboard_mode_idx.wrapping_sub(1);
-            if self.keyboard_mode_idx >= KEYBOARD_MODE_STACK_MAX_DEPTH {
-                self.keyboard_mode_idx %= KEYBOARD_MODE_STACK_MAX_DEPTH;
+        // ConPTY cannot pass KKP input sequences intact on Windows — no-op here.
+        #[cfg(not(target_os = "windows"))]
+        {
+            // If popping more modes than we have, just clear the stack.
+            if usize::from(to_pop) >= KEYBOARD_MODE_STACK_MAX_DEPTH {
+                self.keyboard_mode_stack.fill(KeyboardModes::NO_MODE.bits());
+                self.keyboard_mode_idx = 0;
+                self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
+                return;
             }
-        }
+            for _ in 0..to_pop {
+                self.keyboard_mode_stack[self.keyboard_mode_idx] =
+                    KeyboardModes::NO_MODE.bits();
+                self.keyboard_mode_idx = self.keyboard_mode_idx.wrapping_sub(1);
+                if self.keyboard_mode_idx >= KEYBOARD_MODE_STACK_MAX_DEPTH {
+                    self.keyboard_mode_idx %= KEYBOARD_MODE_STACK_MAX_DEPTH;
+                }
+            }
 
-        // Sync self.mode with keyboard_mode_stack
-        let current_mode = self.keyboard_mode_stack[self.keyboard_mode_idx];
-        self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
-        self.mode |= Mode::from(KeyboardModes::from_bits_truncate(current_mode));
+            // Sync self.mode with keyboard_mode_stack
+            let current_mode = self.keyboard_mode_stack[self.keyboard_mode_idx];
+            self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
+            self.mode |= Mode::from(KeyboardModes::from_bits_truncate(current_mode));
+        }
+        #[cfg(target_os = "windows")]
+        let _ = to_pop;
     }
 
     #[inline]

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -6704,6 +6704,7 @@ mod tests {
     /// - test_keyboard_mode_reset: Terminal reset behavior on keyboard stack
     /// - test_keyboard_mode_stack_underflow_protection: Stack underflow protection
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_push_pop() {
         let size = CrosswordsSize::new(10, 10);
@@ -6751,6 +6752,7 @@ mod tests {
         assert_eq!(term.keyboard_mode_stack[1], KeyboardModes::NO_MODE.bits()); // Should be cleared
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_stack_wraparound() {
         let size = CrosswordsSize::new(10, 10);
@@ -6810,6 +6812,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_set_replace() {
         let size = CrosswordsSize::new(10, 10);
@@ -6846,6 +6849,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_set_union() {
         let size = CrosswordsSize::new(10, 10);
@@ -6878,6 +6882,7 @@ mod tests {
         assert_eq!(term.keyboard_mode_stack[term.keyboard_mode_idx], expected);
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_set_difference() {
         let size = CrosswordsSize::new(10, 10);
@@ -6913,6 +6918,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_report() {
         let size = CrosswordsSize::new(10, 10);
@@ -6961,6 +6967,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_stack_underflow_protection() {
         let size = CrosswordsSize::new(10, 10);
@@ -7081,6 +7088,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_keyboard_mode_syncs_with_mode() {
         let size = CrosswordsSize::new(10, 10);
@@ -7861,6 +7869,7 @@ mod tests {
 
     /// The flag byte an embedder needs to encode keys is the one the terminal
     /// would report; it must survive set, push and pop.
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn keyboard_mode_reports_the_active_flags() {
         use crate::performer::handler::Processor;

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -2359,19 +2359,26 @@ impl<U: EventListener> Crosswords<U> {
 
     #[inline]
     fn set_keyboard_mode(&mut self, mode: u8, apply: KeyboardModesApplyBehavior) {
-        // println!("{:?}", mode);
-        let active_mode = self.keyboard_mode_stack[self.keyboard_mode_idx];
-        let new_mode = match apply {
-            KeyboardModesApplyBehavior::Replace => mode,
-            KeyboardModesApplyBehavior::Union => active_mode | mode,
-            KeyboardModesApplyBehavior::Difference => active_mode & !mode,
-        };
-        info!("Setting keyboard mode to {new_mode:?}");
-        self.keyboard_mode_stack[self.keyboard_mode_idx] = new_mode;
+        // ConPTY cannot pass KKP input sequences intact — ESC is consumed before
+        // reaching the child process, producing mangled output like `[103;5u`.
+        #[cfg(not(target_os = "windows"))]
+        {
+            // println!("{:?}", mode);
+            let active_mode = self.keyboard_mode_stack[self.keyboard_mode_idx];
+            let new_mode = match apply {
+                KeyboardModesApplyBehavior::Replace => mode,
+                KeyboardModesApplyBehavior::Union => active_mode | mode,
+                KeyboardModesApplyBehavior::Difference => active_mode & !mode,
+            };
+            info!("Setting keyboard mode to {new_mode:?}");
+            self.keyboard_mode_stack[self.keyboard_mode_idx] = new_mode;
 
-        // Sync self.mode with keyboard_mode_stack
-        self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
-        self.mode |= Mode::from(KeyboardModes::from_bits_truncate(new_mode));
+            // Sync self.mode with keyboard_mode_stack
+            self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
+            self.mode |= Mode::from(KeyboardModes::from_bits_truncate(new_mode));
+        }
+        #[cfg(target_os = "windows")]
+        let _ = (mode, apply);
     }
 
     /// Find the beginning of the current line across linewraps.
@@ -3572,39 +3579,51 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
     #[inline]
     fn push_keyboard_mode(&mut self, mode: KeyboardModes) {
-        self.keyboard_mode_idx = self.keyboard_mode_idx.wrapping_add(1);
-        if self.keyboard_mode_idx >= KEYBOARD_MODE_STACK_MAX_DEPTH {
-            self.keyboard_mode_idx %= KEYBOARD_MODE_STACK_MAX_DEPTH;
-        }
-        self.keyboard_mode_stack[self.keyboard_mode_idx] = mode.bits();
+        // ConPTY cannot pass KKP input sequences intact on Windows — no-op here.
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.keyboard_mode_idx = self.keyboard_mode_idx.wrapping_add(1);
+            if self.keyboard_mode_idx >= KEYBOARD_MODE_STACK_MAX_DEPTH {
+                self.keyboard_mode_idx %= KEYBOARD_MODE_STACK_MAX_DEPTH;
+            }
+            self.keyboard_mode_stack[self.keyboard_mode_idx] = mode.bits();
 
-        // Sync self.mode with keyboard_mode_stack
-        self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
-        self.mode |= Mode::from(mode);
+            // Sync self.mode with keyboard_mode_stack
+            self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
+            self.mode |= Mode::from(mode);
+        }
+        #[cfg(target_os = "windows")]
+        let _ = mode;
     }
 
     #[inline]
     fn pop_keyboard_modes(&mut self, to_pop: u16) {
-        // If popping more modes than we have, just clear the stack.
-        if usize::from(to_pop) >= KEYBOARD_MODE_STACK_MAX_DEPTH {
-            self.keyboard_mode_stack.fill(KeyboardModes::NO_MODE.bits());
-            self.keyboard_mode_idx = 0;
-            self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
-            return;
-        }
-        for _ in 0..to_pop {
-            self.keyboard_mode_stack[self.keyboard_mode_idx] =
-                KeyboardModes::NO_MODE.bits();
-            self.keyboard_mode_idx = self.keyboard_mode_idx.wrapping_sub(1);
-            if self.keyboard_mode_idx >= KEYBOARD_MODE_STACK_MAX_DEPTH {
-                self.keyboard_mode_idx %= KEYBOARD_MODE_STACK_MAX_DEPTH;
+        // ConPTY cannot pass KKP input sequences intact on Windows — no-op here.
+        #[cfg(not(target_os = "windows"))]
+        {
+            // If popping more modes than we have, just clear the stack.
+            if usize::from(to_pop) >= KEYBOARD_MODE_STACK_MAX_DEPTH {
+                self.keyboard_mode_stack.fill(KeyboardModes::NO_MODE.bits());
+                self.keyboard_mode_idx = 0;
+                self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
+                return;
             }
-        }
+            for _ in 0..to_pop {
+                self.keyboard_mode_stack[self.keyboard_mode_idx] =
+                    KeyboardModes::NO_MODE.bits();
+                self.keyboard_mode_idx = self.keyboard_mode_idx.wrapping_sub(1);
+                if self.keyboard_mode_idx >= KEYBOARD_MODE_STACK_MAX_DEPTH {
+                    self.keyboard_mode_idx %= KEYBOARD_MODE_STACK_MAX_DEPTH;
+                }
+            }
 
-        // Sync self.mode with keyboard_mode_stack
-        let current_mode = self.keyboard_mode_stack[self.keyboard_mode_idx];
-        self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
-        self.mode |= Mode::from(KeyboardModes::from_bits_truncate(current_mode));
+            // Sync self.mode with keyboard_mode_stack
+            let current_mode = self.keyboard_mode_stack[self.keyboard_mode_idx];
+            self.mode &= !Mode::KITTY_KEYBOARD_PROTOCOL;
+            self.mode |= Mode::from(KeyboardModes::from_bits_truncate(current_mode));
+        }
+        #[cfg(target_os = "windows")]
+        let _ = to_pop;
     }
 
     #[inline]


### PR DESCRIPTION
## Problem

When a child process (e.g. zellij, neovim) sends `\x1b[=1u` to enable
Kitty Keyboard Protocol mode, Rio honours the request and starts
encoding keypresses as KKP sequences (`\x1b[codepoint;modifiersu`).

On Windows, these sequences are written to ConPTY's input pipe.
ConPTY processes the `\x1b[` prefix as the start of a CSI sequence
and **consumes the ESC byte** before the bytes reach the child process.
The child receives mangled output like `[103;5u` instead of
`\x1b[103;5u`, breaking keyboard input entirely.

Example: pressing Ctrl+G inside zellij (which requests KKP on startup)
produces `[103;5u[103;5u[103;5u` in the terminal instead of the
expected action.

## Root cause

`set_keyboard_mode`, `push_keyboard_mode`, and `pop_keyboard_modes` in
`Crosswords` have no platform guard. On Windows, ConPTY is the only PTY
mechanism, and it cannot pass KKP input sequences intact.

## Fix

Make `set_keyboard_mode`, `push_keyboard_mode`, and `pop_keyboard_modes`
no-ops on Windows using `#[cfg(not(target_os = "windows"))]`, so that
in-band KKP mode requests from child processes are silently ignored.

`report_keyboard_mode` is **intentionally left unchanged** — it correctly
reports mode 0 on Windows. Well-behaved applications (neovim, etc.) that
query the keyboard mode before activating KKP will receive the correct
response and fall back to traditional key encoding automatically.

## Testing

Verified on Windows 11 Pro: zellij running inside Rio now receives
correct key sequences (Ctrl+G triggers the expected action rather than
producing literal `[103;5u` output).

## Notes

This is a compile-time guard rather than a runtime config option.
ConPTY's inability to pass KKP input sequences is a fundamental
architectural constraint, not a version-dependent behaviour. If a future
Windows/ConPTY version correctly passes KKP sequences through, this
guard can be revisited.

---
*Branch rebased onto current `main` and verified (build, clippy, `cargo test -p rio-backend`: 545 passed) with assistance from Claude Code. The fix itself predates that and was verified manually against zellij/neovim on Windows 11.*
