### PR TITLE
feat: ctrl+wheel font-size zoom

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1,3 +1,4 @@
+use crate::bindings::FontSizeAction;
 use crate::event::{ClickState, EventPayload, EventProxy, RioEvent, RioEventType};
 use crate::ime::Preedit;
 use crate::renderer::utils::update_colors_based_on_theme;
@@ -1560,6 +1561,34 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                 match delta {
                     MouseScrollDelta::LineDelta(columns, lines) => {
+                        // Ctrl+wheel zooms font size (matches WezTerm, Windows
+                        // Terminal, iTerm). Skipped when the app is in
+                        // mouse-reporting mode so tmux mouse-on / vim mouse
+                        // keep working, or when the user opted out via config.
+                        // Touchpad (PixelDelta) is intentionally not handled
+                        // here to avoid a single gesture firing many zoom
+                        // steps; mouse wheels emit LineDelta.
+                        let mods = route.window.screen.modifiers.state();
+                        if self.config.mouse.wheel_zoom
+                            && mods.control_key()
+                            && !mods.shift_key()
+                            && !route.window.screen.mouse_mode()
+                        {
+                            if lines > 0.0 {
+                                route
+                                    .window
+                                    .screen
+                                    .change_font_size(FontSizeAction::Increase);
+                            } else if lines < 0.0 {
+                                route
+                                    .window
+                                    .screen
+                                    .change_font_size(FontSizeAction::Decrease);
+                            }
+                            route.request_redraw();
+                            return;
+                        }
+
                         let font_size =
                             route.window.screen.ctx().current().dimension.font_size;
                         if font_size > 0.0 {

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -6,6 +6,7 @@ pub mod effects;
 pub mod hints;
 pub mod keyboard;
 pub mod layout;
+pub mod mouse;
 pub mod navigation;
 pub mod platform;
 pub mod renderer;
@@ -20,6 +21,7 @@ use crate::config::defaults::*;
 use crate::config::hints::Hints;
 use crate::config::keyboard::Keyboard;
 use crate::config::layout::{Margin, Panel};
+use crate::config::mouse::Mouse;
 use crate::config::navigation::Navigation;
 use crate::config::platform::{Platform, PlatformConfig};
 use crate::config::renderer::Renderer;
@@ -152,6 +154,8 @@ pub struct Config {
         alias = "hide-cursor-when-typing"
     )]
     pub hide_cursor_when_typing: bool,
+    #[serde(default = "Mouse::default")]
+    pub mouse: Mouse,
     #[serde(default = "Renderer::default")]
     pub renderer: Renderer,
     #[serde(default = "bool::default", rename = "draw-bold-text-with-light-colors")]
@@ -658,6 +662,7 @@ impl Default for Config {
             confirm_before_quit: true,
             copy_on_select: false,
             hide_cursor_when_typing: false,
+            mouse: Mouse::default(),
             draw_bold_text_with_light_colors: false,
             hints: Hints::default(),
             bell: Bell::default(),

--- a/rio-backend/src/config/mouse.rs
+++ b/rio-backend/src/config/mouse.rs
@@ -1,0 +1,16 @@
+use crate::config::defaults::default_bool_true;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Mouse {
+    #[serde(default = "default_bool_true", rename = "wheel-zoom")]
+    pub wheel_zoom: bool,
+}
+
+impl Default for Mouse {
+    fn default() -> Self {
+        Mouse {
+            wheel_zoom: default_bool_true(),
+        }
+    }
+}


### PR DESCRIPTION
Closes #792.

Ctrl+mouse-wheel zooms the font size, matching WezTerm, Windows Terminal, iTerm, and similar terminals. The feature has been requested since November 2024.

Hooks into the existing `MouseWheel::LineDelta` arm: when Ctrl is held (and Shift is not, and the focused app is not in mouse-reporting mode), wheel-up calls `change_font_size(Increase)` and wheel-down calls `Decrease`, reusing the handler the keyboard shortcuts already use. Mouse-reporting mode (`tmux mouse on`, vim `:set mouse=a`) is respected so wheel events still pass through unchanged when the inner app wants them.

Touchpad (`PixelDelta`) input intentionally falls through to the existing scroll path. Touchpad gestures fire many small deltas per swipe, and wiring zoom into them naively gives ~12 zoom steps per swipe; a debounced/threshold-based variant is worth a follow-up once the simpler wheel case is in.

Opt out via:

```toml
[mouse]
wheel-zoom = false
```

Defaults to `true` so the feature is discoverable.

Verified locally on Windows 11.

> Aside: `main` (at `a7766425b0`, "update to wgpu 29.0.3") currently fails to build on Windows MSVC because of a `windows` crate version conflict between `wgpu-hal` 29.0.3 (uses `windows` 0.62) and `gpu_allocator` (still on 0.54) in the dx12 backend. This change was developed and tested against `v0.4.5` and applies cleanly. Happy to file a separate issue for the build break if it'd help.