### PR TITLE
Fix Quit action being silently dropped (#892)

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -419,7 +419,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
             }
-            RioEventType::Rio(RioEvent::Exit) => {
+            RioEventType::Rio(RioEvent::Quit) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     if self.config.confirm_before_quit {
                         route.confirm_quit();

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1774,6 +1774,12 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                                 "yes (y)",
                                 "no (n)",
                             );
+                            // The dialog is an overlay drawn outside the
+                            // terminal's damage tracking. `render()` discards
+                            // the frame when no panel is dirty, which would
+                            // drop the overlay on idle frames — force a
+                            // present so the dialog reliably shows.
+                            route.window.screen.mark_dirty();
                         }
 
                         if let Some(window_update) = route.window.screen.render() {

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -331,9 +331,11 @@ impl Route<'_> {
                 match &key_event.logical_key {
                     Key::Character(c) if c.as_str() == "n" || c.as_str() == "N" => {
                         self.path = RoutePath::Terminal;
+                        self.request_overlay_redraw();
                     }
                     Key::Named(NamedKey::Escape) => {
                         self.path = RoutePath::Terminal;
+                        self.request_overlay_redraw();
                     }
                     Key::Character(c) if c.as_str() == "y" || c.as_str() == "Y" => {
                         self.quit();

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -197,9 +197,6 @@ pub enum RioEvent {
         body: String,
     },
 
-    /// Shutdown request.
-    Exit,
-
     /// Quit request.
     Quit,
 
@@ -279,7 +276,6 @@ impl Debug for RioEvent {
             RioEvent::DesktopNotification { title, body } => {
                 write!(f, "DesktopNotification({title}, {body})")
             }
-            RioEvent::Exit => write!(f, "Exit"),
             RioEvent::Quit => write!(f, "Quit"),
             RioEvent::CloseTerminal(route) => write!(f, "CloseTerminal {route}"),
             RioEvent::CreateWindow => write!(f, "CreateWindow"),


### PR DESCRIPTION
## Summary

The `Quit` action does nothing on Linux/Windows: keyboard binds and the command palette both call `ContextManager::quit()`, which emits `RioEvent::Quit` — but `application.rs` only has a handler for `RioEvent::Exit`, so the event falls through and is silently dropped. (macOS is unaffected because it quits via the `applicationShouldTerminate` path.)

The two events are redundant halves of the same intent:
- `RioEvent::Quit` — sent (`context/mod.rs:673`) but never handled
- `RioEvent::Exit` — handled (`application.rs:422`, with the `confirm_before_quit` logic) but never sent

This consolidates them: the handler now matches `RioEvent::Quit` (consistent with `Action::Quit`, `PaletteAction::Quit`, `ContextManager::quit`, `Route::quit`), and the dead `RioEvent::Exit` variant is removed. The existing handler already respects `confirm_before_quit` and otherwise exits, so no behavior is lost.

Fixes #892.

## Test plan

- [x] `cargo check -p rioterm -p rio-backend` passes with no new warnings
- [x] Confirmed on Linux (Arch/Wayland/GNOME): a custom `[bindings]` Quit entry now quits Rio
- [ ] macOS Cmd+Q still quits (unchanged path)
- [ ] Windows quit binding works

Note: `Action::Quit` only ships in the macOS default bindings, so Linux/Windows users still need a custom bind or the command palette to trigger it — but those paths now work. Adding a cross-platform default keybind is left as a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)