### PR TITLE
feat: integrate the Linux bell with the desktop environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,6 +4048,7 @@ dependencies = [
  "futures",
  "image",
  "libc",
+ "libloading",
  "lru",
  "notify",
  "objc-rs 0.3.1",

--- a/extra/man/rio.5.scd
+++ b/extra/man/rio.5.scd
@@ -315,6 +315,41 @@ This section documents the *[scroll]* table of the configuration file.
 
 	Default: _1.0_
 
+# BELL
+
+This section documents the *[bell]* table of the configuration file, which
+controls how the terminal bell (BEL, _\\a_) signals attention.
+
+*audio* = _false_ | _true_ | _"system"_
+
+	Audible bell.
+
+	- _false_ — no sound.
+	- _true_ — a self-synthesized tone (on macOS/Windows the native system beep).
+	- _"system"_ — the desktop environment's event sound. On Linux this uses the
+	  freedesktop sound theme via libcanberra (loaded at runtime; no-op if
+	  unavailable), respecting the configured sound theme, output routing,
+	  volume, mute and Do-Not-Disturb. On macOS/Windows this is the native
+	  system beep.
+
+	Default: _"system"_ on Linux/BSD, _true_ on macOS/Windows
+
+*urgency* = _true_ | _false_
+
+	Set the window urgency / attention hint when the bell fires in an unfocused
+	window, flashing the taskbar/dock entry. Uses the X11 _WM_HINTS_ urgency
+	flag or the Wayland _xdg-activation_ protocol. The hint is cleared when the
+	window regains focus.
+
+	Default: _true_ on Linux/BSD, _false_ on macOS/Windows
+
+*notification* = _true_ | _false_
+
+	Raise a desktop notification (_org.freedesktop.Notifications_) when the bell
+	fires in an unfocused window.
+
+	Default: _false_
+
 # NAVIGATION
 
 This section documents the *[navigation]* table of the configuration file.

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -53,6 +53,9 @@ rio-notifier = { workspace = true }
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "windows")))'.dependencies]
 cpal = { version = "0.15", optional = true }
+# Loaded at runtime via dlopen for the freedesktop event-sound theme
+# (libcanberra). No build-time dependency; degrades gracefully if absent.
+libloading = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = { workspace = true }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -5,14 +5,9 @@ use crate::router::{routes::RoutePath, Router};
 use crate::scheduler::{Scheduler, TimerId, Topic};
 use crate::screen::touch::on_touch;
 use crate::watcher::configuration_file_updates;
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use raw_window_handle::HasDisplayHandle;
 use rio_backend::clipboard::{Clipboard, ClipboardType};
+use rio_backend::config::bell::AudioBell;
 use rio_backend::config::colors::{ColorRgb, NamedColor};
 use rio_window::application::ApplicationHandler;
 use rio_window::event::{
@@ -26,7 +21,7 @@ use rio_window::platform::macos::ActiveEventLoopExtMacOS;
 #[cfg(target_os = "macos")]
 use rio_window::platform::macos::WindowExtMacOS;
 use rio_window::window::WindowId;
-use rio_window::window::{CursorIcon, Fullscreen};
+use rio_window::window::{CursorIcon, Fullscreen, UserAttentionType};
 use std::error::Error;
 use std::time::{Duration, Instant};
 
@@ -99,41 +94,40 @@ impl Application<'_> {
         )
     }
 
