### PR TITLE
fix: claim Wayland PRIMARY selection on mouse release

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -12,7 +12,7 @@ use crate::watcher::configuration_file_updates;
 ))]
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use raw_window_handle::HasDisplayHandle;
-use rio_backend::clipboard::{Clipboard, ClipboardType};
+use rio_backend::clipboard::Clipboard;
 use rio_backend::config::colors::{ColorRgb, NamedColor};
 use rio_window::application::ApplicationHandler;
 use rio_window::event::{
@@ -1227,22 +1227,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         }
 
                         if let MouseButton::Left | MouseButton::Right = button {
-                            // Claim the PRIMARY selection regardless of
-                            // copy_on_select — middle-click / Shift+Insert paste
-                            // PRIMARY, and other terminals all populate it on
-                            // mouse selection. No-op where there is no primary
-                            // selection (macOS, Windows).
-                            route.window.screen.copy_selection(
-                                ClipboardType::Selection,
+                            route.window.screen.copy_selection_on_pointer_release(
+                                self.config.copy_on_select,
                                 &mut self.router.clipboard,
                             );
-
-                            if self.config.copy_on_select {
-                                route.window.screen.copy_selection(
-                                    ClipboardType::Clipboard,
-                                    &mut self.router.clipboard,
-                                );
-                            }
                         }
                     }
                 }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1227,6 +1227,16 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         }
 
                         if let MouseButton::Left | MouseButton::Right = button {
+                            // Claim the PRIMARY selection regardless of
+                            // copy_on_select — middle-click / Shift+Insert paste
+                            // PRIMARY, and other terminals all populate it on
+                            // mouse selection. No-op where there is no primary
+                            // selection (macOS, Windows).
+                            route.window.screen.copy_selection(
+                                ClipboardType::Selection,
+                                &mut self.router.clipboard,
+                            );
+
                             if self.config.copy_on_select {
                                 route.window.screen.copy_selection(
                                     ClipboardType::Clipboard,

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1461,12 +1461,23 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                                 return;
                             }
                         } else if matches!(button, MouseButton::Left | MouseButton::Right)
-                            && self.config.copy_on_select
                         {
+                            // Claim the PRIMARY selection regardless of
+                            // copy_on_select — middle-click / Shift+Insert paste
+                            // PRIMARY, and other terminals all populate it on
+                            // mouse selection. No-op where there is no primary
+                            // selection (macOS, Windows).
                             route.window.screen.copy_selection(
-                                ClipboardType::Clipboard,
+                                ClipboardType::Selection,
                                 &mut self.router.clipboard,
                             );
+
+                            if self.config.copy_on_select {
+                                route.window.screen.copy_selection(
+                                    ClipboardType::Clipboard,
+                                    &mut self.router.clipboard,
+                                );
+                            }
                         }
                     }
                 }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -12,7 +12,7 @@ use crate::watcher::configuration_file_updates;
 ))]
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use raw_window_handle::HasDisplayHandle;
-use rio_backend::clipboard::{Clipboard, ClipboardType};
+use rio_backend::clipboard::Clipboard;
 use rio_backend::config::colors::{ColorRgb, NamedColor};
 use rio_window::application::ApplicationHandler;
 use rio_window::event::{
@@ -1462,22 +1462,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             }
                         } else if matches!(button, MouseButton::Left | MouseButton::Right)
                         {
-                            // Claim the PRIMARY selection regardless of
-                            // copy_on_select — middle-click / Shift+Insert paste
-                            // PRIMARY, and other terminals all populate it on
-                            // mouse selection. No-op where there is no primary
-                            // selection (macOS, Windows).
-                            route.window.screen.copy_selection(
-                                ClipboardType::Selection,
+                            route.window.screen.copy_selection_on_pointer_release(
+                                self.config.copy_on_select,
                                 &mut self.router.clipboard,
                             );
-
-                            if self.config.copy_on_select {
-                                route.window.screen.copy_selection(
-                                    ClipboardType::Clipboard,
-                                    &mut self.router.clipboard,
-                                );
-                            }
                         }
                     }
                 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1738,6 +1738,16 @@ impl Screen<'_> {
         clipboard.set(ty, text);
     }
 
+    pub fn copy_selection_on_pointer_release(
+        &mut self,
+        copy_on_select: bool,
+        clipboard: &mut Clipboard,
+    ) {
+        for &ty in pointer_release_clipboard_targets(copy_on_select) {
+            self.copy_selection(ty, clipboard);
+        }
+    }
+
     #[inline]
     pub fn clear_selection(&mut self) {
         // Clear the selection on the terminal.
@@ -4484,6 +4494,18 @@ impl Screen<'_> {
     }
 }
 
