### PR TITLE
feat: configurable per-slot font weight for bundled Cascadia Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4618,6 +4618,7 @@ dependencies = [
  "swash",
  "thiserror 2.0.18",
  "tiny-skia 0.12.0",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "ttf-parser",
  "twox-hash",

--- a/extra/man/rio.5.scd
+++ b/extra/man/rio.5.scd
@@ -147,29 +147,32 @@ This section documents the *[fonts]* table of the configuration file.
 
 	Additional directories to search for fonts.
 
-*regular* = { family = _"<string>"_, style = _"<string>"_, width = _"<string>"_, weight = _<integer>_ }
+*regular* = { family = _"<string>"_, style = _"<string>"_, weight = _<float>_ }
 
-	Regular font configuration.
+	Regular font configuration. _weight_ sets the variable-font *wght*
+	axis at render time and only takes effect for the bundled Cascadia
+	Code (axis range 200–700); for a system-installed family pick the
+	face via _style_ = _"Light"_ / _"SemiBold"_ / etc.
 
-	Default: { family = _"cascadiacode"_, style = _"Normal"_, width = _"Normal"_, weight = _400_ }
+	Default: { family = _"cascadiacode"_, style = _"Normal"_, weight = _400_ }
 
-*bold* = { family = _"<string>"_, style = _"<string>"_, width = _"<string>"_, weight = _<integer>_ }
+*bold* = { family = _"<string>"_, style = _"<string>"_, weight = _<float>_ }
 
-	Bold font configuration.
+	Bold font configuration. See _regular_ for _weight_ semantics.
 
-	Default: { family = _"cascadiacode"_, style = _"Normal"_, width = _"Normal"_, weight = _800_ }
+	Default: { family = _"cascadiacode"_, style = _"Normal"_, weight = _700_ }
 
-*italic* = { family = _"<string>"_, style = _"<string>"_, width = _"<string>"_, weight = _<integer>_ }
+*italic* = { family = _"<string>"_, style = _"<string>"_, weight = _<float>_ }
 
-	Italic font configuration.
+	Italic font configuration. See _regular_ for _weight_ semantics.
 
-	Default: { family = _"cascadiacode"_, style = _"Italic"_, width = _"Normal"_, weight = _400_ }
+	Default: { family = _"cascadiacode"_, style = _"Italic"_, weight = _400_ }
 
-*bold-italic* = { family = _"<string>"_, style = _"<string>"_, width = _"<string>"_, weight = _<integer>_ }
+*bold-italic* = { family = _"<string>"_, style = _"<string>"_, weight = _<float>_ }
 
-	Bold italic font configuration.
+	Bold italic font configuration. See _regular_ for _weight_ semantics.
 
-	Default: { family = _"cascadiacode"_, style = _"Italic"_, width = _"Normal"_, weight = _800_ }
+	Default: { family = _"cascadiacode"_, style = _"Italic"_, weight = _700_ }
 
 *extras* = [{ family = _"<string>"_ },]
 

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -417,6 +417,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     } else {
                         route.clear_errors();
                     }