-    fn handle_audio_bell(&mut self) {
-        #[cfg(target_os = "macos")]
-        {
-            // Use system bell sound on macOS
-            unsafe {
-                #[link(name = "AppKit", kind = "framework")]
-                extern "C" {
-                    fn NSBeep();
-                }
-                NSBeep();
-            }
+    fn handle_bell(&mut self, window_id: WindowId) {
+        tracing::debug!("bell fired: audio={:?}", self.config.bell.audio);
+        match self.config.bell.audio {
+            AudioBell::Off => {}
+            AudioBell::Beep => crate::bell::beep(),
+            AudioBell::System => crate::bell::system_sound(),
         }
 
-        #[cfg(target_os = "windows")]
-        {
-            // Use MessageBeep on Windows with MB_OK (0x00000000) for default beep
-            unsafe {
-                windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(0x00000000);
-            }
+        let urgency = self.config.bell.urgency.is_enabled();
+        let notify = self.config.bell.notification.is_enabled();
+        if !urgency && !notify {
+            return;
         }
 
-        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
-        {
-            #[cfg(feature = "audio")]
-            {
-                std::thread::spawn(|| {
-                    if let Err(e) = play_bell_sound() {
-                        tracing::warn!("Failed to play bell sound: {}", e);
-                    }
-                });
-            }
-            #[cfg(not(feature = "audio"))]
-            {
-                tracing::debug!("Audio bell requested but audio feature is not enabled");
-            }
+        let Some(route) = self.router.routes.get(&window_id) else {
+            return;
+        };
+        // Urgency and notifications only matter when the window is unfocused;
+        // that is the case where a background bell would otherwise be missed.
+        if route.window.is_focused {
+            return;
+        }
+
+        if urgency {
+            route
+                .window
+                .winit_window
+                .request_user_attention(Some(UserAttentionType::Informational));
+        }
+
+        if notify {
+            let title = route.window.screen.ctx().current_title();
+            let title = if title.is_empty() { "Rio" } else { &title };
+            self.handle_desktop_notification(title, "Terminal bell");
         }
     }
 
@@ -545,10 +539,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::Bell) => {
-                // Handle audio bell
-                if self.config.bell.audio {
-                    self.handle_audio_bell();
-                }
+                self.handle_bell(window_id);
             }
             RioEventType::Rio(RioEvent::DesktopNotification { title, body }) => {
                 self.handle_desktop_notification(&title, &body);
@@ -1699,6 +1690,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 route.window.is_focused = focused;
 
                 if has_regained_focus {
+                    // Clear any bell urgency hint now that the user is back; X11
+                    // only clears it on request (Wayland treats `None` as a no-op).
+                    route.window.winit_window.request_user_attention(None);
                     route.request_redraw();
                 }
 
@@ -1923,76 +1917,4 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
         std::process::exit(0);
     }
-}
-
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn play_bell_sound() -> Result<(), Box<dyn Error>> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or("No output device available")?;
-
-    let config = device.default_output_config()?;
-
-    match config.sample_format() {
-        cpal::SampleFormat::F32 => run_bell::<f32>(&device, &config.into()),
-        cpal::SampleFormat::I16 => run_bell::<i16>(&device, &config.into()),
-        cpal::SampleFormat::U16 => run_bell::<u16>(&device, &config.into()),
-        _ => Err("Unsupported sample format".into()),
-    }
-}
-
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn run_bell<T>(
-    device: &cpal::Device,
-    config: &cpal::StreamConfig,
-) -> Result<(), Box<dyn Error>>
-where
-    T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
-{
-    let sample_rate = config.sample_rate.0 as f32;
-    let channels = config.channels as usize;
-    let duration_secs = crate::constants::BELL_DURATION.as_secs_f32();
-    let total_samples = (sample_rate * duration_secs) as usize;
-
-    let mut sample_clock = 0f32;
-    let mut samples_played = 0usize;
-
-    let stream = device.build_output_stream(
-        config,
-        move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
-            for frame in data.chunks_mut(channels) {
-                if samples_played >= total_samples {
-                    for sample in frame.iter_mut() {
-                        *sample = T::from_sample(0.0);
-                    }
-                } else {
-                    let value = (sample_clock * 440.0 * 2.0 * std::f32::consts::PI
-                        / sample_rate)
-                        .sin()
-                        * 0.2;
-                    for sample in frame.iter_mut() {
-                        *sample = T::from_sample(value);
-                    }
-                    sample_clock += 1.0;
-                    samples_played += 1;
-                }
-            }
-        },
-        |err| tracing::error!("Audio stream error: {}", err),
-        None,
-    )?;
-
-    stream.play()?;
-    std::thread::sleep(crate::constants::BELL_DURATION);
-
-    Ok(())
 }

