### PR TITLE
feat: maximize/zoom the focused split (ToggleSplitZoom)

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1354,8 +1354,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 let scale_factor = route.window.screen.sugarloaf.scale_factor();
                 let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
                 let num_tabs = route.window.screen.ctx().len();
+                let zoom = route.window.screen.context_manager.current_pane_zoom();
                 let nav = &route.window.screen.renderer.navigation;
-                if nav.island_visible(num_tabs) && y <= island_height_px {
+                if nav.island_visible_with(num_tabs, zoom) && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
                 }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1613,8 +1613,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 let scale_factor = route.window.screen.sugarloaf.scale_factor();
                 let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
                 let num_tabs = route.window.screen.ctx().len();
+                let zoom = route.window.screen.context_manager.current_pane_zoom();
                 let nav = &route.window.screen.renderer.navigation;
-                if nav.island_visible(num_tabs) && y <= island_height_px {
+                if nav.island_visible_with(num_tabs, zoom) && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
                 }

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -262,6 +262,7 @@ impl From<String> for Action {
             "movedividerdown" => Some(Action::MoveDividerDown),
             "movedividerleft" => Some(Action::MoveDividerLeft),
             "movedividerright" => Some(Action::MoveDividerRight),
+            "togglesplitzoom" => Some(Action::ToggleSplitZoom),
             "togglevimode" => Some(Action::ToggleViMode),
             "toggleappearancetheme" => Some(Action::ToggleAppearanceTheme),
             "togglefullscreen" => Some(Action::ToggleFullscreen),
@@ -501,6 +502,10 @@ pub enum Action {
 
     /// Move divider right
     MoveDividerRight,
+
+    /// Temporarily maximize the focused split to fill the tab,
+    /// toggling back to the previous layout on a second press.
+    ToggleSplitZoom,
 
     /// Toggle the command palette overlay.
     OpenCommandPalette,
@@ -1061,6 +1066,7 @@ pub fn platform_key_bindings(
             "d", ModifiersState::SUPER | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SplitDown;
             "]", ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectNextSplit;
             "[", ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectPrevSplit;
+            "x", ModifiersState::SUPER | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::ToggleSplitZoom;
             Key::Named(ArrowUp), ModifiersState::CONTROL | ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerUp;
             Key::Named(ArrowDown), ModifiersState::CONTROL | ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerDown;
             Key::Named(ArrowLeft), ModifiersState::CONTROL | ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerLeft;
@@ -1126,6 +1132,7 @@ pub fn platform_key_bindings(
             "d", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SplitDown;
             "]", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectNextSplit;
             "[", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectPrevSplit;
+            "x", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::ToggleSplitZoom;
             Key::Named(ArrowUp), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerUp;
             Key::Named(ArrowDown), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerDown;
             Key::Named(ArrowLeft), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerLeft;
@@ -1196,6 +1203,7 @@ pub fn platform_key_bindings(
             "d", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SplitDown;
             "]", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectNextSplit;
             "[", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectPrevSplit;
+            "x", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::ToggleSplitZoom;
             Key::Named(ArrowUp), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerUp;
             Key::Named(ArrowDown), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerDown;
             Key::Named(ArrowLeft), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerLeft;

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -266,6 +266,7 @@ impl From<String> for Action {
             "movedividerdown" => Some(Action::MoveDividerDown),
             "movedividerleft" => Some(Action::MoveDividerLeft),
             "movedividerright" => Some(Action::MoveDividerRight),
+            "togglesplitzoom" => Some(Action::ToggleSplitZoom),
             "togglevimode" => Some(Action::ToggleViMode),
             "toggleappearancetheme" => Some(Action::ToggleAppearanceTheme),
             "togglefullscreen" => Some(Action::ToggleFullscreen),
@@ -519,6 +520,10 @@ pub enum Action {
 
     /// Move divider right
     MoveDividerRight,
+
+    /// Temporarily maximize the focused split to fill the tab,
+    /// toggling back to the previous layout on a second press.
+    ToggleSplitZoom,
 
     /// Toggle the command palette overlay.
     OpenCommandPalette,
@@ -1179,6 +1184,7 @@ pub fn platform_key_bindings(
             "d", ModifiersState::SUPER | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SplitDown;
             "]", ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectNextSplit;
             "[", ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectPrevSplit;
+            "x", ModifiersState::SUPER | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::ToggleSplitZoom;
             Key::Named(ArrowUp), ModifiersState::CONTROL | ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerUp;
             Key::Named(ArrowDown), ModifiersState::CONTROL | ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerDown;
             Key::Named(ArrowLeft), ModifiersState::CONTROL | ModifiersState::SUPER, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerLeft;
@@ -1242,6 +1248,7 @@ pub fn platform_key_bindings(
             "d", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SplitDown;
             "]", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectNextSplit;
             "[", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectPrevSplit;
+            "x", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::ToggleSplitZoom;
             Key::Named(ArrowUp), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerUp;
             Key::Named(ArrowDown), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerDown;
             Key::Named(ArrowLeft), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerLeft;
@@ -1310,6 +1317,7 @@ pub fn platform_key_bindings(
             "d", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SplitDown;
             "]", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectNextSplit;
             "[", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::SelectPrevSplit;
+            "x", ModifiersState::CONTROL | ModifiersState::SHIFT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::ToggleSplitZoom;
             Key::Named(ArrowUp), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerUp;
             Key::Named(ArrowDown), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerDown;
             Key::Named(ArrowLeft), ModifiersState::CONTROL | ModifiersState::SHIFT | ModifiersState::ALT, ~BindingMode::SEARCH, ~BindingMode::VI; Action::MoveDividerLeft;

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -571,6 +571,19 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         self.current_mut().renderable_content.last_typing = Some(Instant::now());
     }
 
+    /// Toggle zoom on the focused split of the current grid.
+    #[inline]
+    pub fn toggle_split_zoom(&mut self, sugarloaf: &mut Sugarloaf) -> bool {
+        self.contexts[self.current_index].toggle_zoom(sugarloaf)
+    }
+
+    /// Drop the current grid out of zoom (if zoomed). Returns `true`
+    /// when a zoom was cleared.
+    #[inline]
+    pub fn clear_split_zoom(&mut self, sugarloaf: &mut Sugarloaf) -> bool {
+        self.contexts[self.current_index].clear_zoom(sugarloaf)
+    }
+
     #[inline]
     pub fn select_next_split(&mut self) {
         self.contexts[self.current_index].select_next_split();

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -801,6 +801,25 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         &self.contexts[self.current_index]
     }
 
+    /// Whether the grid (tab) at `index` has a maximized (zoomed) pane.
+    /// Per-tab predicate used when drawing the tab strip's zoom glyph.
+    #[inline]
+    pub fn grid_is_zoomed(&self, index: usize) -> bool {
+        self.contexts
+            .get(index)
+            .is_some_and(|grid| grid.is_zoomed())
+    }
+
+    /// Zoom state of the current grid, as the named [`PaneZoom`] the
+    /// layout/island/input visibility checks consume — keeps callers
+    /// from re-deriving it from a bare bool.
+    #[inline]
+    pub fn current_pane_zoom(&self) -> rio_backend::config::navigation::PaneZoom {
+        rio_backend::config::navigation::PaneZoom::from_zoomed(
+            self.grid_is_zoomed(self.current_index),
+        )
+    }
+
     /// Get panel borders for the current grid (returns empty vec if single panel)
     #[inline]
     pub fn get_panel_borders(&self) -> Vec<Rect> {

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -841,6 +841,25 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         &self.contexts[self.current_index]
     }
 
+    /// Whether the grid (tab) at `index` has a maximized (zoomed) pane.
+    /// Per-tab predicate used when drawing the tab strip's zoom glyph.
+    #[inline]
+    pub fn grid_is_zoomed(&self, index: usize) -> bool {
+        self.contexts
+            .get(index)
+            .is_some_and(|grid| grid.is_zoomed())
+    }
+
+    /// Zoom state of the current grid, as the named [`PaneZoom`] the
+    /// layout/island/input visibility checks consume — keeps callers
+    /// from re-deriving it from a bare bool.
+    #[inline]
+    pub fn current_pane_zoom(&self) -> rio_backend::config::navigation::PaneZoom {
+        rio_backend::config::navigation::PaneZoom::from_zoomed(
+            self.grid_is_zoomed(self.current_index),
+        )
+    }
+
     #[inline]
     pub fn get_panel_borders(&self) -> Vec<Rect> {
         self.contexts[self.current_index].get_panel_borders()

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -588,6 +588,19 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         self.current_mut().renderable_content.last_typing = Some(Instant::now());
     }
 
+    /// Toggle zoom on the focused split of the current grid.
+    #[inline]
+    pub fn toggle_split_zoom(&mut self, sugarloaf: &mut Sugarloaf) -> bool {
+        self.contexts[self.current_index].toggle_zoom(sugarloaf)
+    }
+
+    /// Drop the current grid out of zoom (if zoomed). Returns `true`
+    /// when a zoom was cleared.
+    #[inline]
+    pub fn clear_split_zoom(&mut self, sugarloaf: &mut Sugarloaf) -> bool {
+        self.contexts[self.current_index].clear_zoom(sugarloaf)
+    }
+
     #[inline]
     pub fn select_next_split(&mut self) {
         self.contexts[self.current_index].select_next_split();

--- a/frontends/rioterm/src/layout/compute_tests.rs
+++ b/frontends/rioterm/src/layout/compute_tests.rs
@@ -647,3 +647,132 @@ fn test_split_inside_resized_panel_preserves_proportions() {
         "Bottom (bottom half) should be ~400px tall, got {bottom_h}"
     );
 }
+
+// --- ToggleSplitZoom -----------------------------------------------------
+
+fn zoom_test_dimension() -> ContextDimension {
+    let dims = TextDimensions {
+        width: 8.0,
+        height: 16.0,
+        scale: 1.0,
+    };
+    ContextDimension::build(
+        800.0,
+        600.0,
+        dims,
+        cell_for(dims),
+        1.0,
+        14.0,
+        Margin::all(0.0),
+    )
+}
+
+/// Build a grid with `n` panels (each a right-split of the previous
+/// focus). Mirrors `split_right` but stays off sugarloaf by recomputing
+/// with `calculate_positions` instead of `apply_taffy_layout`.
+fn zoom_test_grid(n: usize) -> ContextGrid<rio_backend::event::VoidListener> {
+    use crate::context::create_mock_context;
+    use rio_backend::event::VoidListener;
+    use rio_window::window::WindowId;
+
+    let first =
+        create_mock_context(VoidListener {}, WindowId::from(0), 0, zoom_test_dimension());
+    let mut grid = ContextGrid::new(
+        first,
+        Margin::all(0.0),
+        [0.0; 4],
+        [0.0; 4],
+        rio_backend::config::layout::Panel::default(),
+    );
+
+    for i in 1..n {
+        let ctx = create_mock_context(
+            VoidListener {},
+            WindowId::from(0),
+            i,
+            zoom_test_dimension(),
+        );
+        let new_node = grid.try_split_right().expect("split should succeed");
+        grid.inner.insert(new_node, ContextGridItem::new(ctx));
+        grid.current = new_node;
+        grid.calculate_positions();
+    }
+    grid
+}
+
+fn visible_count(grid: &ContextGrid<rio_backend::event::VoidListener>) -> usize {
+    grid.inner.values().filter(|i| !i.is_hidden()).count()
+}
+
+#[test]
+fn test_zoom_hides_siblings_then_restores() {
+    let mut grid = zoom_test_grid(3);
+    assert_eq!(grid.panel_count(), 3);
+    assert!(!grid.is_zoomed());
+    assert_eq!(visible_count(&grid), 3);
+
+    let focused = grid.current;
+    grid.apply_zoom_styles(focused);
+    grid.calculate_positions();
+
+    assert!(grid.is_zoomed());
+    // Every sibling along the path to the root is hidden.
+    assert_eq!(grid.zoom_hidden.len(), 2);
+    for &node in &grid.zoom_hidden {
+        assert_eq!(grid.tree.style(node).unwrap().display, Display::None);
+    }
+    // Only the focused panel still has area.
+    assert_eq!(visible_count(&grid), 1);
+    assert!(!grid.inner[&focused].is_hidden());
+
+    grid.restore_zoom_styles();
+    grid.calculate_positions();
+
+    assert!(!grid.is_zoomed());
+    assert!(grid.zoom_hidden.is_empty());
+    assert_eq!(visible_count(&grid), 3);
+}
+
+#[test]
+fn test_zoomed_panel_fills_like_a_lone_panel() {
+    let solo = zoom_test_grid(1);
+    let solo_rect = solo.inner.values().next().unwrap().layout_rect;
+
+    let mut grid = zoom_test_grid(3);
+    let focused = grid.current;
+
+    // Before zoom the focused panel is only a fraction of the area.
+    assert!(grid.inner[&focused].layout_rect[2] < solo_rect[2]);
+
+    grid.apply_zoom_styles(focused);
+    grid.calculate_positions();
+
+    let zoomed_rect = grid.inner[&focused].layout_rect;
+    assert!(
+        (zoomed_rect[2] - solo_rect[2]).abs() < 1.0
+            && (zoomed_rect[3] - solo_rect[3]).abs() < 1.0,
+        "zoomed panel {zoomed_rect:?} should fill like a lone panel {solo_rect:?}"
+    );
+}
+
+#[test]
+fn test_zoom_excludes_hidden_panels_from_unfocused_dim() {
+    // Regression: the unfocused-split dim overlay used to tint hidden
+    // (zoomed-away) panels, sizing the rect from their stale dimension.
+    // That painted old-sized shadows over the maximized panel. A zoomed
+    // grid must report no panels to dim at all.
+    let mut grid = zoom_test_grid(3);
+    let focused = grid.current;
+
+    // Without zoom, the other two panels are dimmed.
+    assert_eq!(grid.unfocused_panels(focused).count(), 2);
+
+    grid.apply_zoom_styles(focused);
+    grid.calculate_positions();
+    // Zoomed: the focused panel fills the area and nothing is dimmed.
+    assert_eq!(grid.unfocused_panels(focused).count(), 0);
+
+    grid.restore_zoom_styles();
+    grid.calculate_positions();
+    assert_eq!(grid.unfocused_panels(focused).count(), 2);
+}

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -117,6 +117,14 @@ pub struct ContextGrid<T: EventListener> {
     tree: TaffyTree<()>,
     root_node: NodeId,
     border_config: BorderConfig,
+    /// When `Some`, the panel maximized to fill the whole tab.
+    /// Siblings along its path to the root are hidden via
+    /// `Display::None` so Taffy lays the focused panel out exactly
+    /// as if it were the only one.
+    zoomed: Option<NodeId>,
+    /// Nodes set to `Display::None` for the active zoom, restored to
+    /// `Display::Flex` when zoom is cleared.
+    zoom_hidden: Vec<NodeId>,
 }
 
 pub struct ContextGridItem<T: EventListener> {
@@ -140,6 +148,15 @@ impl<T: rio_backend::event::EventListener> ContextGridItem<T> {
     #[inline]
     pub fn context_mut(&mut self) -> &mut Context<T> {
         &mut self.val
+    }
+
+    /// A panel is hidden when its layout collapsed to zero area —
+    /// today that only happens to the siblings of a zoomed panel,
+    /// which Taffy lays out with `Display::None`. Hidden panels are
+    /// skipped by the resize and render passes.
+    #[inline]
+    pub fn is_hidden(&self) -> bool {
+        self.layout_rect[2] <= 0.0 || self.layout_rect[3] <= 0.0
     }
 
     /// Previously stashed panel position into the rich-text object's
@@ -231,6 +248,8 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             tree,
             root_node,
             border_config,
+            zoomed: None,
+            zoom_hidden: Vec::new(),
         };
         grid.calculate_positions();
         grid
@@ -340,7 +359,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
     /// Find a draggable border near the given mouse position (physical pixels).
     /// Returns None if no border is within the hit threshold.
     pub fn find_border_at_position(&self, x: f32, y: f32) -> Option<PanelBorder> {
-        if self.inner.len() <= 1 {
+        if self.inner.len() <= 1 || self.is_zoomed() {
             return None;
         }
 
@@ -416,7 +435,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
     /// Get separator lines between adjacent panels for rendering.
     pub fn get_panel_borders(&self) -> Vec<Rect> {
-        if !self.should_draw_borders() {
+        if !self.should_draw_borders() || self.is_zoomed() {
             return vec![];
         }
 
@@ -897,8 +916,14 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
         let is_multi_panel = self.inner.len() > 1;
 
         for item in self.inner.values_mut() {
-            let [abs_x, abs_y, width, height] = item.layout_rect;
+            // Panels hidden by a zoom collapse to zero area in Taffy.
+            // Leave their terminal at its previous size rather than
+            // reflowing it to nothing.
+            if item.is_hidden() {
+                continue;
+            }
 
+            let [abs_x, abs_y, width, height] = item.layout_rect;
             let x = (abs_x + self.scaled_margin.left) / scale;
             let y = (abs_y + self.scaled_margin.top) / scale;
 
@@ -922,6 +947,108 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             // panel metadata.
             let _ = (x, y, abs_x, abs_y, width, height, is_multi_panel);
         }
+        true
+    }
+
+    #[inline]
+    pub fn is_zoomed(&self) -> bool {
+        self.zoomed.is_some()
+    }
+
+    /// Panels that should be tinted as "unfocused": every panel other
+    /// than `active`, excluding ones hidden by a zoom. Hidden panels
+    /// are skipped so they don't paint a stale-sized shadow over the
+    /// maximized panel.
+    pub fn unfocused_panels(
+        &self,
+        active: NodeId,
+    ) -> impl Iterator<Item = &ContextGridItem<T>> {
+        self.inner
+            .iter()
+            .filter(move |(key, item)| **key != active && !item.is_hidden())
+            .map(|(_, item)| item)
+    }
+
+    /// Hide every sibling along the path from `target` up to the root by
+    /// setting it to `Display::None`. The visible chain keeps its
+    /// `flex_grow`, so the focused leaf expands to fill the whole area.
+    /// Records the hidden nodes so the change can be reverted exactly.
+    fn apply_zoom_styles(&mut self, target: NodeId) {
+        let mut hidden = Vec::new();
+        let mut node = target;
+        while let Some(parent) = self.tree.parent(node) {
+            if let Ok(siblings) = self.tree.children(parent) {
+                for sibling in siblings {
+                    if sibling == node {
+                        continue;
+                    }
+                    if let Ok(mut style) = self.tree.style(sibling).cloned() {
+                        style.display = Display::None;
+                        if self.tree.set_style(sibling, style).is_ok() {
+                            hidden.push(sibling);
+                        }
+                    }
+                }
+            }
+            node = parent;
+        }
+        self.zoom_hidden = hidden;
+        self.zoomed = Some(target);
+    }
+
+    /// Revert the `Display::None` overrides applied by `apply_zoom_styles`.
+    /// Does not recompute layout — callers that need fresh geometry
+    /// invoke `apply_taffy_layout` afterwards.
+    fn restore_zoom_styles(&mut self) {
+        for node in std::mem::take(&mut self.zoom_hidden) {
+            if let Ok(mut style) = self.tree.style(node).cloned() {
+                style.display = Display::Flex;
+                let _ = self.tree.set_style(node, style);
+            }
+        }
+        self.zoomed = None;
+    }
+
+    /// Force every panel to fully repaint on the next frame. Zooming
+    /// changes which panels are visible without changing the focused
+    /// route, so the renderer's per-panel damage gate would otherwise
+    /// keep the just-revealed panels stale.
+    fn mark_all_panels_full_damage(&mut self) {
+        for item in self.inner.values_mut() {
+            item.val
+                .renderable_content
+                .pending_update
+                .set_terminal_damage(rio_backend::event::TerminalDamage::Full);
+        }
+    }
+
+    /// Toggle zoom on the focused split. Returns `true` when the zoom
+    /// state changed (so the caller can request a repaint). A single
+    /// panel can't be zoomed — there's nothing to hide.
+    pub fn toggle_zoom(&mut self, sugarloaf: &mut Sugarloaf) -> bool {
+        if self.is_zoomed() {
+            self.restore_zoom_styles();
+        } else {
+            if self.inner.len() <= 1 {
+                return false;
+            }
+            self.apply_zoom_styles(self.current);
+        }
+        self.apply_taffy_layout(sugarloaf);
+        self.mark_all_panels_full_damage();
+        true
+    }
+
+    /// Clear an active zoom (if any) and restore the normal layout.
+    /// Returns `true` when a zoom was cleared. Used by navigation and
+    /// other actions that should drop out of zoom first.
+    pub fn clear_zoom(&mut self, sugarloaf: &mut Sugarloaf) -> bool {
+        if !self.is_zoomed() {
+            return false;
+        }
+        self.restore_zoom_styles();
+        self.apply_taffy_layout(sugarloaf);
+        self.mark_all_panels_full_damage();
         true
     }
 
@@ -1243,6 +1370,12 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             return;
         }
 
+        // Drop any zoom first: the zoomed panel may be the one being
+        // removed, and the siblings must be visible again afterwards.
+        if self.is_zoomed() {
+            self.restore_zoom_styles();
+        }
+
         let to_remove = self.current;
 
         if !self.inner.contains_key(&to_remove) {
@@ -1316,6 +1449,12 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             return;
         }
 
+        // Splitting while zoomed drops out of zoom first so the new
+        // layout shows every panel.
+        if self.is_zoomed() {
+            self.restore_zoom_styles();
+        }
+
         // Create taffy node first, then item
         if let Ok(new_node) = self.try_split_right() {
             let new_context = ContextGridItem::new(context);
@@ -1329,6 +1468,12 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
     pub fn split_down(&mut self, context: Context<T>, sugarloaf: &mut Sugarloaf) {
         if !self.inner.contains_key(&self.current) {
             return;
+        }
+
+        // Splitting while zoomed drops out of zoom first so the new
+        // layout shows every panel.
+        if self.is_zoomed() {
+            self.restore_zoom_styles();
         }
 
         // Create taffy node first, then item

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -435,6 +435,8 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
     /// Get separator lines between adjacent panels for rendering.
     pub fn get_panel_borders(&self) -> Vec<Rect> {
+        // No separators while zoomed: only the maximized panel is
+        // visible, so there's nothing to divide.
         if !self.should_draw_borders() || self.is_zoomed() {
             return vec![];
         }

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -441,6 +441,8 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
     /// Get separator lines between adjacent panels for rendering.
     pub fn get_panel_borders(&self) -> Vec<Rect> {
+        // No separators while zoomed: only the maximized panel is
+        // visible, so there's nothing to divide.
         if !self.should_draw_borders() || self.is_zoomed() {
             return vec![];
         }

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -121,6 +121,14 @@ pub struct ContextGrid<T: EventListener> {
     tree: TaffyTree<()>,
     root_node: NodeId,
     border_config: BorderConfig,
+    /// When `Some`, the panel maximized to fill the whole tab.
+    /// Siblings along its path to the root are hidden via
+    /// `Display::None` so Taffy lays the focused panel out exactly
+    /// as if it were the only one.
+    zoomed: Option<NodeId>,
+    /// Nodes set to `Display::None` for the active zoom, restored to
+    /// `Display::Flex` when zoom is cleared.
+    zoom_hidden: Vec<NodeId>,
 }
 
 pub struct ContextGridItem<T: EventListener> {
@@ -144,6 +152,15 @@ impl<T: rio_backend::event::EventListener> ContextGridItem<T> {
     #[inline]
     pub fn context_mut(&mut self) -> &mut Context<T> {
         &mut self.val
+    }
+
+    /// A panel is hidden when its layout collapsed to zero area —
+    /// today that only happens to the siblings of a zoomed panel,
+    /// which Taffy lays out with `Display::None`. Hidden panels are
+    /// skipped by the resize and render passes.
+    #[inline]
+    pub fn is_hidden(&self) -> bool {
+        self.layout_rect[2] <= 0.0 || self.layout_rect[3] <= 0.0
     }
 
     /// Previously stashed panel position into the rich-text object's
@@ -237,6 +254,8 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             tree,
             root_node,
             border_config,
+            zoomed: None,
+            zoom_hidden: Vec::new(),
         };
         grid.calculate_positions();
         grid
@@ -346,7 +365,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
     /// Find a draggable border near the given mouse position (physical pixels).
     /// Returns None if no border is within the hit threshold.
     pub fn find_border_at_position(&self, x: f32, y: f32) -> Option<PanelBorder> {
-        if self.inner.len() <= 1 {
+        if self.inner.len() <= 1 || self.is_zoomed() {
             return None;
         }
 
@@ -422,7 +441,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
     /// Get separator lines between adjacent panels for rendering.
     pub fn get_panel_borders(&self) -> Vec<Rect> {
-        if !self.should_draw_borders() {
+        if !self.should_draw_borders() || self.is_zoomed() {
             return vec![];
         }
 
@@ -903,8 +922,14 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
         let is_multi_panel = self.inner.len() > 1;
 
         for item in self.inner.values_mut() {
-            let [abs_x, abs_y, width, height] = item.layout_rect;
+            // Panels hidden by a zoom collapse to zero area in Taffy.
+            // Leave their terminal at its previous size rather than
+            // reflowing it to nothing.
+            if item.is_hidden() {
+                continue;
+            }
 
+            let [abs_x, abs_y, width, height] = item.layout_rect;
             let x = (abs_x + self.scaled_margin.left) / scale;
             let y = (abs_y + self.scaled_margin.top) / scale;
 
@@ -928,6 +953,108 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             // panel metadata.
             let _ = (x, y, abs_x, abs_y, width, height, is_multi_panel);
         }
+        true
+    }
+
+    #[inline]
+    pub fn is_zoomed(&self) -> bool {
+        self.zoomed.is_some()
+    }
+
+    /// Panels that should be tinted as "unfocused": every panel other
+    /// than `active`, excluding ones hidden by a zoom. Hidden panels
+    /// are skipped so they don't paint a stale-sized shadow over the
+    /// maximized panel.
+    pub fn unfocused_panels(
+        &self,
+        active: NodeId,
+    ) -> impl Iterator<Item = &ContextGridItem<T>> {
+        self.inner
+            .iter()
+            .filter(move |(key, item)| **key != active && !item.is_hidden())
+            .map(|(_, item)| item)
+    }
+
+    /// Hide every sibling along the path from `target` up to the root by
+    /// setting it to `Display::None`. The visible chain keeps its
+    /// `flex_grow`, so the focused leaf expands to fill the whole area.
+    /// Records the hidden nodes so the change can be reverted exactly.
+    fn apply_zoom_styles(&mut self, target: NodeId) {
+        let mut hidden = Vec::new();
+        let mut node = target;
+        while let Some(parent) = self.tree.parent(node) {
+            if let Ok(siblings) = self.tree.children(parent) {
+                for sibling in siblings {
+                    if sibling == node {
+                        continue;
+                    }
+                    if let Ok(mut style) = self.tree.style(sibling).cloned() {
+                        style.display = Display::None;
+                        if self.tree.set_style(sibling, style).is_ok() {
+                            hidden.push(sibling);
+                        }
+                    }
+                }
+            }
+            node = parent;
+        }
+        self.zoom_hidden = hidden;
+        self.zoomed = Some(target);
+    }
+
+    /// Revert the `Display::None` overrides applied by `apply_zoom_styles`.
+    /// Does not recompute layout — callers that need fresh geometry
+    /// invoke `apply_taffy_layout` afterwards.
+    fn restore_zoom_styles(&mut self) {
+        for node in std::mem::take(&mut self.zoom_hidden) {
+            if let Ok(mut style) = self.tree.style(node).cloned() {
+                style.display = Display::Flex;
+                let _ = self.tree.set_style(node, style);
+            }
+        }
+        self.zoomed = None;
+    }
+
+    /// Force every panel to fully repaint on the next frame. Zooming
+    /// changes which panels are visible without changing the focused
+    /// route, so the renderer's per-panel damage gate would otherwise
+    /// keep the just-revealed panels stale.
+    fn mark_all_panels_full_damage(&mut self) {
+        for item in self.inner.values_mut() {
+            item.val
+                .renderable_content
+                .pending_update
+                .set_terminal_damage(rio_backend::event::TerminalDamage::Full);
+        }
+    }
+
+    /// Toggle zoom on the focused split. Returns `true` when the zoom
+    /// state changed (so the caller can request a repaint). A single
+    /// panel can't be zoomed — there's nothing to hide.
+    pub fn toggle_zoom(&mut self, sugarloaf: &mut Sugarloaf) -> bool {
+        if self.is_zoomed() {
+            self.restore_zoom_styles();
+        } else {
+            if self.inner.len() <= 1 {
+                return false;
+            }
+            self.apply_zoom_styles(self.current);
+        }
+        self.apply_taffy_layout(sugarloaf);
+        self.mark_all_panels_full_damage();
+        true
+    }
+
+    /// Clear an active zoom (if any) and restore the normal layout.
+    /// Returns `true` when a zoom was cleared. Used by navigation and
+    /// other actions that should drop out of zoom first.
+    pub fn clear_zoom(&mut self, sugarloaf: &mut Sugarloaf) -> bool {
+        if !self.is_zoomed() {
+            return false;
+        }
+        self.restore_zoom_styles();
+        self.apply_taffy_layout(sugarloaf);
+        self.mark_all_panels_full_damage();
         true
     }
 
@@ -1253,6 +1380,12 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             return;
         }
 
+        // Drop any zoom first: the zoomed panel may be the one being
+        // removed, and the siblings must be visible again afterwards.
+        if self.is_zoomed() {
+            self.restore_zoom_styles();
+        }
+
         let to_remove = self.current;
 
         if !self.inner.contains_key(&to_remove) {
@@ -1326,6 +1459,12 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             return;
         }
 
+        // Splitting while zoomed drops out of zoom first so the new
+        // layout shows every panel.
+        if self.is_zoomed() {
+            self.restore_zoom_styles();
+        }
+
         // Create taffy node first, then item
         if let Ok(new_node) = self.try_split_right() {
             let new_context = ContextGridItem::new(context);
@@ -1339,6 +1478,12 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
     pub fn split_down(&mut self, context: Context<T>, sugarloaf: &mut Sugarloaf) {
         if !self.inner.contains_key(&self.current) {
             return;
+        }
+
+        // Splitting while zoomed drops out of zoom first so the new
+        // layout shows every panel.
+        if self.is_zoomed() {
+            self.restore_zoom_styles();
         }
 
         // Create taffy node first, then item

--- a/frontends/rioterm/src/renderer/command_palette.rs
+++ b/frontends/rioterm/src/renderer/command_palette.rs
@@ -78,6 +78,7 @@ pub enum PaletteAction {
     SplitDown,
     SelectNextSplit,
     SelectPrevSplit,
+    ToggleSplitZoom,
     ConfigEditor,
     WindowCreateNew,
     IncreaseFontSize,
@@ -151,6 +152,11 @@ const COMMANDS: &[Command] = &[
         title: "Previous Split",
         shortcut: "",
         action: PaletteAction::SelectPrevSplit,
+    },
+    Command {
+        title: "Toggle Split Zoom",
+        shortcut: "",
+        action: PaletteAction::ToggleSplitZoom,
     },
     Command {
         title: "Close Split or Tab",

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -40,6 +40,19 @@ const TITLE_FONT_SIZE: f32 = 12.0;
 /// title text so it never butts against the tab separator lines.
 const TAB_PADDING_X: f32 = 24.0;
 
+/// Glyph shown at the left of a tab whose grid has a maximized (zoomed)
+/// pane, mirroring Ghostty's tab zoom indicator. This is the Nerd Font
+/// `nf-fa-search` magnifier (U+F002): the UI text layer can't render the
+/// astral emoji 🔍 (U+1F50D), and plain BMP symbols like ⌕ (U+2315) need
+/// on-demand fontconfig fallback that the tab bar's read-only font
+/// resolution doesn't trigger. U+F002 lives in the bundled Nerd-patched
+/// CascadiaCodeNF, so the resolver picks that font for this glyph and it
+/// always renders. Monochrome, so it also takes the tab text color.
+const ZOOM_INDICATOR: &str = "\u{f002}";
+
+/// Inset from the tab's left edge to the zoom indicator.
+const ZOOM_INDICATOR_PADDING_X: f32 = 8.0;
+
 /// Suffix used when truncating a title that doesn't fit in its tab.
 const TITLE_ELLIPSIS: char = '…';
 
@@ -352,10 +365,13 @@ impl Island {
         let (window_width, _window_height, scale_factor) = dimensions;
         let num_tabs = context_manager.len();
         let current_tab_index = context_manager.current_index();
+        // A maximized pane keeps the strip visible even for a single tab
+        // so it can carry the zoom indicator.
+        let current_zoomed = context_manager.grid_is_zoomed(current_tab_index);
 
         // Immediate-mode: no cached ids to hide. If we early-return
         // without drawing, the tabs just don't appear this frame.
-        if self.hide_if_single && num_tabs == 1 {
+        if self.hide_if_single && num_tabs == 1 && !current_zoomed {
             self.render_progress_bar(sugarloaf, window_width, scale_factor);
             return;
         }
@@ -422,6 +438,18 @@ impl Island {
             let text_x = x_position + (tab_width - text_width) / 2.0;
             let text_y = (ISLAND_HEIGHT / 2.0) - (TITLE_FONT_SIZE / 2.);
             ui.draw(text_x, text_y, &title, &title_opts);
+
+            // Zoom indicator: a magnifier at the tab's left edge when
+            // this tab's grid has a maximized pane (Ghostty-style). Sits
+            // in the left padding zone, clear of the centered title.
+            if context_manager.grid_is_zoomed(tab_index) {
+                ui.draw(
+                    x_position + ZOOM_INDICATOR_PADDING_X,
+                    text_y,
+                    ZOOM_INDICATOR,
+                    &title_opts,
+                );
+            }
 
             // Draw tab background color if set
             if let Some(bg_color) = self.tab_colors.get(&tab_index) {

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -25,6 +25,20 @@ const TAB_PADDING_X: f32 = 27.0;
 const TAB_GAP: f32 = 6.0;
 const TAB_INSET_Y: f32 = 7.0;
 const TAB_RADIUS: f32 = 6.0;
+
+/// Glyph shown at the left of a tab whose grid has a maximized (zoomed)
+/// pane, mirroring Ghostty's tab zoom indicator. This is the Nerd Font
+/// `nf-fa-search` magnifier (U+F002): the UI text layer can't render the
+/// astral emoji 🔍 (U+1F50D), and plain BMP symbols like ⌕ (U+2315) need
+/// on-demand fontconfig fallback that the tab bar's read-only font
+/// resolution doesn't trigger. U+F002 lives in the bundled Nerd-patched
+/// CascadiaCodeNF, so the resolver picks that font for this glyph and it
+/// always renders. Monochrome, so it also takes the tab text color.
+const ZOOM_INDICATOR: &str = "\u{f002}";
+
+/// Inset from the tab's left edge to the zoom indicator.
+const ZOOM_INDICATOR_PADDING_X: f32 = 8.0;
+
 const TITLE_ELLIPSIS: char = '…';
 const DRAG_THRESHOLD: f32 = 4.0;
 const DRAG_ANIMATION_LENGTH: f32 = 0.15;
@@ -716,10 +730,13 @@ impl Island {
         let (window_width, _window_height, scale_factor) = dimensions;
         let num_tabs = context_manager.len();
         let current_tab_index = context_manager.current_index();
+        // A maximized pane keeps the strip visible even for a single tab
+        // so it can carry the zoom indicator.
+        let current_zoomed = context_manager.grid_is_zoomed(current_tab_index);
 
         // Immediate-mode: no cached ids to hide. If we early-return
         // without drawing, the tabs just don't appear this frame.
-        if self.hide_if_single && num_tabs == 1 {
+        if self.hide_if_single && num_tabs == 1 && !current_zoomed {
             // No tab strip — drop any leftover drag/slide state so
             // `needs_redraw` doesn't keep frames alive for invisible
             // tabs.
@@ -833,6 +850,18 @@ impl Island {
                 let text_x = tab_x + (tab_width - text_width) / 2.0;
                 let text_y = (ISLAND_HEIGHT / 2.0) - (TITLE_FONT_SIZE / 2.);
                 ui.draw(text_x, text_y, &title, &title_opts);
+
+                // Zoom indicator: a magnifier at the tab's left edge when
+                // this tab's grid has a maximized pane (Ghostty-style). Sits
+                // in the left padding zone, clear of the centered title.
+                if context_manager.grid_is_zoomed(tab_index) {
+                    ui.draw(
+                        tab_x + ZOOM_INDICATOR_PADDING_X,
+                        text_y,
+                        ZOOM_INDICATOR,
+                        &title_opts,
+                    );
+                }
             }
 
             // Rounded island for this tab. A custom color (picker /

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -283,6 +283,9 @@ impl Renderer {
         if self.scrollbar.is_enabled() {
             self.scrollbar.clear_panel_states();
             for grid_context in grid.contexts_mut().values() {
+                if grid_context.is_hidden() {
+                    continue;
+                }
                 let panel_rect = grid_context.layout_rect;
                 let ctx = grid_context.context();
                 let terminal = ctx.terminal.lock();
@@ -298,6 +301,9 @@ impl Renderer {
         }
 
         for (_key, grid_context) in grid.contexts_mut().iter_mut() {
+            if grid_context.is_hidden() {
+                continue;
+            }
             let panel_rect = grid_context.layout_rect;
             let context = grid_context.context_mut();
 
@@ -535,10 +541,7 @@ impl Renderer {
                 tint[2],
                 1.0 - self.unfocused_split_opacity,
             ];
-            for (key, grid_context) in grid.contexts_mut().iter() {
-                if &active_key == key {
-                    continue;
-                }
+            for grid_context in grid.unfocused_panels(active_key) {
                 // Match the grid renderer's actual paint region —
                 // `.round()`ed integer-pixel origin +
                 // `cols * round(cell_w)` × `rows * round(cell_h)`

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -287,6 +287,9 @@ impl Renderer {
         }
 
         for (_key, grid_context) in grid.contexts_mut().iter_mut() {
+            if grid_context.is_hidden() {
+                continue;
+            }
             let panel_rect = grid_context.layout_rect;
             let context = grid_context.context_mut();
 
@@ -586,6 +589,12 @@ impl Renderer {
         if self.scrollbar.is_enabled() {
             self.scrollbar.clear_panel_states();
             for grid_context in grid.contexts_mut().values() {
+                // A zoomed split collapses its siblings to zero size;
+                // pushing scroll state for them would draw scrollbars
+                // for panels that aren't on screen.
+                if grid_context.is_hidden() {
+                    continue;
+                }
                 let panel_rect = grid_context.layout_rect;
                 let ctx = grid_context.context();
                 let rc = &ctx.renderable_content;
@@ -618,10 +627,7 @@ impl Renderer {
                 tint[2],
                 1.0 - self.unfocused_split_opacity,
             ];
-            for (key, grid_context) in grid.contexts_mut().iter() {
-                if &active_key == key {
-                    continue;
-                }
+            for grid_context in grid.unfocused_panels(active_key) {
                 // Match the grid renderer's actual paint region —
                 // `.round()`ed integer-pixel origin +
                 // `cols * round(cell_w)` × `rows * round(cell_h)`

--- a/frontends/rioterm/src/renderer/utils.rs
+++ b/frontends/rioterm/src/renderer/utils.rs
@@ -1,6 +1,6 @@
 use crate::constants;
 use crate::layout::ContextDimension;
-use rio_backend::config::navigation::Navigation;
+use rio_backend::config::navigation::{Navigation, PaneZoom};
 use rio_backend::config::Config;
 use rio_window::window::Theme;
 
@@ -10,13 +10,16 @@ pub fn padding_top_from_config(
     padding_y_top: f32,
     #[allow(unused)] num_tabs: usize,
     #[allow(unused)] macos_use_unified_titlebar: bool,
+    #[allow(unused)] zoom: PaneZoom,
 ) -> f32 {
     // When navigation is enabled (Tab mode), start content below island
     if navigation.is_enabled() {
         // On Linux/Windows, if hide_if_single is true and there's only one tab,
-        // the island is hidden so render from 0 + configured margin
+        // the island is hidden so render from 0 + configured margin — unless a
+        // pane is zoomed, in which case the island is forced visible to carry
+        // the zoom indicator.
         #[cfg(not(target_os = "macos"))]
-        if navigation.hide_if_single && num_tabs <= 1 {
+        if navigation.hide_if_single && num_tabs <= 1 && zoom == PaneZoom::NotZoomed {
             return constants::PADDING_Y + padding_y_top;
         }
 

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -131,6 +131,7 @@ impl Screen<'_> {
             config.margin.top,
             1,
             config.window.macos_use_unified_titlebar,
+            rio_backend::config::navigation::PaneZoom::NotZoomed,
         );
 
         let padding_y_bottom = config.margin.bottom;
@@ -457,11 +458,13 @@ impl Screen<'_> {
         should_update_font_library: bool,
     ) {
         let num_tabs = self.ctx().len();
+        let zoom = self.context_manager.current_pane_zoom();
         let padding_y_top = padding_top_from_config(
             &config.navigation,
             config.margin.top,
             num_tabs,
             config.window.macos_use_unified_titlebar,
+            zoom,
         );
         let padding_y_bottom = config.margin.bottom;
 
@@ -1318,20 +1321,20 @@ impl Screen<'_> {
                     }
                     Act::SelectNextSplit => {
                         self.cancel_search(clipboard);
-                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                        self.clear_split_zoom();
                         self.context_manager.select_next_split();
                         self.mark_dirty();
                     }
                     Act::SelectPrevSplit => {
                         self.cancel_search(clipboard);
-                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                        self.clear_split_zoom();
                         self.context_manager.select_prev_split();
                         self.mark_dirty();
                     }
                     Act::SelectNextSplitOrTab => {
                         self.cancel_search(clipboard);
                         self.clear_selection();
-                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                        self.clear_split_zoom();
                         let old_index = self.context_manager.current_index();
                         self.context_manager.switch_to_next_split_or_tab();
                         let new_index = self.context_manager.current_index();
@@ -1345,7 +1348,7 @@ impl Screen<'_> {
                     Act::SelectPrevSplitOrTab => {
                         self.cancel_search(clipboard);
                         self.clear_selection();
-                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                        self.clear_split_zoom();
                         let old_index = self.context_manager.current_index();
                         self.context_manager.switch_to_prev_split_or_tab();
                         let new_index = self.context_manager.current_index();
@@ -1459,18 +1462,26 @@ impl Screen<'_> {
     }
 
     pub fn split_right(&mut self) {
+        let was_zoomed = self.context_manager.current_grid().is_zoomed();
         let rich_text_id = next_rich_text_id();
         self.context_manager
             .split(rich_text_id, false, &mut self.sugarloaf);
 
+        if was_zoomed {
+            self.resync_island_after_zoom();
+        }
         self.mark_dirty();
     }
 
     pub fn split_down(&mut self) {
+        let was_zoomed = self.context_manager.current_grid().is_zoomed();
         let rich_text_id = next_rich_text_id();
         self.context_manager
             .split(rich_text_id, true, &mut self.sugarloaf);
 
+        if was_zoomed {
+            self.resync_island_after_zoom();
+        }
         self.mark_dirty();
     }
 
@@ -1479,7 +1490,26 @@ impl Screen<'_> {
             .context_manager
             .toggle_split_zoom(&mut self.sugarloaf)
         {
+            self.resync_island_after_zoom();
             self.mark_dirty();
+        }
+    }
+
+    /// Clear an active zoom on the current grid, re-reserving tab-bar
+    /// space if that changed the bar's visibility. Used by split
+    /// navigation, which drops out of zoom first.
+    pub fn clear_split_zoom(&mut self) {
+        if self.context_manager.clear_split_zoom(&mut self.sugarloaf) {
+            self.resync_island_after_zoom();
+        }
+    }
+
+    /// Re-reserve the tab-bar (island) height after a zoom change. Only
+    /// the single-tab case is affected: with multiple tabs the bar is
+    /// always visible, so its height doesn't depend on zoom.
+    fn resync_island_after_zoom(&mut self) {
+        if self.ctx().len() <= 1 {
+            self.resize_top_or_bottom_line(1);
         }
     }
 
@@ -1558,9 +1588,13 @@ impl Screen<'_> {
 
     pub fn close_split_or_tab(&mut self, clipboard: &mut Clipboard) {
         if self.context_manager.current_grid_len() > 1 {
+            let was_zoomed = self.context_manager.current_grid().is_zoomed();
             self.clear_selection();
             self.context_manager
                 .remove_current_grid(&mut self.sugarloaf);
+            if was_zoomed {
+                self.resync_island_after_zoom();
+            }
             self.mark_dirty();
         } else {
             self.close_tab(clipboard);
@@ -1595,11 +1629,15 @@ impl Screen<'_> {
     pub fn resize_top_or_bottom_line(&mut self, num_tabs: usize) {
         let layout = self.context_manager.current().dimension;
         let previous_margin = layout.margin;
+        let zoom = rio_backend::config::navigation::PaneZoom::from_zoomed(
+            self.context_manager.current_grid().is_zoomed(),
+        );
         let padding_y_top = padding_top_from_config(
             &self.renderer.navigation,
             self.renderer.margin.top,
             num_tabs,
             self.renderer.macos_use_unified_titlebar,
+            zoom,
         );
         let padding_y_bottom = self.renderer.margin.bottom;
 
@@ -2634,7 +2672,9 @@ impl Screen<'_> {
 
         let window_width = self.sugarloaf.window_size().width;
         let num_tabs = self.context_manager.len();
-        let island_visible = self.renderer.navigation.island_visible(num_tabs);
+        let zoom = self.context_manager.current_pane_zoom();
+        let island_visible =
+            self.renderer.navigation.island_visible_with(num_tabs, zoom);
 
         // Check if the color picker is open and the click hits a swatch.
         // Handled before the `island_visible` short-circuit so a picker
@@ -3349,11 +3389,11 @@ impl Screen<'_> {
             PaletteAction::SplitRight => self.split_right(),
             PaletteAction::SplitDown => self.split_down(),
             PaletteAction::SelectNextSplit => {
-                self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                self.clear_split_zoom();
                 self.context_manager.select_next_split();
             }
             PaletteAction::SelectPrevSplit => {
-                self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                self.clear_split_zoom();
                 self.context_manager.select_prev_split();
             }
             PaletteAction::ToggleSplitZoom => self.toggle_split_zoom(),

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1486,10 +1486,7 @@ impl Screen<'_> {
     }
 
     pub fn toggle_split_zoom(&mut self) {
-        if self
-            .context_manager
-            .toggle_split_zoom(&mut self.sugarloaf)
-        {
+        if self.context_manager.toggle_split_zoom(&mut self.sugarloaf) {
             self.resync_island_after_zoom();
             self.mark_dirty();
         }
@@ -2673,8 +2670,7 @@ impl Screen<'_> {
         let window_width = self.sugarloaf.window_size().width;
         let num_tabs = self.context_manager.len();
         let zoom = self.context_manager.current_pane_zoom();
-        let island_visible =
-            self.renderer.navigation.island_visible_with(num_tabs, zoom);
+        let island_visible = self.renderer.navigation.island_visible_with(num_tabs, zoom);
 
         // Check if the color picker is open and the click hits a swatch.
         // Handled before the `island_visible` short-circuit so a picker

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1147,6 +1147,9 @@ impl Screen<'_> {
                     Act::MoveDividerRight => {
                         self.move_divider_right();
                     }
+                    Act::ToggleSplitZoom => {
+                        self.toggle_split_zoom();
+                    }
                     Act::ConfigEditor => {
                         self.context_manager.switch_to_settings();
                     }
@@ -1315,17 +1318,20 @@ impl Screen<'_> {
                     }
                     Act::SelectNextSplit => {
                         self.cancel_search(clipboard);
+                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                         self.context_manager.select_next_split();
                         self.mark_dirty();
                     }
                     Act::SelectPrevSplit => {
                         self.cancel_search(clipboard);
+                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                         self.context_manager.select_prev_split();
                         self.mark_dirty();
                     }
                     Act::SelectNextSplitOrTab => {
                         self.cancel_search(clipboard);
                         self.clear_selection();
+                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                         let old_index = self.context_manager.current_index();
                         self.context_manager.switch_to_next_split_or_tab();
                         let new_index = self.context_manager.current_index();
@@ -1339,6 +1345,7 @@ impl Screen<'_> {
                     Act::SelectPrevSplitOrTab => {
                         self.cancel_search(clipboard);
                         self.clear_selection();
+                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                         let old_index = self.context_manager.current_index();
                         self.context_manager.switch_to_prev_split_or_tab();
                         let new_index = self.context_manager.current_index();
@@ -1465,6 +1472,15 @@ impl Screen<'_> {
             .split(rich_text_id, true, &mut self.sugarloaf);
 
         self.mark_dirty();
+    }
+
+    pub fn toggle_split_zoom(&mut self) {
+        if self
+            .context_manager
+            .toggle_split_zoom(&mut self.sugarloaf)
+        {
+            self.mark_dirty();
+        }
     }
 
     pub fn move_divider_up(&mut self) {
@@ -3333,11 +3349,14 @@ impl Screen<'_> {
             PaletteAction::SplitRight => self.split_right(),
             PaletteAction::SplitDown => self.split_down(),
             PaletteAction::SelectNextSplit => {
+                self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                 self.context_manager.select_next_split();
             }
             PaletteAction::SelectPrevSplit => {
+                self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                 self.context_manager.select_prev_split();
             }
+            PaletteAction::ToggleSplitZoom => self.toggle_split_zoom(),
             PaletteAction::CloseCurrentSplitOrTab => self.close_split_or_tab(clipboard),
             PaletteAction::ConfigEditor => {
                 self.context_manager.switch_to_settings();
@@ -3628,6 +3647,12 @@ impl Screen<'_> {
                 .contexts_mut()
                 .iter_mut()
             {
+                // Skip panels hidden by a zoom. Their snapshot buffers
+                // stay untouched, so there's nothing to restore for
+                // them at the end of the pass.
+                if item.is_hidden() {
+                    continue;
+                }
                 let ctx = &mut item.val;
                 let dim = ctx.dimension;
                 // Canonical integer cell stride — single source of

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -131,6 +131,7 @@ impl Screen<'_> {
             config.margin.top,
             1,
             config.window.macos_use_unified_titlebar,
+            rio_backend::config::navigation::PaneZoom::NotZoomed,
         );
 
         let padding_y_bottom = config.margin.bottom;
@@ -420,11 +421,13 @@ impl Screen<'_> {
         should_update_font_library: bool,
     ) {
         let num_tabs = self.ctx().len();
+        let zoom = self.context_manager.current_pane_zoom();
         let padding_y_top = padding_top_from_config(
             &config.navigation,
             config.margin.top,
             num_tabs,
             config.window.macos_use_unified_titlebar,
+            zoom,
         );
         let padding_y_bottom = config.margin.bottom;
 
@@ -1341,20 +1344,20 @@ impl Screen<'_> {
                     }
                     Act::SelectNextSplit => {
                         self.cancel_search(clipboard);
-                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                        self.clear_split_zoom();
                         self.context_manager.select_next_split();
                         self.mark_dirty();
                     }
                     Act::SelectPrevSplit => {
                         self.cancel_search(clipboard);
-                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                        self.clear_split_zoom();
                         self.context_manager.select_prev_split();
                         self.mark_dirty();
                     }
                     Act::SelectNextSplitOrTab => {
                         self.cancel_search(clipboard);
                         self.clear_selection();
-                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                        self.clear_split_zoom();
                         let old_index = self.context_manager.current_index();
                         self.context_manager.switch_to_next_split_or_tab();
                         let new_index = self.context_manager.current_index();
@@ -1368,7 +1371,7 @@ impl Screen<'_> {
                     Act::SelectPrevSplitOrTab => {
                         self.cancel_search(clipboard);
                         self.clear_selection();
-                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                        self.clear_split_zoom();
                         let old_index = self.context_manager.current_index();
                         self.context_manager.switch_to_prev_split_or_tab();
                         let new_index = self.context_manager.current_index();
@@ -1492,18 +1495,26 @@ impl Screen<'_> {
     }
 
     pub fn split_right(&mut self) {
+        let was_zoomed = self.context_manager.current_grid().is_zoomed();
         let rich_text_id = next_rich_text_id();
         self.context_manager
             .split(rich_text_id, false, &mut self.sugarloaf);
 
+        if was_zoomed {
+            self.resync_island_after_zoom();
+        }
         self.mark_dirty();
     }
 
     pub fn split_down(&mut self) {
+        let was_zoomed = self.context_manager.current_grid().is_zoomed();
         let rich_text_id = next_rich_text_id();
         self.context_manager
             .split(rich_text_id, true, &mut self.sugarloaf);
 
+        if was_zoomed {
+            self.resync_island_after_zoom();
+        }
         self.mark_dirty();
     }
 
@@ -1512,7 +1523,26 @@ impl Screen<'_> {
             .context_manager
             .toggle_split_zoom(&mut self.sugarloaf)
         {
+            self.resync_island_after_zoom();
             self.mark_dirty();
+        }
+    }
+
+    /// Clear an active zoom on the current grid, re-reserving tab-bar
+    /// space if that changed the bar's visibility. Used by split
+    /// navigation, which drops out of zoom first.
+    pub fn clear_split_zoom(&mut self) {
+        if self.context_manager.clear_split_zoom(&mut self.sugarloaf) {
+            self.resync_island_after_zoom();
+        }
+    }
+
+    /// Re-reserve the tab-bar (island) height after a zoom change. Only
+    /// the single-tab case is affected: with multiple tabs the bar is
+    /// always visible, so its height doesn't depend on zoom.
+    fn resync_island_after_zoom(&mut self) {
+        if self.ctx().len() <= 1 {
+            self.resize_top_or_bottom_line(1);
         }
     }
 
@@ -1591,9 +1621,13 @@ impl Screen<'_> {
 
     pub fn close_split_or_tab(&mut self, clipboard: &mut Clipboard) {
         if self.context_manager.current_grid_len() > 1 {
+            let was_zoomed = self.context_manager.current_grid().is_zoomed();
             self.clear_selection();
             self.context_manager
                 .remove_current_grid(&mut self.sugarloaf);
+            if was_zoomed {
+                self.resync_island_after_zoom();
+            }
             self.mark_dirty();
         } else {
             self.close_tab(clipboard);
@@ -1628,11 +1662,13 @@ impl Screen<'_> {
     }
 
     pub fn resize_top_or_bottom_line(&mut self, num_tabs: usize) {
+        let zoom = self.context_manager.current_pane_zoom();
         let padding_y_top = padding_top_from_config(
             &self.renderer.navigation,
             self.renderer.margin.top,
             num_tabs,
             self.renderer.macos_use_unified_titlebar,
+            zoom,
         );
         let padding_y_bottom = self.renderer.margin.bottom;
 
@@ -2808,7 +2844,9 @@ impl Screen<'_> {
 
         let window_width = self.sugarloaf.window_size().width;
         let num_tabs = self.context_manager.len();
-        let island_visible = self.renderer.navigation.island_visible(num_tabs);
+        let zoom = self.context_manager.current_pane_zoom();
+        let island_visible =
+            self.renderer.navigation.island_visible_with(num_tabs, zoom);
 
         if let Some(ref mut island) = self.renderer.island {
             if island.is_color_picker_open() {
@@ -3655,11 +3693,11 @@ impl Screen<'_> {
             PaletteAction::SplitRight => self.split_right(),
             PaletteAction::SplitDown => self.split_down(),
             PaletteAction::SelectNextSplit => {
-                self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                self.clear_split_zoom();
                 self.context_manager.select_next_split();
             }
             PaletteAction::SelectPrevSplit => {
-                self.context_manager.clear_split_zoom(&mut self.sugarloaf);
+                self.clear_split_zoom();
                 self.context_manager.select_prev_split();
             }
             PaletteAction::ToggleSplitZoom => self.toggle_split_zoom(),

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1146,6 +1146,9 @@ impl Screen<'_> {
                     Act::MoveDividerRight => {
                         self.move_divider_right();
                     }
+                    Act::ToggleSplitZoom => {
+                        self.toggle_split_zoom();
+                    }
                     Act::ConfigEditor => {
                         self.context_manager.switch_to_settings();
                     }
@@ -1338,17 +1341,20 @@ impl Screen<'_> {
                     }
                     Act::SelectNextSplit => {
                         self.cancel_search(clipboard);
+                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                         self.context_manager.select_next_split();
                         self.mark_dirty();
                     }
                     Act::SelectPrevSplit => {
                         self.cancel_search(clipboard);
+                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                         self.context_manager.select_prev_split();
                         self.mark_dirty();
                     }
                     Act::SelectNextSplitOrTab => {
                         self.cancel_search(clipboard);
                         self.clear_selection();
+                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                         let old_index = self.context_manager.current_index();
                         self.context_manager.switch_to_next_split_or_tab();
                         let new_index = self.context_manager.current_index();
@@ -1362,6 +1368,7 @@ impl Screen<'_> {
                     Act::SelectPrevSplitOrTab => {
                         self.cancel_search(clipboard);
                         self.clear_selection();
+                        self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                         let old_index = self.context_manager.current_index();
                         self.context_manager.switch_to_prev_split_or_tab();
                         let new_index = self.context_manager.current_index();
@@ -1498,6 +1505,15 @@ impl Screen<'_> {
             .split(rich_text_id, true, &mut self.sugarloaf);
 
         self.mark_dirty();
+    }
+
+    pub fn toggle_split_zoom(&mut self) {
+        if self
+            .context_manager
+            .toggle_split_zoom(&mut self.sugarloaf)
+        {
+            self.mark_dirty();
+        }
     }
 
     pub fn move_divider_up(&mut self) {
@@ -3639,11 +3655,14 @@ impl Screen<'_> {
             PaletteAction::SplitRight => self.split_right(),
             PaletteAction::SplitDown => self.split_down(),
             PaletteAction::SelectNextSplit => {
+                self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                 self.context_manager.select_next_split();
             }
             PaletteAction::SelectPrevSplit => {
+                self.context_manager.clear_split_zoom(&mut self.sugarloaf);
                 self.context_manager.select_prev_split();
             }
+            PaletteAction::ToggleSplitZoom => self.toggle_split_zoom(),
             PaletteAction::CloseCurrentSplitOrTab => self.close_split_or_tab(clipboard),
             PaletteAction::ConfigEditor => {
                 self.context_manager.switch_to_settings();
@@ -3912,6 +3931,12 @@ impl Screen<'_> {
                 .contexts_mut()
                 .iter_mut()
             {
+                // Skip panels hidden by a zoom. Their snapshot buffers
+                // stay untouched, so there's nothing to restore for
+                // them at the end of the pass.
+                if item.is_hidden() {
+                    continue;
+                }
                 let ctx = &mut item.val;
                 let dim = ctx.dimension;
                 // Canonical integer cell stride — single source of

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1519,10 +1519,7 @@ impl Screen<'_> {
     }
 
     pub fn toggle_split_zoom(&mut self) {
-        if self
-            .context_manager
-            .toggle_split_zoom(&mut self.sugarloaf)
-        {
+        if self.context_manager.toggle_split_zoom(&mut self.sugarloaf) {
             self.resync_island_after_zoom();
             self.mark_dirty();
         }
@@ -2845,8 +2842,7 @@ impl Screen<'_> {
         let window_width = self.sugarloaf.window_size().width;
         let num_tabs = self.context_manager.len();
         let zoom = self.context_manager.current_pane_zoom();
-        let island_visible =
-            self.renderer.navigation.island_visible_with(num_tabs, zoom);
+        let island_visible = self.renderer.navigation.island_visible_with(num_tabs, zoom);
 
         if let Some(ref mut island) = self.renderer.island {
             if island.is_color_picker_open() {

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -199,15 +199,89 @@ impl Navigation {
     /// the empty band over a hidden island doesn't intercept events.
     #[inline]
     pub fn island_visible(&self, num_tabs: usize) -> bool {
-        self.is_enabled() && !(self.hide_if_single && num_tabs == 1)
+        self.island_visible_with(num_tabs, PaneZoom::NotZoomed)
+    }
+
+    /// Like [`Self::island_visible`], but a maximized pane keeps the strip
+    /// visible even for a single tab so it can carry the zoom indicator.
+    #[inline]
+    pub fn island_visible_with(&self, num_tabs: usize, zoom: PaneZoom) -> bool {
+        self.is_enabled()
+            && (zoom == PaneZoom::Zoomed || !(self.hide_if_single && num_tabs == 1))
+    }
+}
+
+/// Whether a maximized (zoomed) pane is forcing the tab strip to stay
+/// visible. A named alternative to a bare `bool` at the several call
+/// sites that decide tab-bar visibility and top-margin reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneZoom {
+    Zoomed,
+    NotZoomed,
+}
+
+impl PaneZoom {
+    #[inline]
+    pub fn from_zoomed(zoomed: bool) -> Self {
+        if zoomed {
+            PaneZoom::Zoomed
+        } else {
+            PaneZoom::NotZoomed
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::config::colors::hex_to_color_arr;
-    use crate::config::navigation::{Navigation, NavigationMode};
+    use crate::config::navigation::{Navigation, NavigationMode, PaneZoom};
     use serde::Deserialize;
+
+    fn nav(mode: NavigationMode, hide_if_single: bool) -> Navigation {
+        Navigation {
+            mode,
+            hide_if_single,
+            ..Navigation::default()
+        }
+    }
+
+    #[test]
+    fn island_visibility_across_config_tab_and_zoom() {
+        use NavigationMode::{Plain, Tab};
+        use PaneZoom::{NotZoomed, Zoomed};
+
+        // Tab mode, hide_if_single: single tab hides the bar unless a
+        // pane is zoomed; multiple tabs always show it.
+        let hide = nav(Tab, true);
+        assert!(!hide.island_visible_with(1, NotZoomed));
+        assert!(hide.island_visible_with(1, Zoomed));
+        assert!(hide.island_visible_with(2, NotZoomed));
+        assert!(hide.island_visible_with(2, Zoomed));
+
+        // Tab mode, hide_if_single off: bar always shows, zoom is moot.
+        let show = nav(Tab, false);
+        assert!(show.island_visible_with(1, NotZoomed));
+        assert!(show.island_visible_with(1, Zoomed));
+        assert!(show.island_visible_with(2, NotZoomed));
+
+        // Plain mode has no strip; zoom can't force one into existence.
+        let plain = nav(Plain, true);
+        assert!(!plain.island_visible_with(1, NotZoomed));
+        assert!(!plain.island_visible_with(1, Zoomed));
+        assert!(!plain.island_visible_with(2, NotZoomed));
+
+        // `island_visible` is the not-zoomed case of `island_visible_with`.
+        for n in 1..=3 {
+            assert_eq!(
+                hide.island_visible(n),
+                hide.island_visible_with(n, NotZoomed)
+            );
+            assert_eq!(
+                plain.island_visible(n),
+                plain.island_visible_with(n, NotZoomed)
+            );
+        }
+    }
 
     #[derive(Debug, Clone, Deserialize, PartialEq)]
     struct Root {

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -221,15 +221,89 @@ impl Navigation {
     /// the empty band over a hidden island doesn't intercept events.
     #[inline]
     pub fn island_visible(&self, num_tabs: usize) -> bool {
-        self.is_enabled() && !(self.hide_if_single && num_tabs == 1)
+        self.island_visible_with(num_tabs, PaneZoom::NotZoomed)
+    }
+
+    /// Like [`Self::island_visible`], but a maximized pane keeps the strip
+    /// visible even for a single tab so it can carry the zoom indicator.
+    #[inline]
+    pub fn island_visible_with(&self, num_tabs: usize, zoom: PaneZoom) -> bool {
+        self.is_enabled()
+            && (zoom == PaneZoom::Zoomed || !(self.hide_if_single && num_tabs == 1))
+    }
+}
+
+/// Whether a maximized (zoomed) pane is forcing the tab strip to stay
+/// visible. A named alternative to a bare `bool` at the several call
+/// sites that decide tab-bar visibility and top-margin reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneZoom {
+    Zoomed,
+    NotZoomed,
+}
+
+impl PaneZoom {
+    #[inline]
+    pub fn from_zoomed(zoomed: bool) -> Self {
+        if zoomed {
+            PaneZoom::Zoomed
+        } else {
+            PaneZoom::NotZoomed
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::config::colors::hex_to_color_arr;
-    use crate::config::navigation::{Navigation, NavigationMode};
+    use crate::config::navigation::{Navigation, NavigationMode, PaneZoom};
     use serde::Deserialize;
+
+    fn nav(mode: NavigationMode, hide_if_single: bool) -> Navigation {
+        Navigation {
+            mode,
+            hide_if_single,
+            ..Navigation::default()
+        }
+    }
+
+    #[test]
+    fn island_visibility_across_config_tab_and_zoom() {
+        use NavigationMode::{Plain, Tab};
+        use PaneZoom::{NotZoomed, Zoomed};
+
+        // Tab mode, hide_if_single: single tab hides the bar unless a
+        // pane is zoomed; multiple tabs always show it.
+        let hide = nav(Tab, true);
+        assert!(!hide.island_visible_with(1, NotZoomed));
+        assert!(hide.island_visible_with(1, Zoomed));
+        assert!(hide.island_visible_with(2, NotZoomed));
+        assert!(hide.island_visible_with(2, Zoomed));
+
+        // Tab mode, hide_if_single off: bar always shows, zoom is moot.
+        let show = nav(Tab, false);
+        assert!(show.island_visible_with(1, NotZoomed));
+        assert!(show.island_visible_with(1, Zoomed));
+        assert!(show.island_visible_with(2, NotZoomed));
+
+        // Plain mode has no strip; zoom can't force one into existence.
+        let plain = nav(Plain, true);
+        assert!(!plain.island_visible_with(1, NotZoomed));
+        assert!(!plain.island_visible_with(1, Zoomed));
+        assert!(!plain.island_visible_with(2, NotZoomed));
+
+        // `island_visible` is the not-zoomed case of `island_visible_with`.
+        for n in 1..=3 {
+            assert_eq!(
+                hide.island_visible(n),
+                hide.island_visible_with(n, NotZoomed)
+            );
+            assert_eq!(
+                plain.island_visible(n),
+                plain.island_visible_with(n, NotZoomed)
+            );
+        }
+    }
 
     #[derive(Debug, Clone, Deserialize, PartialEq)]
     struct Root {


### PR DESCRIPTION
## Summary

Adds a tmux-style "zoom" action that temporarily expands the focused split to
fill the whole tab, toggling back to the exact prior layout on a second press
(FR #1615). Siblings are hidden via Taffy `Display::None`, so the zoomed panel
lays out identically to a lone panel while sibling processes keep running.

## Details

- New `ToggleSplitZoom` action, bound to **Ctrl+Shift+X** (**Cmd+Shift+X** on
  macOS), exposed via config (`action = "ToggleSplitZoom"`) and the command palette.
- Hidden panels collapse to zero area and are skipped by the resize, render,
  scrollbar, border and unfocused-dim passes via a new `ContextGridItem::is_hidden()`.
- Zoom is cleared automatically on split create/close and on split navigation.
- A magnifier glyph (Nerd Font `nf-fa-search`, U+F002) marks a zoomed tab in the
  strip; for a single tab the strip is forced visible while zoomed to carry the
  indicator (the CSD title bar can't render the glyph). Island visibility now flows
  through one zoom-aware predicate (`Navigation::island_visible_with`) shared by the
  top-margin reservation, the render gate and input routing.

## Testing

`cargo test -p rioterm` — adds layout/compute tests covering zoom hide/restore,
hidden-panel exclusion from resize/dim passes, and island re-reservation.

Closes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)