+
+                    // Config reloads mutate damage state and (for font
+                    // changes) the FontLibrary and per-panel atlases, but
+                    // nothing else in this handler schedules a redraw —
+                    // the window stays idle until a later focus/input
+                    // event triggers a frame. Ask for one now so the
+                    // updated config takes effect immediately.
+                    route.request_redraw();
                 }
             }
             RioEventType::Rio(RioEvent::Exit) => {

--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -1496,6 +1496,12 @@ fn shape_run_swash(
         .shape_ctx
         .builder(font_ref)
         .size(size_u16 as f32)
+        // Clear stale coordinates before applying `wght`: swash's
+        // `ShaperBuilder::variations()` shares the same never-cleared coord
+        // buffer as the scaler, so an unweighted run shaped after a weighted
+        // one would inherit the prior `wght` (wrong advances). See the
+        // matching note in `rasterize_glyph_native`.
+        .normalized_coords(core::iter::empty::<i16>())
         .variations(var_slice.iter().copied())
         .build();
     shaper.add_str(&rasterizer.run_str_scratch);
@@ -2511,6 +2517,17 @@ fn rasterize_glyph_native(
         .builder(font_ref)
         .hint(hinting)
         .size(size_u16 as f32)
+        // Force a clean coordinate slate before applying our `wght`. swash's
+        // `variations()` only `resize()`s the shared `ScaleContext` coord
+        // buffer and overwrites the axes it's handed — it never clears stale
+        // entries. So a slot with no variation (`wght == None`, empty
+        // `var_slice`) would inherit the previous build's coordinates: an
+        // unweighted italic glyph rasterized right after a bold one would
+        // come out bold. `normalized_coords()` *does* clear, giving a
+        // deterministic default-instance slate that `variations()` then sets
+        // `wght` on. (Far more visible under dim text, which fragments runs
+        // and interleaves more weights through this one shared context.)
+        .normalized_coords(core::iter::empty::<i16>())
         .variations(var_slice.iter().copied())
         .build();
 
@@ -2654,6 +2671,127 @@ mod wght_rasterize_tests {
              instance, yielding a lighter glyph (ink {} vs {}).",
             ink_mass(&cold_glyph),
             ink_mass(&bold),
+        );
+    }
+
+    /// swash's `ScaleContext` keeps a single coordinate buffer that every
+    /// `builder(..).variations(..)` reuses. `variations()` only `resize()`s
+    /// and overwrites the axes it's given — it never clears stale entries —
+    /// so a slot with `wght == None` (empty variation set) silently inherits
+    /// the *previous* build's `wght` coordinate. In the grid renderer the
+    /// one `scale_ctx` is shared across every font_id, so an unweighted
+    /// italic glyph rasterized right after a bold (wght 700) glyph comes out
+    /// bold. That's the rare "false bold" artifact — rare because it needs a
+    /// weighted build to immediately precede an unweighted one, and far more
+    /// frequent under dim text, which fragments runs and interleaves more
+    /// weights through the shared context.
+    ///
+    /// This test drives two font_ids through one rasterizer: id 0 = bold
+    /// (wght 700), id 1 = unweighted (wght None, the italic/regular-default
+    /// case). It pins the invariant that the unweighted glyph rasterizes
+    /// identically whether or not a bold glyph was rasterized just before it.
+    /// Fails before the fix (post-bold render matches bold's heavier ink),
+    /// passes once the builder clears coordinates before applying `wght`.
+    #[test]
+    fn unweighted_slot_unaffected_by_prior_bold_rasterize() {
+        let mut data = FontLibraryData::default();
+        // id 0: bold slot (wght 700).
+        data.insert(
+            FontData::from_static_slice_with_wght(
+                FONT_CASCADIA_CODE_NF,
+                Some(700.0),
+                Some(Weight::BOLD),
+            )
+            .expect("load bold slot"),
+        );
+        // id 1: unweighted slot (wght None) — same upright face, default
+        // instance, mirroring how the italic / regular-default slots load.
+        data.insert(
+            FontData::from_static_slice_with_wght(FONT_CASCADIA_CODE_NF, None, None)
+                .expect("load unweighted slot"),
+        );
+        let lib = FontLibrary {
+            inner: Arc::new(parking_lot::RwLock::new(data)),
+        };
+        assert_eq!(lib.inner.read().get(&0).wght_variation, Some(700.0));
+        assert_eq!(lib.inner.read().get(&1).wght_variation, None);
+
+        let glyph_id = FontRef::from_index(FONT_CASCADIA_CODE_NF, 0)
+            .expect("font ref")
+            .charmap()
+            .map('a' as u32);
+        assert_ne!(glyph_id, 0, "'a' must be present in Cascadia Code");
+
+        let size_u16 = 32u16;
+        let bold_entry = lib.inner.read().get_data(&0).expect("bold data");
+        let plain_entry = lib.inner.read().get_data(&1).expect("plain data");
+
+        // Baseline: rasterize the unweighted glyph on a fresh rasterizer
+        // with no prior build polluting the shared ScaleContext. This is the
+        // correct default-instance reference.
+        let mut clean = GridGlyphRasterizer::new();
+        clean.font_data_cache.insert(1, plain_entry.clone());
+        clean.wght_variation_cache.insert(1, None);
+        let plain_ref = rasterize_glyph_native(
+            &mut clean, 1, glyph_id, size_u16, false, false, false, &lib,
+        )
+        .expect("baseline rasterize");
+
+        // Leak path: rasterize the BOLD glyph first (seeds the shared
+        // scale_ctx coords with wght 700), then the unweighted glyph through
+        // the SAME rasterizer. Without the fix, the unweighted build inherits
+        // the stale 700 coordinate and renders bold.
+        let mut shared = GridGlyphRasterizer::new();
+        shared.font_data_cache.insert(0, bold_entry);
+        shared.wght_variation_cache.insert(0, Some(700.0));
+        shared.font_data_cache.insert(1, plain_entry);
+        shared.wght_variation_cache.insert(1, None);
+        let bold_first = rasterize_glyph_native(
+            &mut shared,
+            0,
+            glyph_id,
+            size_u16,
+            false,
+            false,
+            false,
+            &lib,
+        )
+        .expect("bold rasterize");
+        let plain_after = rasterize_glyph_native(
+            &mut shared,
+            1,
+            glyph_id,
+            size_u16,
+            false,
+            false,
+            false,
+            &lib,
+        )
+        .expect("post-bold unweighted rasterize");
+
+        assert!(ink_mass(&plain_ref) > 0, "baseline glyph must have ink");
+        // Sanity: bold really is heavier than the unweighted default, so the
+        // assertion below can actually distinguish a leak.
+        assert!(
+            ink_mass(&bold_first) > ink_mass(&plain_ref),
+            "bold glyph (ink {}) must be heavier than the unweighted default \
+             (ink {}) for this test to be meaningful",
+            ink_mass(&bold_first),
+            ink_mass(&plain_ref),
+        );
+        assert_eq!(
+            (
+                plain_after.width,
+                plain_after.height,
+                ink_mass(&plain_after)
+            ),
+            (plain_ref.width, plain_ref.height, ink_mass(&plain_ref)),
+            "an unweighted (wght None) glyph must rasterize at the default \
+             instance regardless of a preceding bold rasterize through the \
+             shared ScaleContext. It instead inherited the stale wght 700 \
+             coordinate (ink {} vs the correct {}), rendering a false bold.",
+            ink_mass(&plain_after),
+            ink_mass(&plain_ref),
         );
     }
 }

--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -2629,18 +2629,20 @@ mod wght_rasterize_tests {
         let mut warm = GridGlyphRasterizer::new();
         warm.font_data_cache.insert(0, font_entry.clone());
         warm.wght_variation_cache.insert(0, Some(700.0));
-        let bold =
-            rasterize_glyph_native(&mut warm, 0, glyph_id, size_u16, false, false, false, &lib)
-                .expect("warm rasterize");
+        let bold = rasterize_glyph_native(
+            &mut warm, 0, glyph_id, size_u16, false, false, false, &lib,
+        )
+        .expect("warm rasterize");
 
         // Cold path: shaping was skipped (run-cache *hit*), so the side
         // cache has no entry for this font_id. This is the buggy case.
         let mut cold = GridGlyphRasterizer::new();
         cold.font_data_cache.insert(0, font_entry);
         // Intentionally leave `wght_variation_cache` empty.
-        let cold_glyph =
-            rasterize_glyph_native(&mut cold, 0, glyph_id, size_u16, false, false, false, &lib)
-                .expect("cold rasterize");
+        let cold_glyph = rasterize_glyph_native(
+            &mut cold, 0, glyph_id, size_u16, false, false, false, &lib,
+        )
+        .expect("cold rasterize");
 
         assert!(ink_mass(&bold) > 0, "reference glyph must have ink");
         assert_eq!(

--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -1174,6 +1174,13 @@ pub struct GridGlyphRasterizer {
             rio_backend::sugarloaf::swash::CacheKey,
         ),
     >,
+    /// `wght` axis value per font_id, populated lazily on first shape /
+    /// rasterize. `None` means the face has no variable-axis override
+    /// (system-loaded fonts), `Some(v)` means a bundled variable face
+    /// with a baked `wght` value (Cascadia Code regular at 400, bold at
+    /// 700, or user-overridden values from `fonts.<slot>.weight`).
+    #[cfg(not(target_os = "macos"))]
+    wght_variation_cache: FxHashMap<u32, Option<f32>>,
 }
 
 impl Default for GridGlyphRasterizer {
@@ -1207,6 +1214,8 @@ impl GridGlyphRasterizer {
             scale_ctx: rio_backend::sugarloaf::swash::scale::ScaleContext::new(),
             #[cfg(not(target_os = "macos"))]
             font_data_cache: FxHashMap::default(),
+            #[cfg(not(target_os = "macos"))]
+            wght_variation_cache: FxHashMap::default(),
         }
     }
 
@@ -1439,7 +1448,7 @@ fn shape_run_swash(
     size_bucket: u16,
     font_library: &FontLibrary,
 ) -> Option<(Vec<ShapedGlyph>, i16)> {
-    use rio_backend::sugarloaf::swash::FontRef;
+    use rio_backend::sugarloaf::swash::{FontRef, Setting};
 
     let font_entry = rasterizer
         .font_data_cache
@@ -1455,6 +1464,26 @@ fn shape_run_swash(
         key: font_entry.2,
     };
 
+    let wght = *rasterizer
+        .wght_variation_cache
+        .entry(font_id)
+        .or_insert_with(|| {
+            font_library
+                .inner
+                .read()
+                .get(&(font_id as usize))
+                .wght_variation
+        });
+    const WGHT_TAG: rio_backend::sugarloaf::swash::Tag = u32::from_be_bytes(*b"wght");
+    let wght_var = wght.map(|v| Setting {
+        tag: WGHT_TAG,
+        value: v,
+    });
+    let var_slice: &[Setting<f32>] = match wght_var {
+        Some(ref s) => std::slice::from_ref(s),
+        None => &[],
+    };
+
     let ascent_px = *rasterizer
         .ascent_cache
         .entry((font_id, size_bucket))
@@ -1467,6 +1496,7 @@ fn shape_run_swash(
         .shape_ctx
         .builder(font_ref)
         .size(size_u16 as f32)
+        .variations(var_slice.iter().copied())
         .build();
     shaper.add_str(&rasterizer.run_str_scratch);
     let mut glyphs: Vec<ShapedGlyph> = Vec::new();
@@ -2430,7 +2460,7 @@ fn rasterize_glyph_native(
             Render, Source, StrikeWith,
         },
         zeno::{Angle, Format, Transform},
-        FontRef,
+        FontRef, Setting,
     };
 
     let font_entry = rasterizer.font_data_cache.get(&font_id)?.clone();
@@ -2440,12 +2470,31 @@ fn rasterize_glyph_native(
         key: font_entry.2,
     };
 
+    // wght_variation_cache is populated by the matching shape_run_swash
+    // call earlier in the frame; `copied().flatten()` keeps `None` if it
+    // wasn't (a glyph that bypassed shaping has no variable-axis override).
+    let wght = rasterizer
+        .wght_variation_cache
+        .get(&font_id)
+        .copied()
+        .flatten();
+    const WGHT_TAG: rio_backend::sugarloaf::swash::Tag = u32::from_be_bytes(*b"wght");
+    let wght_var = wght.map(|v| Setting {
+        tag: WGHT_TAG,
+        value: v,
+    });
+    let var_slice: &[Setting<f32>] = match wght_var {
+        Some(ref s) => std::slice::from_ref(s),
+        None => &[],
+    };
+
     let hinting = font_library_hinting(rasterizer);
     let mut scaler = rasterizer
         .scale_ctx
         .builder(font_ref)
         .hint(hinting)
         .size(size_u16 as f32)
+        .variations(var_slice.iter().copied())
         .build();
 
     let sources: &[Source] = &[

--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -2041,6 +2041,7 @@ pub fn build_row_fg(
                 is_emoji,
                 synthetic_italic,
                 synthetic_bold,
+                font_library,
             ) else {
                 continue;
             };
@@ -2273,6 +2274,7 @@ fn ensure_glyph_by_id(
     is_emoji: bool,
     synthetic_italic: bool,
     synthetic_bold: bool,
+    font_library: &FontLibrary,
 ) -> Option<(GlyphKey, AtlasSlot, bool)> {
     let key = GlyphKey {
         font_id,
@@ -2295,6 +2297,7 @@ fn ensure_glyph_by_id(
         is_emoji,
         synthetic_bold,
         synthetic_italic,
+        font_library,
     )?;
     let is_color = raw.is_color;
 
@@ -2424,6 +2427,10 @@ fn rasterize_glyph_native(
     is_emoji: bool,
     synthetic_bold: bool,
     synthetic_italic: bool,
+    // macOS bakes `wght` into the CTFont handle at load time, so the
+    // rasterize path needs no library lookup — accepted for signature
+    // parity with the swash backend.
+    _font_library: &FontLibrary,
 ) -> Option<RawGlyph> {
     let handle = rasterizer.handle_cache.get(&font_id)?.clone();
     let raw = rio_backend::sugarloaf::font::macos::rasterize_glyph(
@@ -2453,6 +2460,7 @@ fn rasterize_glyph_native(
     _is_emoji: bool,
     synthetic_bold: bool,
     synthetic_italic: bool,
+    font_library: &FontLibrary,
 ) -> Option<RawGlyph> {
     use rio_backend::sugarloaf::swash::{
         scale::{
@@ -2470,14 +2478,23 @@ fn rasterize_glyph_native(
         key: font_entry.2,
     };
 
-    // wght_variation_cache is populated by the matching shape_run_swash
-    // call earlier in the frame; `copied().flatten()` keeps `None` if it
-    // wasn't (a glyph that bypassed shaping has no variable-axis override).
-    let wght = rasterizer
+    // Resolve the `wght` axis the same deterministic way shaping does:
+    // populate the per-font_id cache from the font library on a miss.
+    // Rasterization must NOT depend on `shape_run_swash` having run this
+    // frame — when the shaped-run cache hits, shaping is skipped, and a
+    // bare `flatten()` to `None` here would rasterize a bold slot at the
+    // variable font's default 400 instance (the "some glyphs aren't bold"
+    // artifact, varying per window with cache state).
+    let wght = *rasterizer
         .wght_variation_cache
-        .get(&font_id)
-        .copied()
-        .flatten();
+        .entry(font_id)
+        .or_insert_with(|| {
+            font_library
+                .inner
+                .read()
+                .get(&(font_id as usize))
+                .wght_variation
+        });
     const WGHT_TAG: rio_backend::sugarloaf::swash::Tag = u32::from_be_bytes(*b"wght");
     let wght_var = wght.map(|v| Setting {
         tag: WGHT_TAG,
@@ -2544,4 +2561,97 @@ fn font_library_hinting(_r: &GridGlyphRasterizer) -> bool {
     // For now the lock on swash rasterize is a small fraction of
     // render time; optimise if profiling flags it.
     true
+}
+
+/// A bundled variable-font slot (e.g. bold / bold-italic) bakes its
+/// weight into the swash `wght` axis at *rasterize* time via
+/// `wght_variation`. The grid rasterizer feeds that axis through a
+/// per-font_id side cache (`wght_variation_cache`) that is populated by
+/// `shape_run_swash`. But shaping is skipped whenever the shaped-run
+/// cache hits (`run_cache_get(..).is_some()`), so a glyph can reach
+/// `rasterize_glyph_native` with the side cache still empty for its
+/// font_id. The old code then `flatten()`ed the miss to `None` and
+/// rasterized at the variable font's default 400 instance — producing a
+/// *non-bold* glyph for a bold slot, depending purely on whether shaping
+/// happened to run this frame. That's the "some symbols aren't bold, and
+/// which ones varies per window" artifact.
+///
+/// This test pins the invariant: the rasterized outline for a bold slot
+/// must be identical whether or not `shape_run_swash` pre-populated the
+/// side cache. It fails before the fix (cold path renders lighter) and
+/// passes once `rasterize_glyph_native` resolves `wght` from the font
+/// library on a cache miss instead of defaulting to `None`.
+#[cfg(all(test, not(target_os = "macos")))]
+mod wght_rasterize_tests {
+    use super::*;
+    use rio_backend::sugarloaf::font::constants::FONT_CASCADIA_CODE_NF;
+    use rio_backend::sugarloaf::font::{FontData, FontLibrary, FontLibraryData};
+    use rio_backend::sugarloaf::swash::{FontRef, Weight};
+    use std::sync::Arc;
+
+    fn ink_mass(g: &RawGlyph) -> u64 {
+        g.bytes.iter().map(|&b| b as u64).sum()
+    }
+
+    #[test]
+    fn bold_slot_rasterizes_bold_without_prior_shaping() {
+        // font_id 0 = bundled Cascadia baked to the bold axis (wght 700),
+        // exactly how the bold / bold-italic slots are loaded.
+        let mut data = FontLibraryData::default();
+        data.insert(
+            FontData::from_static_slice_with_wght(
+                FONT_CASCADIA_CODE_NF,
+                Some(700.0),
+                Some(Weight::BOLD),
+            )
+            .expect("load bold slot"),
+        );
+        let lib = FontLibrary {
+            inner: Arc::new(parking_lot::RwLock::new(data)),
+        };
+        assert_eq!(
+            lib.inner.read().get(&0).wght_variation,
+            Some(700.0),
+            "slot must carry the bold wght axis override"
+        );
+
+        let glyph_id = FontRef::from_index(FONT_CASCADIA_CODE_NF, 0)
+            .expect("font ref")
+            .charmap()
+            .map('a' as u32);
+        assert_ne!(glyph_id, 0, "'a' must be present in Cascadia Code");
+
+        let size_u16 = 32u16;
+        let font_entry = lib.inner.read().get_data(&0).expect("font data");
+
+        // Warm path: side cache populated, as a run-cache *miss* would
+        // leave it after `shape_run_swash`. This is the correct reference.
+        let mut warm = GridGlyphRasterizer::new();
+        warm.font_data_cache.insert(0, font_entry.clone());
+        warm.wght_variation_cache.insert(0, Some(700.0));
+        let bold =
+            rasterize_glyph_native(&mut warm, 0, glyph_id, size_u16, false, false, false, &lib)
+                .expect("warm rasterize");
+
+        // Cold path: shaping was skipped (run-cache *hit*), so the side
+        // cache has no entry for this font_id. This is the buggy case.
+        let mut cold = GridGlyphRasterizer::new();
+        cold.font_data_cache.insert(0, font_entry);
+        // Intentionally leave `wght_variation_cache` empty.
+        let cold_glyph =
+            rasterize_glyph_native(&mut cold, 0, glyph_id, size_u16, false, false, false, &lib)
+                .expect("cold rasterize");
+
+        assert!(ink_mass(&bold) > 0, "reference glyph must have ink");
+        assert_eq!(
+            (cold_glyph.width, cold_glyph.height, ink_mass(&cold_glyph)),
+            (bold.width, bold.height, ink_mass(&bold)),
+            "bold-slot glyph must rasterize at wght 700 regardless of whether \
+             shape_run_swash ran this frame. The cold path (run-cache hit -> no \
+             side-cache entry) fell back to the variable font's default 400 \
+             instance, yielding a lighter glyph (ink {} vs {}).",
+            ink_mass(&cold_glyph),
+            ink_mass(&bold),
+        );
+    }
 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -467,6 +467,21 @@ impl Screen<'_> {
 
         if should_update_font_library {
             self.sugarloaf.update_font(font_library);
+            // The rasterizer's per-font_id caches (font_data, wght_variation,
+            // ascent, run, synthesis, handle) point at the previous
+            // FontLibrary's faces — keeping them after a font rebuild would
+            // shape/raster the new ids against stale bytes, ascents, and
+            // variable-axis values. Replace with a fresh rasterizer so the
+            // next frame repopulates from the new library.
+            self.grid_rasterizer = crate::grid_emit::GridGlyphRasterizer::new();
+            // Per-panel GridRenderers hold glyph atlases keyed by
+            // (font_id, glyph_id, size_bucket); an atlas hit short-circuits
+            // rasterization, so leaving them around would keep serving the
+            // old wght / outlines from existing tabs while only freshly-
+            // opened tabs (which lazily build a new GridRenderer) would
+            // pick up the reload. Drop them so `ensure_grid` reinstates
+            // each panel with an empty atlas on the next frame.
+            self.grids.clear();
         }
         let s = self.sugarloaf.style_mut();
         s.font_size = config.fonts.size;
@@ -519,6 +534,17 @@ impl Screen<'_> {
                 let mut terminal = current_context.terminal.lock();
                 current_context.renderable_content =
                     RenderableContent::from_cursor_config(&config.cursor);
+                if should_update_font_library {
+                    // Font library swap invalidates every cached glyph but
+                    // doesn't dirty the panel by itself, so the renderer's
+                    // damage gate keeps serving the previous frame until
+                    // some other event (focus, input, resize) marks it
+                    // dirty. Force a full repaint here so each existing
+                    // panel re-emits its cells against the new fonts.
+                    current_context.renderable_content.pending_update.set_terminal_damage(
+                        rio_backend::event::TerminalDamage::Full,
+                    );
+                }
                 let shape = config.cursor.shape;
                 terminal.cursor_shape = shape;
                 terminal.default_cursor_shape = shape;

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -541,9 +541,10 @@ impl Screen<'_> {
                     // some other event (focus, input, resize) marks it
                     // dirty. Force a full repaint here so each existing
                     // panel re-emits its cells against the new fonts.
-                    current_context.renderable_content.pending_update.set_terminal_damage(
-                        rio_backend::event::TerminalDamage::Full,
-                    );
+                    current_context
+                        .renderable_content
+                        .pending_update
+                        .set_terminal_damage(rio_backend::event::TerminalDamage::Full);
                 }
                 let shape = config.cursor.shape;
                 terminal.cursor_shape = shape;

--- a/sugarloaf/Cargo.toml
+++ b/sugarloaf/Cargo.toml
@@ -125,6 +125,7 @@ rio-window = { workspace = true }
 png = "0.17.16"
 deflate = "1.0.0"
 criterion = { workspace = true }
+toml = "0.9.2"
 
 [features]
 default = ["scale", "render"]

--- a/sugarloaf/src/font/fonts.rs
+++ b/sugarloaf/src/font/fonts.rs
@@ -82,6 +82,14 @@ pub struct SugarloafFont {
     pub family: String,
     #[serde(default)]
     pub style: FontStyle,
+    /// `wght` axis override for this slot. Only takes effect when the slot
+    /// is served by the bundled Cascadia Code variable font — i.e. when
+    /// `family` is the default and no system face was matched. Lets users
+    /// dial the regular face below its 400 default (e.g. 350 for a lighter
+    /// look) or pull the bold face below 700. For a non-bundled family,
+    /// pick the weight via `style = "Light"` / `"SemiBold"` instead.
+    #[serde(default)]
+    pub weight: Option<f32>,
 }
 
 impl Default for SugarloafFont {
@@ -89,6 +97,7 @@ impl Default for SugarloafFont {
         Self {
             family: default_font_family(),
             style: FontStyle::Default,
+            weight: None,
         }
     }
 }
@@ -149,6 +158,32 @@ pub struct SugarloafFonts {
     pub disable_warnings_not_found: bool,
     #[serde(default = "Option::default", rename = "additional-dirs")]
     pub additional_dirs: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod toml_tests {
+    use super::*;
+
+    /// User-facing TOML snippet must round-trip into `weight` field as
+    /// `Some(f32)`, regardless of integer vs float spelling and whether
+    /// `style` is also set on the same slot.
+    #[test]
+    fn weight_field_parses_from_toml() {
+        let snippet = r#"
+[regular]
+weight = 300
+style = "Light"
+
+[bold]
+weight = 600
+style = "SemiBold"
+"#;
+        let fonts: SugarloafFonts = toml::from_str(snippet).unwrap();
+        assert_eq!(fonts.regular.weight, Some(300.0));
+        assert_eq!(fonts.regular.style, FontStyle::Named("Light".into()));
+        assert_eq!(fonts.bold.weight, Some(600.0));
+        assert_eq!(fonts.bold.style, FontStyle::Named("SemiBold".into()));
+    }
 }
 
 pub fn parse_unicode(input: &str) -> Option<char> {

--- a/sugarloaf/src/font/mod.rs
+++ b/sugarloaf/src/font/mod.rs
@@ -886,7 +886,7 @@ impl FontLibraryData {
                     fonts_not_fount.push(spec.to_owned());
                 }
 
-                self.insert(load_fallback_from_memory(Slot::Regular));
+                self.insert(load_fallback_from_memory(Slot::Regular, spec.weight));
             }
         }
 
@@ -914,7 +914,7 @@ impl FontLibraryData {
                         // forces a cascade-discovery fallback at shape
                         // time — which can resolve bold to a system font
                         // with mismatched metrics.
-                        self.insert(load_fallback_from_memory(slot));
+                        self.insert(load_fallback_from_memory(slot, spec.weight));
                     } else {
                         // Family resolved but the requested style/weight
                         // didn't — log-only, no UI warning. Alias to the
@@ -1160,7 +1160,7 @@ impl PartialEq for FontData {
 impl FontData {
     #[inline]
     pub fn is_bold(&self) -> bool {
-        self.weight >= Weight(700)
+        self.weight >= Weight::BOLD
     }
 
     #[inline]
@@ -1317,7 +1317,7 @@ impl FontData {
         let (should_embolden, should_italicize) = synth_decisions(
             slot,
             font_spec,
-            weight >= Weight(700),
+            weight >= Weight::BOLD,
             style == Style::Italic,
         );
 
@@ -1451,33 +1451,34 @@ impl FontData {
     pub fn from_static_slice(
         data: &'static [u8],
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::from_static_slice_with_wght(data, None)
+        Self::from_static_slice_with_wght(data, None, None)
     }
 
-    /// Like [`from_static_slice`] but optionally bakes a `wght` axis
-    /// value into the loaded face. Mirrors ghostty's `Face.setVariations`
-    /// pattern: load the same variable-font bytes for every weight slot,
-    /// then set the `wght` axis post-construction so the rasterizer pulls
-    /// the right outlines (regular vs. bold) from a single source file.
+    /// Like [`from_static_slice`] but lets the caller bake a `wght` axis
+    /// value into the loaded face and/or override the logical weight
+    /// metadata. Mirrors ghostty's `Face.setVariations` pattern: load the
+    /// same variable-font bytes for every weight slot, then set the `wght`
+    /// axis post-construction so the rasterizer pulls the right outlines
+    /// from a single source file.
     ///
-    /// `wght = None` leaves the font at its default instance. Pass
-    /// `Some(700.0)` for the bold slot, etc.
+    /// The two parameters intentionally drive different things:
+    ///   - `wght` is the variable-font axis value used at rasterization
+    ///     time. `None` leaves the font at its default instance.
+    ///   - `logical_weight` is the CSS-style category used for cascade
+    ///     matching and `is_bold()`. `None` lets the font report its
+    ///     attribute-table weight (typically 400 for a variable file's
+    ///     default instance). Pass `Some(Weight::BOLD)` to mark the face
+    ///     as the bold slot regardless of the axis value the user picked.
     pub fn from_static_slice_with_wght(
         data: &'static [u8],
         wght: Option<f32>,
+        logical_weight: Option<swash::Weight>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let font = FontRef::from_index(data, 0).unwrap();
         let (offset, key) = (font.offset, font.key);
         let attributes = font.attributes();
         let style = attributes.style();
-        // The default instance of a variable font reports the regular
-        // weight (e.g. 400). When the caller asks for a specific `wght`
-        // value we override the reported weight so `is_bold()` and the
-        // bold-spec lookup walk match the slot's intent.
-        let weight = match wght {
-            Some(v) => swash::Weight(v.round().clamp(0.0, u16::MAX as f32) as u16),
-            None => attributes.weight(),
-        };
+        let weight = logical_weight.unwrap_or_else(|| attributes.weight());
         let stretch = attributes.stretch();
         let synth = attributes.synthesize(attributes);
         let is_emoji = has_color_tables(&font);
@@ -1816,17 +1817,28 @@ fn find_font(
 /// `ghostty/src/font/SharedGridSet.zig:264-317`): regular and bold load
 /// the same upright variable file, italic and bold-italic load the same
 /// italic variable file, and the bold slots set the `wght` axis to 700.
-fn load_fallback_from_memory(slot: Slot) -> FontData {
+///
+/// `weight_override` lets the user dial the `wght` axis (config field
+/// `fonts.<slot>.weight`). When set, it replaces the slot's default
+/// rendering value (400-ish for regular, 700 for bold). The logical
+/// weight reported to the cascade walk is decided separately from the
+/// axis value: bold slots always mark the face as `Weight::BOLD` so
+/// `is_bold()` and the bold-text lookup walk match the slot's intent,
+/// even when the user picked a lighter rendering axis (e.g. 500).
+fn load_fallback_from_memory(slot: Slot, weight_override: Option<f32>) -> FontData {
     use constants::{FONT_CASCADIA_CODE_NF, FONT_CASCADIA_CODE_NF_ITALIC, WGHT_BOLD};
 
-    let (data, wght) = match slot {
+    let (data, slot_default_wght) = match slot {
         Slot::Regular => (FONT_CASCADIA_CODE_NF, None),
         Slot::Bold => (FONT_CASCADIA_CODE_NF, Some(WGHT_BOLD)),
         Slot::Italic => (FONT_CASCADIA_CODE_NF_ITALIC, None),
         Slot::BoldItalic => (FONT_CASCADIA_CODE_NF_ITALIC, Some(WGHT_BOLD)),
     };
 
-    FontData::from_static_slice_with_wght(data, wght).unwrap()
+    let wght = weight_override.or(slot_default_wght);
+    let logical_weight = slot.is_bold().then_some(Weight::BOLD);
+
+    FontData::from_static_slice_with_wght(data, wght, logical_weight).unwrap()
 }
 
 #[cfg(test)]
@@ -1882,10 +1894,10 @@ mod alias_tests {
     /// embedded bold slot unloaded with default config.
     #[test]
     fn fallback_bold_slot_reports_is_bold() {
-        let regular = load_fallback_from_memory(Slot::Regular);
-        let bold = load_fallback_from_memory(Slot::Bold);
-        let italic = load_fallback_from_memory(Slot::Italic);
-        let bold_italic = load_fallback_from_memory(Slot::BoldItalic);
+        let regular = load_fallback_from_memory(Slot::Regular, None);
+        let bold = load_fallback_from_memory(Slot::Bold, None);
+        let italic = load_fallback_from_memory(Slot::Italic, None);
+        let bold_italic = load_fallback_from_memory(Slot::BoldItalic, None);
 
         assert!(!regular.is_bold(), "regular slot must not be bold");
         assert!(bold.is_bold(), "bold slot must report is_bold");
@@ -1907,6 +1919,72 @@ mod alias_tests {
         assert_eq!(bold_italic.wght_variation, Some(constants::WGHT_BOLD));
         assert_eq!(regular.wght_variation, None);
         assert_eq!(italic.wght_variation, None);
+    }
+
+    /// End-to-end: a `SugarloafFonts` spec with per-slot `weight`
+    /// overrides flows through `FontLibrary::load` into the right
+    /// `wght_variation` on each slot's `FontData`. Pins the path
+    /// `fonts.<slot>.weight` config → bundled Cascadia Code → swash
+    /// variable axis at shape/rasterize time.
+    #[test]
+    fn load_applies_per_slot_weight_overrides() {
+        use crate::font::fonts::{SugarloafFont, SugarloafFonts};
+
+        let spec = SugarloafFonts {
+            regular: SugarloafFont {
+                weight: Some(300.0),
+                ..SugarloafFont::default()
+            },
+            bold: SugarloafFont {
+                weight: Some(600.0),
+                ..SugarloafFont::default()
+            },
+            ..SugarloafFonts::default()
+        };
+
+        let mut lib = FontLibraryData::default();
+        let _ = lib.load(spec);
+
+        assert_eq!(lib.get(&0).wght_variation, Some(300.0));
+        assert!(!lib.get(&0).is_bold(), "regular stays non-bold");
+
+        assert_eq!(lib.get(&1).wght_variation, None);
+        assert!(!lib.get(&1).is_bold());
+
+        assert_eq!(lib.get(&2).wght_variation, Some(600.0));
+        assert!(
+            lib.get(&2).is_bold(),
+            "bold slot keeps is_bold() even at user-set 600"
+        );
+
+        assert_eq!(
+            lib.get(&3).wght_variation,
+            Some(constants::WGHT_BOLD),
+            "bold-italic without override falls back to slot default"
+        );
+        assert!(lib.get(&3).is_bold());
+    }
+
+    /// User-supplied `weight` override drives only the variable-font
+    /// `wght` axis. The cascade-match weight (`is_bold()`) is decided by
+    /// the slot, so a user asking for a less-heavy bold (e.g. 500) still
+    /// gets a face that satisfies bold-text requests in the lookup walk.
+    #[test]
+    fn fallback_user_weight_decouples_axis_from_logical_weight() {
+        let light_regular = load_fallback_from_memory(Slot::Regular, Some(350.0));
+        let light_bold = load_fallback_from_memory(Slot::Bold, Some(500.0));
+
+        assert_eq!(light_regular.wght_variation, Some(350.0));
+        assert!(
+            !light_regular.is_bold(),
+            "lighter regular must not register as bold"
+        );
+
+        assert_eq!(light_bold.wght_variation, Some(500.0));
+        assert!(
+            light_bold.is_bold(),
+            "bold slot must keep is_bold() even when the user picks a lighter wght"
+        );
     }
 
     /// Aliases share the target's `metrics_cache`, so requesting


### PR DESCRIPTION
## Summary

Adds an optional `weight = <number>` field to each per-slot font section
(`fonts.regular`, `fonts.bold`, `fonts.italic`, `fonts.bold-italic`). When the
slot is served by the bundled Cascadia Code variable font, the value is baked
into the `wght` axis at shape and rasterize time — so a user who wants a lighter
regular face can write `weight = 350` instead of installing a system "Cascadia
Code Light". Refs #1577.

## Details

- `from_static_slice_with_wght` takes the `wght` axis value and the logical
  CSS-style weight as separate parameters, decoupling the rendered axis from the
  cascade-match weight — so `is_bold()` and bold-fallback routing still see
  `Weight::BOLD` for bold slots even when the user picks a lighter axis (e.g. 500).
- The terminal grid path (`grid_emit::shape_run_swash` / `rasterize_glyph_native`)
  now applies the `wght` variation via a per-rasterizer cache mirroring
  `sugarloaf::text`; macOS gets it through the `CTFont` handle.
- Config live-reload propagates a `weight` change: the grid rasterizer and per-panel
  glyph atlases are rebuilt and a redraw is scheduled (the `UpdateConfig` handler
  previously mutated state without requesting a frame).
- The 700 bold threshold is centralized on `swash::Weight::BOLD`.
- man page: per-slot signatures updated to reflect that `weight` deserializes, bold
  defaults corrected to `WGHT_BOLD` (700), and the phantom `width` column dropped.

## Testing

`cargo test -p sugarloaf` — TOML deserialization, full `FontLibrary::load`
per-slot `wght_variation`, and axis/logical-weight decoupling.

Refs #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)