--- a/frontends/rioterm/src/bell/canberra.rs
+++ b/frontends/rioterm/src/bell/canberra.rs
@@ -1,0 +1,133 @@
+//! Minimal runtime binding to libcanberra, loaded via `dlopen` so Rio gains no
+//! build-time dependency and degrades gracefully when the library is absent —
+//! matching how the rest of the project loads Linux system libraries (x11-dl,
+//! xkbcommon-dl, wayland-dlopen).
+//!
+//! Playing through libcanberra is what makes the bell respect the user's
+//! freedesktop event-sound theme, output routing, volume, mute and
+//! Do-Not-Disturb state.
+
+use libloading::Library;
+use std::ffi::{c_char, c_int, c_void, CString};
+use std::sync::OnceLock;
+
+type CaContext = c_void;
+type CaProplist = c_void;
+
+type CaContextCreate = unsafe extern "C" fn(*mut *mut CaContext) -> c_int;
+type CaContextChangePropsFull =
+    unsafe extern "C" fn(*mut CaContext, *mut CaProplist) -> c_int;
+type CaContextPlayFull = unsafe extern "C" fn(
+    *mut CaContext,
+    u32,
+    *mut CaProplist,
+    *mut c_void,
+    *mut c_void,
+) -> c_int;
+type CaProplistCreate = unsafe extern "C" fn(*mut *mut CaProplist) -> c_int;
+type CaProplistSets =
+    unsafe extern "C" fn(*mut CaProplist, *const c_char, *const c_char) -> c_int;
+type CaProplistDestroy = unsafe extern "C" fn(*mut CaProplist) -> c_int;
+
+struct Canberra {
+    // Kept alive so the resolved function pointers remain valid.
+    _lib: Library,
+    context: *mut CaContext,
+    play_full: CaContextPlayFull,
+    proplist_create: CaProplistCreate,
+    proplist_sets: CaProplistSets,
+    proplist_destroy: CaProplistDestroy,
+}
+
+// The context is only ever touched from the main event-loop thread, but the
+// `OnceLock` requires the stored value to be `Sync`. The raw pointer and
+// function pointers are valid for the process lifetime.
+unsafe impl Send for Canberra {}
+unsafe impl Sync for Canberra {}
+
+static CANBERRA: OnceLock<Option<Canberra>> = OnceLock::new();
+
+impl Canberra {
+    unsafe fn load() -> Option<Canberra> {
+        let lib = Library::new("libcanberra.so.0")
+            .or_else(|_| Library::new("libcanberra.so"))
+            .ok()?;
+
+        let create: CaContextCreate = *lib.get(b"ca_context_create\0").ok()?;
+        let change_props_full: CaContextChangePropsFull =
+            *lib.get(b"ca_context_change_props_full\0").ok()?;
+        let play_full: CaContextPlayFull = *lib.get(b"ca_context_play_full\0").ok()?;
+        let proplist_create: CaProplistCreate = *lib.get(b"ca_proplist_create\0").ok()?;
+        let proplist_sets: CaProplistSets = *lib.get(b"ca_proplist_sets\0").ok()?;
+        let proplist_destroy: CaProplistDestroy =
+            *lib.get(b"ca_proplist_destroy\0").ok()?;
+
+        let mut context: *mut CaContext = std::ptr::null_mut();
+        let err = create(&mut context);
+        if err != 0 || context.is_null() {
+            tracing::debug!("ca_context_create failed (error {err})");
+            return None;
+        }
+
+        // The PulseAudio/PipeWire backend refuses to open a context that has no
+        // application name (driver_open returns CA_ERROR_STATE), which would
+        // make every play silently fail. Set it up front.
+        let mut props: *mut CaProplist = std::ptr::null_mut();
+        if proplist_create(&mut props) == 0 && !props.is_null() {
+            proplist_sets(props, c"application.name".as_ptr(), c"Rio".as_ptr());
+            proplist_sets(props, c"application.id".as_ptr(), c"rio".as_ptr());
+            proplist_sets(props, c"application.icon_name".as_ptr(), c"rio".as_ptr());
+            change_props_full(context, props);
+            proplist_destroy(props);
+        }
+
+        Some(Canberra {
+            _lib: lib,
+            context,
+            play_full,
+            proplist_create,
+            proplist_sets,
+            proplist_destroy,
+        })
+    }
+}
+
+fn canberra() -> Option<&'static Canberra> {
+    CANBERRA
+        .get_or_init(|| unsafe { Canberra::load() })
+        .as_ref()
+}
+
+/// Play a freedesktop event sound by id (e.g. `"bell"`). Returns immediately;
+/// libcanberra plays the sound asynchronously. No-op if libcanberra cannot be
+/// loaded.
+pub fn play(event_id: &str) {
+    let Some(canberra) = canberra() else {
+        tracing::debug!("libcanberra unavailable; skipping system bell sound");
+        return;
+    };
+    let Ok(id) = CString::new(event_id) else {
+        return;
+    };
+
+    unsafe {
+        let mut proplist: *mut CaProplist = std::ptr::null_mut();
+        if (canberra.proplist_create)(&mut proplist) != 0 || proplist.is_null() {
+            return;
+        }
+        // CA_PROP_EVENT_ID
+        (canberra.proplist_sets)(proplist, c"event.id".as_ptr(), id.as_ptr());
+        let err = (canberra.play_full)(
+            canberra.context,
+            0,
+            proplist,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        (canberra.proplist_destroy)(proplist);
+
+        if err != 0 {
+            tracing::warn!("libcanberra failed to play '{event_id}' (error {err})");
+        }
+    }
+}

--- a/frontends/rioterm/src/bell/mod.rs
+++ b/frontends/rioterm/src/bell/mod.rs
@@ -1,0 +1,135 @@
+//! Terminal bell side effects: the audible beep and the desktop environment's
+//! event sound theme.
+
+#[cfg(all(unix, not(target_os = "macos")))]
+mod canberra;
+
+/// Play the legacy/native beep: the self-synthesized tone on Linux/BSD (behind
+/// the `audio` feature), or the OS system beep on macOS/Windows.
+pub fn beep() {
+    #[cfg(target_os = "macos")]
+    {
+        // Use the system bell sound on macOS.
+        unsafe {
+            #[link(name = "AppKit", kind = "framework")]
+            extern "C" {
+                fn NSBeep();
+            }
+            NSBeep();
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // MB_OK (0x00000000) plays the default system beep.
+        unsafe {
+            windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(0x00000000);
+        }
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        #[cfg(feature = "audio")]
+        {
+            std::thread::spawn(|| {
+                if let Err(e) = tone::play() {
+                    tracing::warn!("Failed to play bell sound: {}", e);
+                }
+            });
+        }
+        #[cfg(not(feature = "audio"))]
+        {
+            tracing::debug!(
+                "Audio bell requested but the `audio` feature is not enabled"
+            );
+        }
+    }
+}
+
+/// Play the desktop environment's configured event sound. On Linux/BSD this is
+/// the freedesktop sound theme (via libcanberra), which respects the user's
+/// theme, output routing, volume, mute and Do-Not-Disturb. On macOS/Windows the
+/// native system beep already is the system sound.
+pub fn system_sound() {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        beep();
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        canberra::play("bell");
+    }
+}
+
+#[cfg(all(
+    feature = "audio",
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+mod tone {
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use std::error::Error;
+
+    pub fn play() -> Result<(), Box<dyn Error>> {
+        let host = cpal::default_host();
+        let device = host
+            .default_output_device()
+            .ok_or("No output device available")?;
+
+        let config = device.default_output_config()?;
+
+        match config.sample_format() {
+            cpal::SampleFormat::F32 => run::<f32>(&device, &config.into()),
+            cpal::SampleFormat::I16 => run::<i16>(&device, &config.into()),
+            cpal::SampleFormat::U16 => run::<u16>(&device, &config.into()),
+            _ => Err("Unsupported sample format".into()),
+        }
+    }
+
+    fn run<T>(
+        device: &cpal::Device,
+        config: &cpal::StreamConfig,
+    ) -> Result<(), Box<dyn Error>>
+    where
+        T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
+    {
+        let sample_rate = config.sample_rate.0 as f32;
+        let channels = config.channels as usize;
+        let duration_secs = crate::constants::BELL_DURATION.as_secs_f32();
+        let total_samples = (sample_rate * duration_secs) as usize;
+
+        let mut sample_clock = 0f32;
+        let mut samples_played = 0usize;
+
+        let stream = device.build_output_stream(
+            config,
+            move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+                for frame in data.chunks_mut(channels) {
+                    if samples_played >= total_samples {
+                        for sample in frame.iter_mut() {
+                            *sample = T::from_sample(0.0);
+                        }
+                    } else {
+                        let value = (sample_clock * 440.0 * 2.0 * std::f32::consts::PI
+                            / sample_rate)
+                            .sin()
+                            * 0.2;
+                        for sample in frame.iter_mut() {
+                            *sample = T::from_sample(value);
+                        }
+                        sample_clock += 1.0;
+                        samples_played += 1;
+                    }
+                }
+            },
+            |err| tracing::error!("Audio stream error: {}", err),
+            None,
+        )?;
+
+        stream.play()?;
+        std::thread::sleep(crate::constants::BELL_DURATION);
+
+        Ok(())
+    }
+}

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -719,6 +719,14 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
+    pub fn current_title(&self) -> String {
+        self.titles
+            .titles
+            .get(&self.current_index)
+            .map(|title| title.content.clone())
+            .unwrap_or_default()
+    }
+
     pub fn update_titles(&mut self) {
         let interval_time = Duration::from_secs(2);
         if self

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -5,6 +5,7 @@
 #![windows_subsystem = "windows"]
 
 mod application;
+mod bell;
 mod bindings;
 mod cli;
 mod constants;

--- a/rio-backend/src/config/bell.rs
+++ b/rio-backend/src/config/bell.rs
@@ -1,27 +1,268 @@
+use serde::de::{self, Deserializer};
+use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Bell {
-    #[serde(default = "default_audio_bell")]
-    pub audio: bool,
+    #[serde(default = "default_audio")]
+    pub audio: AudioBell,
+    #[serde(default = "default_urgency")]
+    pub urgency: UrgencyHint,
+    #[serde(default = "default_notification")]
+    pub notification: BellNotification,
+}
+
+/// How the audible bell behaves.
+///
+/// Deserializes from either a bool (`false`/`true`, kept for backwards
+/// compatibility) or a string (`"off"`/`"beep"`/`"system"`):
+/// - `false` / `"off"` — no sound.
+/// - `true` / `"beep"` — legacy self-synthesized tone (macOS/Windows use the
+///   native system beep).
+/// - `"system"` — the desktop environment's event sound theme (Linux:
+///   libcanberra; macOS/Windows: the native system beep).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioBell {
+    Off,
+    Beep,
+    System,
+}
+
+/// Whether the bell sets the window urgency / attention hint (taskbar/dock
+/// flash) when it fires in an unfocused window. Accepts a bool or
+/// `"on"`/`"off"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UrgencyHint {
+    Disabled,
+    Enabled,
+}
+
+/// Whether the bell raises a desktop notification when it fires in an unfocused
+/// window. Accepts a bool or `"on"`/`"off"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BellNotification {
+    Disabled,
+    Enabled,
+}
+
+impl UrgencyHint {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, UrgencyHint::Enabled)
+    }
+}
+
+impl BellNotification {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, BellNotification::Enabled)
+    }
 }
 
 impl Default for Bell {
     fn default() -> Self {
         Bell {
-            audio: default_audio_bell(),
+            audio: default_audio(),
+            urgency: default_urgency(),
+            notification: default_notification(),
         }
     }
 }
 