+// Clipboard slots that receive the current selection when a pointer button is
+// released after a text drag. PRIMARY is unconditional — middle-click and
+// Shift+Insert paste it, and other terminals all populate it on mouse
+// selection. `copy_on_select` additionally mirrors into the system clipboard.
+fn pointer_release_clipboard_targets(copy_on_select: bool) -> &'static [ClipboardType] {
+    if copy_on_select {
+        &[ClipboardType::Selection, ClipboardType::Clipboard]
+    } else {
+        &[ClipboardType::Selection]
+    }
+}
+
 /// Apply post-processing to hyperlink URIs to remove trailing delimiters and handle uneven brackets.
 fn post_process_hyperlink_uri(uri: &str) -> String {
     let chars: Vec<char> = uri.chars().collect();
@@ -4593,6 +4615,21 @@ mod tests {
         assert_eq!(
             post_process_hyperlink_uri("https://example.com/path[with]brackets"),
             "https://example.com/path[with]brackets"
+        );
+    }
+
+    // Regression test for #1620: mouse selection must claim the PRIMARY
+    // selection regardless of copy_on_select, so middle-click / Shift+Insert
+    // paste the text just selected in Rio.
+    #[test]
+    fn pointer_release_always_claims_primary() {
+        assert_eq!(
+            pointer_release_clipboard_targets(false),
+            &[ClipboardType::Selection],
+        );
+        assert_eq!(
+            pointer_release_clipboard_targets(true),
+            &[ClipboardType::Selection, ClipboardType::Clipboard],
         );
     }
 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1784,6 +1784,16 @@ impl Screen<'_> {
         clipboard.set(ty, text);
     }
 
+    pub fn copy_selection_on_pointer_release(
+        &mut self,
+        copy_on_select: bool,
+        clipboard: &mut Clipboard,
+    ) {
+        for &ty in pointer_release_clipboard_targets(copy_on_select) {
+            self.copy_selection(ty, clipboard);
+        }
+    }
+
     #[inline]
     pub fn select_all(&mut self) {
         let current = self.context_manager.current_mut();
@@ -4851,6 +4861,18 @@ impl Screen<'_> {
     }
 }
 
+// Clipboard slots that receive the current selection when a pointer button is
+// released after a text drag. PRIMARY is unconditional — middle-click and
+// Shift+Insert paste it, and other terminals all populate it on mouse
+// selection. `copy_on_select` additionally mirrors into the system clipboard.
+fn pointer_release_clipboard_targets(copy_on_select: bool) -> &'static [ClipboardType] {
+    if copy_on_select {
+        &[ClipboardType::Selection, ClipboardType::Clipboard]
+    } else {
+        &[ClipboardType::Selection]
+    }
+}
+
 /// Apply post-processing to hyperlink URIs to remove trailing delimiters and handle uneven brackets.
 fn post_process_hyperlink_uri(uri: &str) -> String {
     let chars: Vec<char> = uri.chars().collect();
@@ -4993,6 +5015,21 @@ mod tests {
         assert_eq!(
             post_process_hyperlink_uri("https://example.com/path[with]brackets"),
             "https://example.com/path[with]brackets"
+        );
+    }
+
+    // Regression test for #1620: mouse selection must claim the PRIMARY
+    // selection regardless of copy_on_select, so middle-click / Shift+Insert
+    // paste the text just selected in Rio.
+    #[test]
+    fn pointer_release_always_claims_primary() {
+        assert_eq!(
+            pointer_release_clipboard_targets(false),
+            &[ClipboardType::Selection],
+        );
+        assert_eq!(
+            pointer_release_clipboard_targets(true),
+            &[ClipboardType::Selection, ClipboardType::Clipboard],
         );
     }
 }


### PR DESCRIPTION
## Summary

Selecting text in Rio never claimed the Wayland PRIMARY selection, so
middle-click and Shift+Insert pasted whatever other application last owned
PRIMARY instead of the text just selected. Every other Wayland terminal
populates PRIMARY on mouse selection independently of copy-on-select; do the same.

## Details

- On mouse release with a Left/Right button, claim `ClipboardType::Selection`
  regardless of `copy_on_select` (no-op on macOS/Windows where there is no
  primary selection). `copy_on_select` still independently drives the regular
  clipboard.
- The mouse-release clipboard-targeting policy is extracted into a pure helper
  (`copy_selection_on_pointer_release`) with a unit test asserting PRIMARY is in
  the target set regardless of `copy_on_select`, locking the fix against future
  refactors.

## Testing

`cargo test -p rioterm`; manual: select in Rio, middle-click / Shift+Insert in
another window pastes Rio's selection.

Closes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)