-fn default_audio_bell() -> bool {
-    // Enable audio bell by default on macOS and Windows since they use the system sound
+fn default_audio() -> AudioBell {
+    // macOS and Windows beep with the native system sound; Linux integrates
+    // with the freedesktop event-sound theme via libcanberra.
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
-        true
+        AudioBell::Beep
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        false
+        AudioBell::System
+    }
+}
+
+fn default_urgency() -> UrgencyHint {
+    // The window urgency / attention hint is the primary reason a bell is
+    // useful on Linux (taskbar/dock flash when unfocused). Leave the existing
+    // macOS/Windows behavior untouched.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        UrgencyHint::Disabled
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        UrgencyHint::Enabled
+    }
+}
+
+fn default_notification() -> BellNotification {
+    BellNotification::Disabled
+}
+
+impl<'de> Deserialize<'de> for AudioBell {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match BoolOrStr::deserialize(deserializer)? {
+            BoolOrStr::Bool(true) => Ok(AudioBell::Beep),
+            BoolOrStr::Bool(false) => Ok(AudioBell::Off),
+            BoolOrStr::Str(s) => match s.to_ascii_lowercase().as_str() {
+                "off" | "false" | "none" => Ok(AudioBell::Off),
+                "beep" | "true" | "tone" => Ok(AudioBell::Beep),
+                "system" => Ok(AudioBell::System),
+                other => Err(de::Error::custom(format!(
+                    "invalid bell audio value {other:?} (expected false, true, or \"system\")"
+                ))),
+            },
+        }
+    }
+}
+
+impl Serialize for AudioBell {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            AudioBell::Off => serializer.serialize_bool(false),
+            AudioBell::Beep => serializer.serialize_bool(true),
+            AudioBell::System => serializer.serialize_str("system"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UrgencyHint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(if toggle_from(deserializer)? {
+            UrgencyHint::Enabled
+        } else {
+            UrgencyHint::Disabled
+        })
+    }
+}
+
+impl Serialize for UrgencyHint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bool(self.is_enabled())
+    }
+}
+
+impl<'de> Deserialize<'de> for BellNotification {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(if toggle_from(deserializer)? {
+            BellNotification::Enabled
+        } else {
+            BellNotification::Disabled
+        })
+    }
+}
+
+impl Serialize for BellNotification {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bool(self.is_enabled())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum BoolOrStr {
+    Bool(bool),
+    Str(String),
+}
+
+/// Parse an on/off toggle that accepts a TOML bool or a string spelling.
+fn toggle_from<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match BoolOrStr::deserialize(deserializer)? {
+        BoolOrStr::Bool(b) => Ok(b),
+        BoolOrStr::Str(s) => match s.to_ascii_lowercase().as_str() {
+            "on" | "true" | "enabled" | "yes" => Ok(true),
+            "off" | "false" | "disabled" | "no" | "none" => Ok(false),
+            other => Err(de::Error::custom(format!(
+                "invalid toggle value {other:?} (expected true or false)"
+            ))),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> Bell {
+        toml::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn audio_accepts_legacy_bools() {
+        assert_eq!(parse("audio = true").audio, AudioBell::Beep);
+        assert_eq!(parse("audio = false").audio, AudioBell::Off);
+    }
+
+    #[test]
+    fn audio_accepts_strings() {
+        assert_eq!(parse("audio = \"system\"").audio, AudioBell::System);
+        assert_eq!(parse("audio = \"beep\"").audio, AudioBell::Beep);
+        assert_eq!(parse("audio = \"off\"").audio, AudioBell::Off);
+    }
+
+    #[test]
+    fn audio_rejects_unknown_strings() {
+        assert!(toml::from_str::<Bell>("audio = \"loud\"").is_err());
+    }
+
+    #[test]
+    fn toggles_accept_bools_and_strings() {
+        assert!(parse("urgency = true").urgency.is_enabled());
+        assert!(!parse("urgency = false").urgency.is_enabled());
+        assert!(parse("notification = \"on\"").notification.is_enabled());
+        assert!(!parse("notification = \"off\"").notification.is_enabled());
+    }
+
+    #[test]
+    fn defaults_match_platform() {
+        let bell = Bell::default();
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        {
+            assert_eq!(bell.audio, AudioBell::System);
+            assert!(bell.urgency.is_enabled());
+        }
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        {
+            assert_eq!(bell.audio, AudioBell::Beep);
+            assert!(!bell.urgency.is_enabled());
+        }
+        assert!(!bell.notification.is_enabled());
+    }
+
+    #[test]
+    fn missing_fields_use_defaults() {
+        let bell = parse("");
+        assert_eq!(bell, Bell::default());
+    }
+
+    #[test]
+    fn round_trips_through_serialize() {
+        let bell = Bell {
+            audio: AudioBell::System,
+            urgency: UrgencyHint::Enabled,
+            notification: BellNotification::Disabled,
+        };
+        let serialized = toml::to_string(&bell).unwrap();
+        assert_eq!(toml::from_str::<Bell>(&serialized).unwrap(), bell);
     }
 }


### PR DESCRIPTION
## Summary

On Linux the terminal bell now integrates with native desktop-environment
attention mechanisms instead of only a synthesized 440 Hz tone (#1616).

## Details

- `[bell] audio` accepts `"system"` (default on Linux) to play the freedesktop
  event-sound theme via libcanberra — respecting the user's sound theme, output
  routing, volume, mute and Do-Not-Disturb. libcanberra is loaded at runtime via
  `dlopen`, so there is no build-time dependency and it degrades gracefully when
  absent. `true`/`false` stay backwards compatible (legacy tone / off).
- `[bell] urgency` (default true on Linux) sets the window urgency / attention
  hint (X11 `WM_HINTS`, Wayland `xdg-activation`) when the bell fires in an
  unfocused window, and clears it on focus-regain.
- `[bell] notification` (default false) raises an `org.freedesktop.Notifications`
  notification for an unfocused window.

The audio/urgency/notification config values use named enums rather than bare
bools to avoid boolean blindness. The cpal tone moves into a new `bell` module
alongside the libcanberra binding. New keys are documented in the rio.5 man page.

## Testing

`cargo test -p rioterm`; manual: `printf '\a'` in focused/unfocused windows under
GNOME (Wayland) and an X11 WM.

Closes #1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
