### PR TITLE
feat: smart double-click selection (OSC 8 links + regex rules)

### DIFF
--- a/extra/man/rio.5.scd
+++ b/extra/man/rio.5.scd
@@ -403,6 +403,60 @@ This section documents the *[renderer]* table of the configuration file.
 
 	Default: _3_
 
+# SMART SELECTION
+
+This section documents the *[smart-selection]* table of the configuration file.
+
+Double-clicking inside the terminal selects the token under the cursor. The
+resolution order is:
+
+. OSC 8 hyperlink span (the producer-emitted link, including non-URL anchor
+	text and soft-wrapped spans).
+. Smart-selection rules listed here: each rule's regex is matched against the
+	soft-wrapped logical line containing the click; the highest-precision
+	match that covers the click wins, with longest match as the tiebreaker.
+. The classic semantic selection (word-by-word stopping at the separator
+	characters).
+
+Steps 2 and 3 only run when step 1 doesn't apply, so producers that emit
+OSC 8 always win.
+
+*enabled* = _true_ | _false_
+
+	Master switch for the rule engine. When _false_, double-click goes
+	straight from the OSC 8 fast path to the semantic fallback.
+
+	Default: _true_
+
+*rules* = [{ name = _"<string>"_, regex = _"<string>"_, precision = _<integer>_, enabled = _true_ | _false_ },]
+
+	User-defined rules layered on top of the built-in set. Matching by
+	*name* against a default _replaces_ that rule; setting *enabled = false*
+	on a default's name _removes_ it; a fresh name _appends_ a new rule.
+	*precision* is a _0..=255_ integer (higher wins, ties broken by match
+	length).
+
+	Built-in rules (with their precisions): *url* (200), *file_line* (150),
+	*uuid* (140), *ipv4* (130), *email* (130), *git_sha* (50). Patterns use
+	the regex-automata DFA subset — no look-around, ASCII word boundaries
+	only (_(?-u:\\b)_).
+
+	Example:
+
+```
+	[smart-selection]
+	enabled = true
+
+	[[smart-selection.rules]]
+	name = "jira-ticket"
+	regex = "[A-Z]{2,10}-\\\\d+"
+	precision = 100
+
+	[[smart-selection.rules]]
+	name = "git_sha"
+	enabled = false
+```
+
 # DEVELOPER
 
 This section documents the *[developer]* table of the configuration file.

--- a/extra/man/rio.5.scd
+++ b/extra/man/rio.5.scd
@@ -418,6 +418,60 @@ This section documents the *[renderer]* table of the configuration file.
 
 	Default: _3_
 
+# SMART SELECTION
+
+This section documents the *[smart-selection]* table of the configuration file.
+
+Double-clicking inside the terminal selects the token under the cursor. The
+resolution order is:
+
+. OSC 8 hyperlink span (the producer-emitted link, including non-URL anchor
+	text and soft-wrapped spans).
+. Smart-selection rules listed here: each rule's regex is matched against the
+	soft-wrapped logical line containing the click; the highest-precision
+	match that covers the click wins, with longest match as the tiebreaker.
+. The classic semantic selection (word-by-word stopping at the separator
+	characters).
+
+Steps 2 and 3 only run when step 1 doesn't apply, so producers that emit
+OSC 8 always win.
+
+*enabled* = _true_ | _false_
+
+	Master switch for the rule engine. When _false_, double-click goes
+	straight from the OSC 8 fast path to the semantic fallback.
+
+	Default: _true_
+
+*rules* = [{ name = _"<string>"_, regex = _"<string>"_, precision = _<integer>_, enabled = _true_ | _false_ },]
+
+	User-defined rules layered on top of the built-in set. Matching by
+	*name* against a default _replaces_ that rule; setting *enabled = false*
+	on a default's name _removes_ it; a fresh name _appends_ a new rule.
+	*precision* is a _0..=255_ integer (higher wins, ties broken by match
+	length).
+
+	Built-in rules (with their precisions): *url* (200), *file_line* (150),
+	*uuid* (140), *ipv4* (130), *email* (130), *git_sha* (50). Patterns use
+	the regex-automata DFA subset — no look-around, ASCII word boundaries
+	only (_(?-u:\\b)_).
+
+	Example:
+
+```
+	[smart-selection]
+	enabled = true
+
+	[[smart-selection.rules]]
+	name = "jira-ticket"
+	regex = "[A-Z]{2,10}-\\\\d+"
+	precision = 100
+
+	[[smart-selection.rules]]
+	name = "git_sha"
+	enabled = false
+```
+
 # DEVELOPER
 
 This section documents the *[developer]* table of the configuration file.

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1770,6 +1770,30 @@ impl Screen<'_> {
         self.context_manager.request_render();
     }
 
+    /// Install a pre-computed selection range. Used by the OSC 8
+    /// double-click fast path, where the span comes from the extras
+    /// table walk instead of a `SelectionType`-driven expansion. Builds
+    /// a `Simple` selection covering exactly the supplied cells so
+    /// `terminal.selection_to_string()` (and any later drag-extend)
+    /// works the same way as a manual drag selection would.
+    #[inline]
+    fn set_selection_range(
+        &mut self,
+        range: rio_backend::selection::SelectionRange,
+        clipboard: &mut Clipboard,
+    ) {
+        self.copy_selection(ClipboardType::Selection, clipboard);
+        let current = self.context_manager.current_mut();
+        let mut terminal = current.terminal.lock();
+        let mut selection = Selection::new(SelectionType::Simple, range.start, Side::Left);
+        selection.update(range.end, Side::Right);
+        terminal.selection = Some(selection);
+        drop(terminal);
+
+        current.set_selection(Some(range));
+        self.context_manager.request_render();
+    }
+
     #[inline]
     fn toggle_selection(
         &mut self,
@@ -2014,32 +2038,11 @@ impl Screen<'_> {
             return None;
         }
 
-        // Look up the cell's hyperlink via the per-grid extras table.
-        // Cells in the same OSC 8 span share an `extras_id`, so we
-        // walk left/right comparing ids (cheap u16 compare) to find
-        // the span boundaries, then look up the URI once.
-        let id = terminal.cell_hyperlink_id(point.row, point.col)?;
-
-        let mut start_col = point.col;
-        let mut end_col = point.col;
-
-        while start_col > rio_backend::crosswords::pos::Column(0) {
-            let prev_col = start_col - 1;
-            if terminal.cell_hyperlink_id(point.row, prev_col) == Some(id) {
-                start_col = prev_col;
-            } else {
-                break;
-            }
-        }
-        while end_col < grid.columns() - 1 {
-            let next_col = end_col + 1;
-            if terminal.cell_hyperlink_id(point.row, next_col) == Some(id) {
-                end_col = next_col;
-            } else {
-                break;
-            }
-        }
-
+        // Delegate the span walk (including soft-wrap row crossing) to
+        // the shared helper so this code path and the OSC 8 double-click
+        // fast path agree on the selection boundaries.
+        let span =
+            rio_backend::crosswords::hyperlink::hyperlink_span_at(terminal, point)?;
         let hyperlink = terminal.cell_hyperlink(point.row, point.col)?;
 
         // Build a synthetic hint config so the rest of the hint
@@ -2066,8 +2069,8 @@ impl Screen<'_> {
 
         Some(crate::hints::HintMatch {
             text: uri,
-            start: rio_backend::crosswords::pos::Pos::new(point.row, start_col),
-            end: rio_backend::crosswords::pos::Pos::new(point.row, end_col),
+            start: span.start,
+            end: span.end,
             hint: hint_config,
         })
     }
@@ -2776,7 +2779,22 @@ impl Screen<'_> {
                 }
             }
             ClickState::DoubleClick => {
-                self.start_selection(SelectionType::Semantic, point, side, clipboard);
+                // OSC 8 fast path: if the click cell carries a hyperlink,
+                // select the full link span instead of the semantic-word
+                // boundaries. Producers that emit OSC 8 (gh, fd, eza,
+                // most modern shells) get correct selection even when
+                // the anchor text isn't itself a parseable URL.
+                let osc8 = {
+                    let terminal = self.context_manager.current().terminal.lock();
+                    rio_backend::crosswords::hyperlink::hyperlink_span_at(
+                        &terminal, point,
+                    )
+                };
+                if let Some(range) = osc8 {
+                    self.set_selection_range(range, clipboard);
+                } else {
+                    self.start_selection(SelectionType::Semantic, point, side, clipboard);
+                }
             }
             ClickState::TripleClick => {
                 self.start_selection(SelectionType::Lines, point, side, clipboard);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -90,6 +90,10 @@ pub struct Screen<'screen> {
     /// char → font resolution cache; the per-panel atlas lives on
     /// each `GridRenderer`.
     pub grid_rasterizer: crate::grid_emit::GridGlyphRasterizer,
+    /// Compiled smart-selection rules; consulted on double-click
+    /// after the OSC 8 fast path. Kept on `Screen` to amortize the
+    /// DFA compile cost across clicks.
+    smart_rules: Vec<rio_backend::crosswords::smart_select::SmartRule>,
 }
 
 pub struct ScreenWindowProperties {
@@ -326,6 +330,8 @@ impl Screen<'_> {
             resize_state: None,
             grids: rustc_hash::FxHashMap::default(),
             grid_rasterizer: crate::grid_emit::GridGlyphRasterizer::new(),
+            smart_rules:
+                rio_backend::config::smart_selection::compile_default_rules(),
         })
     }
 
@@ -2779,18 +2785,27 @@ impl Screen<'_> {
                 }
             }
             ClickState::DoubleClick => {
-                // OSC 8 fast path: if the click cell carries a hyperlink,
-                // select the full link span instead of the semantic-word
-                // boundaries. Producers that emit OSC 8 (gh, fd, eza,
-                // most modern shells) get correct selection even when
-                // the anchor text isn't itself a parseable URL.
-                let osc8 = {
+                // Double-click resolution order:
+                //   1. OSC 8 hyperlink span (precise, producer-driven).
+                //   2. Smart-select rules (URL, file:line, UUID, ...).
+                //   3. Fallback to semantic word boundaries.
+                // Each step short-circuits on success so the cheaper
+                // checks run first and unrelated text falls through to
+                // the existing semantic behavior with no regression.
+                let resolved = {
                     let terminal = self.context_manager.current().terminal.lock();
                     rio_backend::crosswords::hyperlink::hyperlink_span_at(
                         &terminal, point,
                     )
+                    .or_else(|| {
+                        rio_backend::crosswords::smart_select::smart_select_at(
+                            &terminal,
+                            &mut self.smart_rules,
+                            point,
+                        )
+                    })
                 };
-                if let Some(range) = osc8 {
+                if let Some(range) = resolved {
                     self.set_selection_range(range, clipboard);
                 } else {
                     self.start_selection(SelectionType::Semantic, point, side, clipboard);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -330,10 +330,9 @@ impl Screen<'_> {
             resize_state: None,
             grids: rustc_hash::FxHashMap::default(),
             grid_rasterizer: crate::grid_emit::GridGlyphRasterizer::new(),
-            smart_selector:
-                rio_backend::crosswords::smart_select::SmartSelector::new(
-                    &config.smart_selection,
-                ),
+            smart_selector: rio_backend::crosswords::smart_select::SmartSelector::new(
+                &config.smart_selection,
+            ),
         })
     }
 
@@ -1798,7 +1797,8 @@ impl Screen<'_> {
         self.copy_selection(ClipboardType::Selection, clipboard);
         let current = self.context_manager.current_mut();
         let mut terminal = current.terminal.lock();
-        let mut selection = Selection::new(SelectionType::Simple, range.start, Side::Left);
+        let mut selection =
+            Selection::new(SelectionType::Simple, range.start, Side::Left);
         selection.update(range.end, Side::Right);
         terminal.selection = Some(selection);
         drop(terminal);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -91,9 +91,9 @@ pub struct Screen<'screen> {
     /// each `GridRenderer`.
     pub grid_rasterizer: crate::grid_emit::GridGlyphRasterizer,
     /// Compiled smart-selection rules; consulted on double-click
-    /// after the OSC 8 fast path. Kept on `Screen` to amortize the
-    /// DFA compile cost across clicks.
-    smart_rules: Vec<rio_backend::crosswords::smart_select::SmartRule>,
+    /// after the OSC 8 fast path. Owns its own reload logic so
+    /// config edits take effect without rebuilding the `Screen`.
+    smart_selector: rio_backend::crosswords::smart_select::SmartSelector,
 }
 
 pub struct ScreenWindowProperties {
@@ -330,8 +330,10 @@ impl Screen<'_> {
             resize_state: None,
             grids: rustc_hash::FxHashMap::default(),
             grid_rasterizer: crate::grid_emit::GridGlyphRasterizer::new(),
-            smart_rules:
-                rio_backend::config::smart_selection::compile_default_rules(),
+            smart_selector:
+                rio_backend::crosswords::smart_select::SmartSelector::new(
+                    &config.smart_selection,
+                ),
         })
     }
 
@@ -538,6 +540,11 @@ impl Screen<'_> {
 
         // Update keyboard config in context manager
         self.context_manager.config.keyboard = config.keyboard;
+
+        // Recompile smart-selection rules so [smart-selection] edits
+        // take effect without a restart. A bad user regex is warned
+        // and skipped by `compile()` itself.
+        self.smart_selector.reload(&config.smart_selection);
 
         // Re-evaluate the opaque flag — toggling `window.opacity` /
         // `window.blur` at runtime should flip the compositor mode.
@@ -2797,13 +2804,7 @@ impl Screen<'_> {
                     rio_backend::crosswords::hyperlink::hyperlink_span_at(
                         &terminal, point,
                     )
-                    .or_else(|| {
-                        rio_backend::crosswords::smart_select::smart_select_at(
-                            &terminal,
-                            &mut self.smart_rules,
-                            point,
-                        )
-                    })
+                    .or_else(|| self.smart_selector.select_at(&terminal, point))
                 };
                 if let Some(range) = resolved {
                     self.set_selection_range(range, clipboard);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -82,6 +82,10 @@ pub struct Screen<'screen> {
     last_close_press: Option<(std::time::Instant, f32)>,
     pub grids: rustc_hash::FxHashMap<usize, rio_backend::sugarloaf::grid::GridRenderer>,
     pub grid_rasterizer: crate::grid_emit::GridGlyphRasterizer,
+    /// Compiled smart-selection rules; consulted on double-click
+    /// after the OSC 8 fast path. Kept on `Screen` to amortize the
+    /// DFA compile cost across clicks.
+    smart_rules: Vec<rio_backend::crosswords::smart_select::SmartRule>,
 }
 
 pub struct ChromePress {
@@ -319,6 +323,8 @@ impl Screen<'_> {
             last_close_press: None,
             grids: rustc_hash::FxHashMap::default(),
             grid_rasterizer: crate::grid_emit::GridGlyphRasterizer::new(),
+            smart_rules:
+                rio_backend::config::smart_selection::compile_default_rules(),
         })
     }
 
@@ -3060,18 +3066,27 @@ impl Screen<'_> {
                 }
             }
             ClickState::DoubleClick => {
-                // OSC 8 fast path: if the click cell carries a hyperlink,
-                // select the full link span instead of the semantic-word
-                // boundaries. Producers that emit OSC 8 (gh, fd, eza,
-                // most modern shells) get correct selection even when
-                // the anchor text isn't itself a parseable URL.
-                let osc8 = {
+                // Double-click resolution order:
+                //   1. OSC 8 hyperlink span (precise, producer-driven).
+                //   2. Smart-select rules (URL, file:line, UUID, ...).
+                //   3. Fallback to semantic word boundaries.
+                // Each step short-circuits on success so the cheaper
+                // checks run first and unrelated text falls through to
+                // the existing semantic behavior with no regression.
+                let resolved = {
                     let terminal = self.context_manager.current().terminal.lock();
                     rio_backend::crosswords::hyperlink::hyperlink_span_at(
                         &terminal, point,
                     )
+                    .or_else(|| {
+                        rio_backend::crosswords::smart_select::smart_select_at(
+                            &terminal,
+                            &mut self.smart_rules,
+                            point,
+                        )
+                    })
                 };
-                if let Some(range) = osc8 {
+                if let Some(range) = resolved {
                     self.set_selection_range(range, clipboard);
                 } else {
                     self.start_selection(SelectionType::Semantic, point, side, clipboard);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1832,6 +1832,30 @@ impl Screen<'_> {
         self.context_manager.request_render();
     }
 
+    /// Install a pre-computed selection range. Used by the OSC 8
+    /// double-click fast path, where the span comes from the extras
+    /// table walk instead of a `SelectionType`-driven expansion. Builds
+    /// a `Simple` selection covering exactly the supplied cells so
+    /// `terminal.selection_to_string()` (and any later drag-extend)
+    /// works the same way as a manual drag selection would.
+    #[inline]
+    fn set_selection_range(
+        &mut self,
+        range: rio_backend::selection::SelectionRange,
+        clipboard: &mut Clipboard,
+    ) {
+        self.copy_selection(ClipboardType::Selection, clipboard);
+        let current = self.context_manager.current_mut();
+        let mut terminal = current.terminal.lock();
+        let mut selection = Selection::new(SelectionType::Simple, range.start, Side::Left);
+        selection.update(range.end, Side::Right);
+        terminal.selection = Some(selection);
+        drop(terminal);
+
+        current.set_selection(Some(range));
+        self.context_manager.request_render();
+    }
+
     #[inline]
     fn toggle_selection(
         &mut self,
@@ -2076,32 +2100,11 @@ impl Screen<'_> {
             return None;
         }
 
-        // Look up the cell's hyperlink via the per-grid extras table.
-        // Cells in the same OSC 8 span share an `extras_id`, so we
-        // walk left/right comparing ids (cheap u16 compare) to find
-        // the span boundaries, then look up the URI once.
-        let id = terminal.cell_hyperlink_id(point.row, point.col)?;
-
-        let mut start_col = point.col;
-        let mut end_col = point.col;
-
-        while start_col > rio_backend::crosswords::pos::Column(0) {
-            let prev_col = start_col - 1;
-            if terminal.cell_hyperlink_id(point.row, prev_col) == Some(id) {
-                start_col = prev_col;
-            } else {
-                break;
-            }
-        }
-        while end_col < grid.columns() - 1 {
-            let next_col = end_col + 1;
-            if terminal.cell_hyperlink_id(point.row, next_col) == Some(id) {
-                end_col = next_col;
-            } else {
-                break;
-            }
-        }
-
+        // Delegate the span walk (including soft-wrap row crossing) to
+        // the shared helper so this code path and the OSC 8 double-click
+        // fast path agree on the selection boundaries.
+        let span =
+            rio_backend::crosswords::hyperlink::hyperlink_span_at(terminal, point)?;
         let hyperlink = terminal.cell_hyperlink(point.row, point.col)?;
 
         // Build a synthetic hint config so the rest of the hint
@@ -2128,8 +2131,8 @@ impl Screen<'_> {
 
         Some(crate::hints::HintMatch {
             text: uri,
-            start: rio_backend::crosswords::pos::Pos::new(point.row, start_col),
-            end: rio_backend::crosswords::pos::Pos::new(point.row, end_col),
+            start: span.start,
+            end: span.end,
             hint: hint_config,
         })
     }
@@ -3057,7 +3060,22 @@ impl Screen<'_> {
                 }
             }
             ClickState::DoubleClick => {
-                self.start_selection(SelectionType::Semantic, point, side, clipboard);
+                // OSC 8 fast path: if the click cell carries a hyperlink,
+                // select the full link span instead of the semantic-word
+                // boundaries. Producers that emit OSC 8 (gh, fd, eza,
+                // most modern shells) get correct selection even when
+                // the anchor text isn't itself a parseable URL.
+                let osc8 = {
+                    let terminal = self.context_manager.current().terminal.lock();
+                    rio_backend::crosswords::hyperlink::hyperlink_span_at(
+                        &terminal, point,
+                    )
+                };
+                if let Some(range) = osc8 {
+                    self.set_selection_range(range, clipboard);
+                } else {
+                    self.start_selection(SelectionType::Semantic, point, side, clipboard);
+                }
             }
             ClickState::TripleClick => {
                 self.start_selection(SelectionType::Lines, point, side, clipboard);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -83,9 +83,9 @@ pub struct Screen<'screen> {
     pub grids: rustc_hash::FxHashMap<usize, rio_backend::sugarloaf::grid::GridRenderer>,
     pub grid_rasterizer: crate::grid_emit::GridGlyphRasterizer,
     /// Compiled smart-selection rules; consulted on double-click
-    /// after the OSC 8 fast path. Kept on `Screen` to amortize the
-    /// DFA compile cost across clicks.
-    smart_rules: Vec<rio_backend::crosswords::smart_select::SmartRule>,
+    /// after the OSC 8 fast path. Owns its own reload logic so
+    /// config edits take effect without rebuilding the `Screen`.
+    smart_selector: rio_backend::crosswords::smart_select::SmartSelector,
 }
 
 pub struct ChromePress {
@@ -323,8 +323,10 @@ impl Screen<'_> {
             last_close_press: None,
             grids: rustc_hash::FxHashMap::default(),
             grid_rasterizer: crate::grid_emit::GridGlyphRasterizer::new(),
-            smart_rules:
-                rio_backend::config::smart_selection::compile_default_rules(),
+            smart_selector:
+                rio_backend::crosswords::smart_select::SmartSelector::new(
+                    &config.smart_selection,
+                ),
         })
     }
 
@@ -509,6 +511,11 @@ impl Screen<'_> {
 
         // Update keyboard config in context manager
         self.context_manager.config.keyboard = config.keyboard;
+
+        // Recompile smart-selection rules so [smart-selection] edits
+        // take effect without a restart. A bad user regex is warned
+        // and skipped by `compile()` itself.
+        self.smart_selector.reload(&config.smart_selection);
 
         // Re-evaluate the opaque flag — toggling `window.opacity` /
         // `window.blur` at runtime should flip the compositor mode.
@@ -3078,13 +3085,7 @@ impl Screen<'_> {
                     rio_backend::crosswords::hyperlink::hyperlink_span_at(
                         &terminal, point,
                     )
-                    .or_else(|| {
-                        rio_backend::crosswords::smart_select::smart_select_at(
-                            &terminal,
-                            &mut self.smart_rules,
-                            point,
-                        )
-                    })
+                    .or_else(|| self.smart_selector.select_at(&terminal, point))
                 };
                 if let Some(range) = resolved {
                     self.set_selection_range(range, clipboard);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -323,10 +323,9 @@ impl Screen<'_> {
             last_close_press: None,
             grids: rustc_hash::FxHashMap::default(),
             grid_rasterizer: crate::grid_emit::GridGlyphRasterizer::new(),
-            smart_selector:
-                rio_backend::crosswords::smart_select::SmartSelector::new(
-                    &config.smart_selection,
-                ),
+            smart_selector: rio_backend::crosswords::smart_select::SmartSelector::new(
+                &config.smart_selection,
+            ),
         })
     }
 
@@ -1860,7 +1859,8 @@ impl Screen<'_> {
         self.copy_selection(ClipboardType::Selection, clipboard);
         let current = self.context_manager.current_mut();
         let mut terminal = current.terminal.lock();
-        let mut selection = Selection::new(SelectionType::Simple, range.start, Side::Left);
+        let mut selection =
+            Selection::new(SelectionType::Simple, range.start, Side::Left);
         selection.update(range.end, Side::Right);
         terminal.selection = Some(selection);
         drop(terminal);

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -159,6 +159,11 @@ pub struct Config {
     pub draw_bold_text_with_light_colors: bool,
     #[serde(default = "Hints::default")]
     pub hints: Hints,
+    #[serde(
+        default = "smart_selection::SmartSelectionConfig::default",
+        rename = "smart-selection"
+    )]
+    pub smart_selection: smart_selection::SmartSelectionConfig,
     #[serde(default = "Bell::default")]
     pub bell: Bell,
     #[serde(default = "default_bool_true", rename = "enable-scroll-bar")]
@@ -661,6 +666,7 @@ impl Default for Config {
             hide_cursor_when_typing: false,
             draw_bold_text_with_light_colors: false,
             hints: Hints::default(),
+            smart_selection: smart_selection::SmartSelectionConfig::default(),
             bell: Bell::default(),
             enable_scroll_bar: true,
             scrollback_history_limit: default_scrollback_history_limit(),

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -9,6 +9,7 @@ pub mod layout;
 pub mod navigation;
 pub mod platform;
 pub mod renderer;
+pub mod smart_selection;
 pub mod theme;
 pub mod title;
 pub mod window;

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -159,6 +159,11 @@ pub struct Config {
     pub draw_bold_text_with_light_colors: bool,
     #[serde(default = "Hints::default")]
     pub hints: Hints,
+    #[serde(
+        default = "smart_selection::SmartSelectionConfig::default",
+        rename = "smart-selection"
+    )]
+    pub smart_selection: smart_selection::SmartSelectionConfig,
     #[serde(default = "Bell::default")]
     pub bell: Bell,
     #[serde(default = "default_bool_true", rename = "enable-scroll-bar")]
@@ -666,6 +671,7 @@ impl Default for Config {
             hide_cursor_when_typing: false,
             draw_bold_text_with_light_colors: false,
             hints: Hints::default(),
+            smart_selection: smart_selection::SmartSelectionConfig::default(),
             bell: Bell::default(),
             enable_scroll_bar: true,
             scrollback_history_limit: default_scrollback_history_limit(),

--- a/rio-backend/src/config/smart_selection.rs
+++ b/rio-backend/src/config/smart_selection.rs
@@ -1,0 +1,79 @@
+//! Built-in smart-selection rules.
+//!
+//! Phase 2 ships a hardcoded rule set tuned to win for the common
+//! double-click targets — URLs, file:line:col, UUIDs, IPv4 addresses,
+//! emails, git SHAs. Phase 3 will add a user-facing config section
+//! that layers on top of these defaults.
+
+use crate::crosswords::smart_select::SmartRule;
+
+/// Precision constants. Higher wins; ties broken by match length.
+/// Using `u8` keeps comparisons integer-only and reserves room for
+/// future user rules without exhausting the space.
+pub const PRECISION_URL: u8 = 200;
+pub const PRECISION_HIGH: u8 = 150;
+pub const PRECISION_MEDIUM: u8 = 130;
+pub const PRECISION_LOW: u8 = 50;
+
+/// `(name, pattern, precision)` for every built-in rule.
+///
+/// Patterns use the subset of regex syntax supported by
+/// `regex_automata::hybrid::dfa` — notably, no look-around and ASCII
+/// word boundaries only (`(?-u:\b)`; Unicode `\b` can't be compiled
+/// to a DFA). The `url` rule allows `://` and `:/` to accommodate
+/// `file:/path` forms.
+pub fn default_rules() -> Vec<(&'static str, &'static str, u8)> {
+    vec![
+        (
+            "url",
+            // Brackets and parens are excluded so a URL inside `[…]`
+            // or `(…)` stops at the boundary; producers that need a
+            // bracketed URL preserved should emit OSC 8 (handled by
+            // the fast path).
+            r#"(?:https?|ftp|file|ssh|git|mailto|gemini|gopher|news|magnet|ipfs|ipns)://?[^\s<>"\\{}\^\x00-\x1f\[\]()]+"#,
+            PRECISION_URL,
+        ),
+        ("file_line", r"[\w./~-]+\.[\w]+:\d+(?::\d+)?", PRECISION_HIGH),
+        (
+            "uuid",
+            r"(?-u:\b)[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}(?-u:\b)",
+            PRECISION_MEDIUM + 10,
+        ),
+        (
+            "ipv4",
+            r"(?-u:\b)(?:\d{1,3}\.){3}\d{1,3}(?-u:\b)",
+            PRECISION_MEDIUM,
+        ),
+        (
+            "email",
+            r"(?-u:\b)[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}(?-u:\b)",
+            PRECISION_MEDIUM,
+        ),
+        ("git_sha", r"(?-u:\b)[0-9a-f]{7,40}(?-u:\b)", PRECISION_LOW),
+    ]
+}
+
+/// Compile the built-in rule set. Panics on a regex compile error
+/// because every default pattern is hardcoded — a failure here means a
+/// developer typo, and `cargo test` will catch it before shipping.
+pub fn compile_default_rules() -> Vec<SmartRule> {
+    default_rules()
+        .into_iter()
+        .map(|(name, pattern, precision)| {
+            SmartRule::new(name, pattern, precision).unwrap_or_else(|e| {
+                panic!("invalid built-in smart-selection rule {name}: {e}")
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_default_rules_compile() {
+        let rules = compile_default_rules();
+        assert_eq!(rules.len(), default_rules().len());
+    }
+}

--- a/rio-backend/src/config/smart_selection.rs
+++ b/rio-backend/src/config/smart_selection.rs
@@ -39,7 +39,11 @@ pub fn default_rules() -> Vec<(&'static str, &'static str, u8)> {
             r#"(?:https?|ftp|file|ssh|git|mailto|gemini|gopher|news|magnet|ipfs|ipns)://?[^\s<>"\\{}\^\x00-\x1f\[\]()]+"#,
             PRECISION_URL,
         ),
-        ("file_line", r"[\w./~-]+\.[\w]+:\d+(?::\d+)?", PRECISION_HIGH),
+        (
+            "file_line",
+            r"[\w./~-]+\.[\w]+:\d+(?::\d+)?",
+            PRECISION_HIGH,
+        ),
         (
             "uuid",
             r"(?-u:\b)[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}(?-u:\b)",
@@ -171,10 +175,7 @@ impl SmartSelectionConfig {
                 match SmartRule::new(name.clone(), &pattern, precision) {
                     Ok(rule) => Some(rule),
                     Err(e) => {
-                        warn!(
-                            "smart-selection rule {:?} failed to compile: {}",
-                            name, e
-                        );
+                        warn!("smart-selection rule {:?} failed to compile: {}", name, e);
                         None
                     }
                 }

--- a/rio-backend/src/config/smart_selection.rs
+++ b/rio-backend/src/config/smart_selection.rs
@@ -1,9 +1,15 @@
-//! Built-in smart-selection rules.
+//! Smart-selection configuration: built-in rule set plus user
+//! overrides.
 //!
-//! Phase 2 ships a hardcoded rule set tuned to win for the common
-//! double-click targets — URLs, file:line:col, UUIDs, IPv4 addresses,
-//! emails, git SHAs. Phase 3 will add a user-facing config section
-//! that layers on top of these defaults.
+//! At runtime the rule list is the merge of [`default_rules`] and the
+//! user's `[[smart-selection.rules]]` entries: a user rule whose
+//! `name` matches a default replaces it (or removes it when
+//! `enabled = false`); a rule with a fresh name is appended. Bad user
+//! regexes log a warning and are skipped, so a typo in one rule
+//! doesn't take the rest down.
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::crosswords::smart_select::SmartRule;
 
@@ -53,9 +59,10 @@ pub fn default_rules() -> Vec<(&'static str, &'static str, u8)> {
     ]
 }
 
-/// Compile the built-in rule set. Panics on a regex compile error
-/// because every default pattern is hardcoded — a failure here means a
-/// developer typo, and `cargo test` will catch it before shipping.
+/// Compile the built-in rule set with no user customization. Panics
+/// on a regex compile error because every default pattern is
+/// hardcoded — a failure here means a developer typo, and `cargo
+/// test` catches it before shipping.
 pub fn compile_default_rules() -> Vec<SmartRule> {
     default_rules()
         .into_iter()
@@ -67,6 +74,119 @@ pub fn compile_default_rules() -> Vec<SmartRule> {
         .collect()
 }
 
+/// `[smart-selection]` config table.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SmartSelectionConfig {
+    /// Master switch. When `false`, double-click falls straight to
+    /// the existing semantic selection (the OSC 8 fast path is also
+    /// bypassed because the runtime rule list is empty).
+    #[serde(default = "default_bool_true")]
+    pub enabled: bool,
+
+    /// User-defined rules. Layered on top of the built-in defaults
+    /// by name.
+    #[serde(default)]
+    pub rules: Vec<UserRule>,
+}
+
+impl Default for SmartSelectionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            rules: Vec::new(),
+        }
+    }
+}
+
+/// One entry in `[[smart-selection.rules]]`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserRule {
+    /// Identifier; matches against a built-in rule for override/removal.
+    pub name: String,
+
+    /// Regex pattern. Optional when overriding a default and only
+    /// changing the precision, or when disabling a default.
+    #[serde(default)]
+    pub regex: Option<String>,
+
+    /// Match precision (higher wins). Optional under the same
+    /// conditions as `regex`.
+    #[serde(default)]
+    pub precision: Option<u8>,
+
+    /// When `false`, removes the same-named default from the runtime
+    /// rule list. Defaults to `true`.
+    #[serde(default = "default_bool_true")]
+    pub enabled: bool,
+}
+
+impl SmartSelectionConfig {
+    /// Build the runtime rule list. Defaults come first; user rules
+    /// either override (same `name`), remove (`enabled = false`), or
+    /// append. Bad user regexes log a warning and the rule is
+    /// skipped so the remaining rules still apply.
+    pub fn compile(&self) -> Vec<SmartRule> {
+        if !self.enabled {
+            return Vec::new();
+        }
+
+        let mut merged: Vec<(String, String, u8)> = default_rules()
+            .into_iter()
+            .map(|(n, r, p)| (n.to_string(), r.to_string(), p))
+            .collect();
+
+        for user in &self.rules {
+            if let Some(idx) = merged.iter().position(|(n, _, _)| n == &user.name) {
+                if !user.enabled {
+                    merged.remove(idx);
+                    continue;
+                }
+                if let Some(regex) = &user.regex {
+                    merged[idx].1 = regex.clone();
+                }
+                if let Some(precision) = user.precision {
+                    merged[idx].2 = precision;
+                }
+            } else {
+                if !user.enabled {
+                    continue;
+                }
+                match (&user.regex, user.precision) {
+                    (Some(regex), Some(precision)) => {
+                        merged.push((user.name.clone(), regex.clone(), precision));
+                    }
+                    _ => {
+                        warn!(
+                            "smart-selection rule {:?} needs both `regex` and `precision`; skipping",
+                            user.name,
+                        );
+                    }
+                }
+            }
+        }
+
+        merged
+            .into_iter()
+            .filter_map(|(name, pattern, precision)| {
+                match SmartRule::new(name.clone(), &pattern, precision) {
+                    Ok(rule) => Some(rule),
+                    Err(e) => {
+                        warn!(
+                            "smart-selection rule {:?} failed to compile: {}",
+                            name, e
+                        );
+                        None
+                    }
+                }
+            })
+            .collect()
+    }
+}
+
+fn default_bool_true() -> bool {
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -75,5 +195,161 @@ mod tests {
     fn all_default_rules_compile() {
         let rules = compile_default_rules();
         assert_eq!(rules.len(), default_rules().len());
+    }
+
+    #[test]
+    fn default_config_compiles_to_default_rules() {
+        let cfg = SmartSelectionConfig::default();
+        assert_eq!(cfg.compile().len(), default_rules().len());
+    }
+
+    #[test]
+    fn disabled_master_switch_yields_empty() {
+        let cfg = SmartSelectionConfig {
+            enabled: false,
+            rules: vec![],
+        };
+        assert!(cfg.compile().is_empty());
+    }
+
+    #[test]
+    fn user_rule_appended_when_name_is_fresh() {
+        let cfg = SmartSelectionConfig {
+            enabled: true,
+            rules: vec![UserRule {
+                name: "jira".into(),
+                regex: Some(r"[A-Z]{2,10}-\d+".into()),
+                precision: Some(100),
+                enabled: true,
+            }],
+        };
+        let compiled = cfg.compile();
+        assert_eq!(compiled.len(), default_rules().len() + 1);
+        assert_eq!(compiled.last().unwrap().name, "jira");
+    }
+
+    #[test]
+    fn user_rule_disables_default_by_name() {
+        let cfg = SmartSelectionConfig {
+            enabled: true,
+            rules: vec![UserRule {
+                name: "git_sha".into(),
+                regex: None,
+                precision: None,
+                enabled: false,
+            }],
+        };
+        let compiled = cfg.compile();
+        assert_eq!(compiled.len(), default_rules().len() - 1);
+        assert!(compiled.iter().all(|r| r.name != "git_sha"));
+    }
+
+    #[test]
+    fn user_rule_overrides_default_pattern_and_precision() {
+        let cfg = SmartSelectionConfig {
+            enabled: true,
+            rules: vec![UserRule {
+                name: "git_sha".into(),
+                regex: Some(r"(?-u:\b)[0-9a-f]{12,40}(?-u:\b)".into()),
+                precision: Some(60),
+                enabled: true,
+            }],
+        };
+        let compiled = cfg.compile();
+        assert_eq!(compiled.len(), default_rules().len());
+        let sha = compiled.iter().find(|r| r.name == "git_sha").unwrap();
+        assert_eq!(sha.precision, 60);
+    }
+
+    #[test]
+    fn user_rule_can_change_only_precision() {
+        let cfg = SmartSelectionConfig {
+            enabled: true,
+            rules: vec![UserRule {
+                name: "git_sha".into(),
+                regex: None,
+                precision: Some(60),
+                enabled: true,
+            }],
+        };
+        let sha = cfg
+            .compile()
+            .into_iter()
+            .find(|r| r.name == "git_sha")
+            .unwrap();
+        assert_eq!(sha.precision, 60);
+    }
+
+    #[test]
+    fn bad_user_regex_is_skipped_others_still_compile() {
+        let cfg = SmartSelectionConfig {
+            enabled: true,
+            rules: vec![UserRule {
+                name: "broken".into(),
+                regex: Some(r"[unterminated".into()),
+                precision: Some(10),
+                enabled: true,
+            }],
+        };
+        let compiled = cfg.compile();
+        // Defaults still present; broken rule dropped.
+        assert_eq!(compiled.len(), default_rules().len());
+        assert!(compiled.iter().all(|r| r.name != "broken"));
+    }
+
+    #[test]
+    fn user_rule_without_regex_or_precision_is_skipped() {
+        let cfg = SmartSelectionConfig {
+            enabled: true,
+            rules: vec![UserRule {
+                name: "incomplete".into(),
+                regex: None,
+                precision: None,
+                enabled: true,
+            }],
+        };
+        let compiled = cfg.compile();
+        assert_eq!(compiled.len(), default_rules().len());
+    }
+
+    #[test]
+    fn parses_from_toml() {
+        let toml_src = r#"
+enabled = true
+
+[[rules]]
+name = "jira"
+regex = "[A-Z]{2,10}-\\d+"
+precision = 100
+
+[[rules]]
+name = "git_sha"
+enabled = false
+"#;
+        let cfg: SmartSelectionConfig = toml::from_str(toml_src).unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.rules.len(), 2);
+        let compiled = cfg.compile();
+        // +1 for jira, -1 for git_sha disabled.
+        assert_eq!(compiled.len(), default_rules().len());
+        assert!(compiled.iter().any(|r| r.name == "jira"));
+        assert!(compiled.iter().all(|r| r.name != "git_sha"));
+    }
+
+    #[test]
+    fn parses_inside_full_config() {
+        use crate::config::Config;
+        let src = r#"
+[smart-selection]
+enabled = true
+
+[[smart-selection.rules]]
+name = "ticket"
+regex = "T-\\d+"
+precision = 80
+"#;
+        let cfg: Config = toml::from_str(src).unwrap();
+        assert!(cfg.smart_selection.enabled);
+        assert_eq!(cfg.smart_selection.rules.len(), 1);
     }
 }

--- a/rio-backend/src/config/smart_selection.rs
+++ b/rio-backend/src/config/smart_selection.rs
@@ -13,15 +13,8 @@ use tracing::warn;
 
 use crate::crosswords::smart_select::SmartRule;
 
-/// Precision constants. Higher wins; ties broken by match length.
-/// Using `u8` keeps comparisons integer-only and reserves room for
-/// future user rules without exhausting the space.
-pub const PRECISION_URL: u8 = 200;
-pub const PRECISION_HIGH: u8 = 150;
-pub const PRECISION_MEDIUM: u8 = 130;
-pub const PRECISION_LOW: u8 = 50;
-
-/// `(name, pattern, precision)` for every built-in rule.
+/// `(name, pattern, precision)` for every built-in rule. Precision is
+/// `0..=255`, higher wins, ties broken by match length.
 ///
 /// Patterns use the subset of regex syntax supported by
 /// `regex_automata::hybrid::dfa` — notably, no look-around and ASCII
@@ -37,29 +30,21 @@ pub fn default_rules() -> Vec<(&'static str, &'static str, u8)> {
             // bracketed URL preserved should emit OSC 8 (handled by
             // the fast path).
             r#"(?:https?|ftp|file|ssh|git|mailto|gemini|gopher|news|magnet|ipfs|ipns)://?[^\s<>"\\{}\^\x00-\x1f\[\]()]+"#,
-            PRECISION_URL,
+            200,
         ),
-        (
-            "file_line",
-            r"[\w./~-]+\.[\w]+:\d+(?::\d+)?",
-            PRECISION_HIGH,
-        ),
+        ("file_line", r"[\w./~-]+\.[\w]+:\d+(?::\d+)?", 150),
         (
             "uuid",
             r"(?-u:\b)[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}(?-u:\b)",
-            PRECISION_MEDIUM + 10,
+            140,
         ),
-        (
-            "ipv4",
-            r"(?-u:\b)(?:\d{1,3}\.){3}\d{1,3}(?-u:\b)",
-            PRECISION_MEDIUM,
-        ),
+        ("ipv4", r"(?-u:\b)(?:\d{1,3}\.){3}\d{1,3}(?-u:\b)", 130),
         (
             "email",
             r"(?-u:\b)[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}(?-u:\b)",
-            PRECISION_MEDIUM,
+            130,
         ),
-        ("git_sha", r"(?-u:\b)[0-9a-f]{7,40}(?-u:\b)", PRECISION_LOW),
+        ("git_sha", r"(?-u:\b)[0-9a-f]{7,40}(?-u:\b)", 50),
     ]
 }
 
@@ -194,14 +179,13 @@ mod tests {
 
     #[test]
     fn all_default_rules_compile() {
-        let rules = compile_default_rules();
-        assert_eq!(rules.len(), default_rules().len());
-    }
-
-    #[test]
-    fn default_config_compiles_to_default_rules() {
-        let cfg = SmartSelectionConfig::default();
-        assert_eq!(cfg.compile().len(), default_rules().len());
+        // compile_default_rules() panics on a bad built-in pattern; the
+        // default config must reach the same rule set through compile().
+        assert_eq!(compile_default_rules().len(), default_rules().len());
+        assert_eq!(
+            SmartSelectionConfig::default().compile().len(),
+            default_rules().len()
+        );
     }
 
     #[test]

--- a/rio-backend/src/crosswords/hyperlink.rs
+++ b/rio-backend/src/crosswords/hyperlink.rs
@@ -107,10 +107,7 @@ mod tests {
     fn single_cell_hyperlink() {
         let mut term = cw(20, 5);
         let mut p = Processor::default();
-        p.advance(
-            &mut term,
-            b"\x1b]8;;https://example.com\x07X\x1b]8;;\x07",
-        );
+        p.advance(&mut term, b"\x1b]8;;https://example.com\x07X\x1b]8;;\x07");
         let r = hyperlink_span_at(&term, Pos::new(Line(0), Column(0))).unwrap();
         assert_eq!(r.start, Pos::new(Line(0), Column(0)));
         assert_eq!(r.end, Pos::new(Line(0), Column(0)));

--- a/rio-backend/src/crosswords/hyperlink.rs
+++ b/rio-backend/src/crosswords/hyperlink.rs
@@ -1,0 +1,173 @@
+//! OSC 8 hyperlink span resolution.
+//!
+//! A click on a hyperlinked cell maps to the full span of cells that
+//! share the same OSC 8 `extras_id`. The walk crosses soft-wrapped row
+//! boundaries (via the `wrapline` flag) so that a link broken across
+//! two rows still selects as one range.
+
+use crate::crosswords::grid::Dimensions;
+use crate::crosswords::pos::{Column, Pos};
+use crate::crosswords::Crosswords;
+use crate::event::EventListener;
+use crate::selection::SelectionRange;
+
+/// Resolve the OSC 8 hyperlink span containing `click`, if any.
+/// Returns the inclusive cell range covering every cell that shares
+/// the click cell's `extras_id`.
+pub fn hyperlink_span_at<T: EventListener>(
+    term: &Crosswords<T>,
+    click: Pos,
+) -> Option<SelectionRange> {
+    let id = term.cell_hyperlink_id(click.row, click.col)?;
+    let start = walk_left(term, click, id);
+    let end = walk_right(term, click, id);
+    Some(SelectionRange {
+        start,
+        end,
+        is_block: false,
+    })
+}
+
+fn walk_left<T: EventListener>(term: &Crosswords<T>, mut pos: Pos, id: u16) -> Pos {
+    let topmost = term.grid.topmost_line();
+    let last_col = term.grid.last_column();
+    loop {
+        if pos.col > Column(0) {
+            let prev = Pos::new(pos.row, pos.col - 1);
+            if term.cell_hyperlink_id(prev.row, prev.col) == Some(id) {
+                pos = prev;
+                continue;
+            }
+            return pos;
+        }
+        if pos.row > topmost
+            && term.grid[pos.row - 1i32][last_col].wrapline()
+            && term.cell_hyperlink_id(pos.row - 1i32, last_col) == Some(id)
+        {
+            pos = Pos::new(pos.row - 1i32, last_col);
+            continue;
+        }
+        return pos;
+    }
+}
+
+fn walk_right<T: EventListener>(term: &Crosswords<T>, mut pos: Pos, id: u16) -> Pos {
+    let bottommost = term.grid.bottommost_line();
+    let last_col = term.grid.last_column();
+    loop {
+        if pos.col < last_col {
+            let next = Pos::new(pos.row, pos.col + 1);
+            if term.cell_hyperlink_id(next.row, next.col) == Some(id) {
+                pos = next;
+                continue;
+            }
+            return pos;
+        }
+        if pos.row < bottommost
+            && term.grid[pos.row][last_col].wrapline()
+            && term.cell_hyperlink_id(pos.row + 1i32, Column(0)) == Some(id)
+        {
+            pos = Pos::new(pos.row + 1i32, Column(0));
+            continue;
+        }
+        return pos;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ansi::CursorShape;
+    use crate::crosswords::pos::Line;
+    use crate::crosswords::{Crosswords, CrosswordsSize};
+    use crate::event::{VoidListener, WindowId};
+    use crate::performer::handler::Processor;
+
+    fn cw(cols: usize, lines: usize) -> Crosswords<VoidListener> {
+        let size = CrosswordsSize::new(cols, lines);
+        Crosswords::new(
+            size,
+            CursorShape::Block,
+            VoidListener {},
+            WindowId::from(0),
+            0,
+            10_000,
+        )
+    }
+
+    #[test]
+    fn no_hyperlink_returns_none() {
+        let mut term = cw(20, 5);
+        let mut p = Processor::default();
+        p.advance(&mut term, b"hello");
+        assert!(hyperlink_span_at(&term, Pos::new(Line(0), Column(2))).is_none());
+    }
+
+    #[test]
+    fn single_cell_hyperlink() {
+        let mut term = cw(20, 5);
+        let mut p = Processor::default();
+        p.advance(
+            &mut term,
+            b"\x1b]8;;https://example.com\x07X\x1b]8;;\x07",
+        );
+        let r = hyperlink_span_at(&term, Pos::new(Line(0), Column(0))).unwrap();
+        assert_eq!(r.start, Pos::new(Line(0), Column(0)));
+        assert_eq!(r.end, Pos::new(Line(0), Column(0)));
+        assert!(!r.is_block);
+    }
+
+    #[test]
+    fn multi_cell_hyperlink_single_row() {
+        let mut term = cw(20, 5);
+        let mut p = Processor::default();
+        p.advance(
+            &mut term,
+            b"go \x1b]8;;https://example.com\x07click\x1b]8;;\x07.",
+        );
+        // Click in the middle of "click" (cols 3..=7).
+        let r = hyperlink_span_at(&term, Pos::new(Line(0), Column(5))).unwrap();
+        assert_eq!(r.start, Pos::new(Line(0), Column(3)));
+        assert_eq!(r.end, Pos::new(Line(0), Column(7)));
+    }
+
+    #[test]
+    fn adjacent_links_with_different_ids_return_only_clicked() {
+        let mut term = cw(20, 5);
+        let mut p = Processor::default();
+        p.advance(
+            &mut term,
+            b"\x1b]8;;https://a.example\x07A\x1b]8;;\x07\
+              \x1b]8;;https://b.example\x07B\x1b]8;;\x07",
+        );
+        let a = hyperlink_span_at(&term, Pos::new(Line(0), Column(0))).unwrap();
+        let b = hyperlink_span_at(&term, Pos::new(Line(0), Column(1))).unwrap();
+        assert_eq!(a.start, Pos::new(Line(0), Column(0)));
+        assert_eq!(a.end, Pos::new(Line(0), Column(0)));
+        assert_eq!(b.start, Pos::new(Line(0), Column(1)));
+        assert_eq!(b.end, Pos::new(Line(0), Column(1)));
+    }
+
+    #[test]
+    fn hyperlink_crossing_soft_wrap() {
+        // 5-col grid; write 8 chars inside one OSC 8 link so the row wraps.
+        let mut term = cw(5, 4);
+        let mut p = Processor::default();
+        p.advance(
+            &mut term,
+            b"\x1b]8;;https://example.com\x07abcdefgh\x1b]8;;\x07",
+        );
+        // Sanity: the wrap should be a soft wrap (wrapline=true on row 0
+        // last col); not a CRLF.
+        assert!(term.grid[Line(0)][Column(4)].wrapline());
+
+        let r = hyperlink_span_at(&term, Pos::new(Line(0), Column(2))).unwrap();
+        assert_eq!(r.start, Pos::new(Line(0), Column(0)));
+        assert_eq!(r.end, Pos::new(Line(1), Column(2)));
+
+        // Click on the wrapped row, same span.
+        let r2 = hyperlink_span_at(&term, Pos::new(Line(1), Column(1))).unwrap();
+        assert_eq!(r2.start, Pos::new(Line(0), Column(0)));
+        assert_eq!(r2.end, Pos::new(Line(1), Column(2)));
+    }
+}

--- a/rio-backend/src/crosswords/hyperlink.rs
+++ b/rio-backend/src/crosswords/hyperlink.rs
@@ -6,7 +6,7 @@
 //! two rows still selects as one range.
 
 use crate::crosswords::grid::Dimensions;
-use crate::crosswords::pos::{Column, Pos};
+use crate::crosswords::pos::{Column, Direction, Pos};
 use crate::crosswords::Crosswords;
 use crate::event::EventListener;
 use crate::selection::SelectionRange;
@@ -19,58 +19,46 @@ pub fn hyperlink_span_at<T: EventListener>(
     click: Pos,
 ) -> Option<SelectionRange> {
     let id = term.cell_hyperlink_id(click.row, click.col)?;
-    let start = walk_left(term, click, id);
-    let end = walk_right(term, click, id);
     Some(SelectionRange {
-        start,
-        end,
+        start: walk(term, click, id, Direction::Left),
+        end: walk(term, click, id, Direction::Right),
         is_block: false,
     })
 }
 
-fn walk_left<T: EventListener>(term: &Crosswords<T>, mut pos: Pos, id: u16) -> Pos {
-    let topmost = term.grid.topmost_line();
+/// Step outward from `pos` while cells keep the same `extras_id`,
+/// following the `wrapline` flag across soft-wrapped row boundaries.
+fn walk<T: EventListener>(
+    term: &Crosswords<T>,
+    mut pos: Pos,
+    id: u16,
+    dir: Direction,
+) -> Pos {
     let last_col = term.grid.last_column();
     loop {
-        if pos.col > Column(0) {
-            let prev = Pos::new(pos.row, pos.col - 1);
-            if term.cell_hyperlink_id(prev.row, prev.col) == Some(id) {
-                pos = prev;
-                continue;
+        let candidate = match dir {
+            Direction::Left if pos.col > Column(0) => Pos::new(pos.row, pos.col - 1),
+            Direction::Right if pos.col < last_col => Pos::new(pos.row, pos.col + 1),
+            // At a row edge: only continue if the row that feeds this
+            // one was soft-wrapped rather than hard-broken.
+            Direction::Left
+                if pos.row > term.grid.topmost_line()
+                    && term.grid[pos.row - 1i32][last_col].wrapline() =>
+            {
+                Pos::new(pos.row - 1i32, last_col)
             }
+            Direction::Right
+                if pos.row < term.grid.bottommost_line()
+                    && term.grid[pos.row][last_col].wrapline() =>
+            {
+                Pos::new(pos.row + 1i32, Column(0))
+            }
+            _ => return pos,
+        };
+        if term.cell_hyperlink_id(candidate.row, candidate.col) != Some(id) {
             return pos;
         }
-        if pos.row > topmost
-            && term.grid[pos.row - 1i32][last_col].wrapline()
-            && term.cell_hyperlink_id(pos.row - 1i32, last_col) == Some(id)
-        {
-            pos = Pos::new(pos.row - 1i32, last_col);
-            continue;
-        }
-        return pos;
-    }
-}
-
-fn walk_right<T: EventListener>(term: &Crosswords<T>, mut pos: Pos, id: u16) -> Pos {
-    let bottommost = term.grid.bottommost_line();
-    let last_col = term.grid.last_column();
-    loop {
-        if pos.col < last_col {
-            let next = Pos::new(pos.row, pos.col + 1);
-            if term.cell_hyperlink_id(next.row, next.col) == Some(id) {
-                pos = next;
-                continue;
-            }
-            return pos;
-        }
-        if pos.row < bottommost
-            && term.grid[pos.row][last_col].wrapline()
-            && term.cell_hyperlink_id(pos.row + 1i32, Column(0)) == Some(id)
-        {
-            pos = Pos::new(pos.row + 1i32, Column(0));
-            continue;
-        }
-        return pos;
+        pos = candidate;
     }
 }
 

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod attr;
 pub mod grid;
+pub mod hyperlink;
 pub mod pos;
 pub mod search;
 pub mod square;

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -19,6 +19,7 @@ pub mod grid;
 pub mod hyperlink;
 pub mod pos;
 pub mod search;
+pub mod smart_select;
 pub mod square;
 pub mod style;
 pub mod vi_mode;

--- a/rio-backend/src/crosswords/smart_select.rs
+++ b/rio-backend/src/crosswords/smart_select.rs
@@ -6,6 +6,7 @@
 //! `None` when nothing matches, leaving the caller free to use a
 //! plainer selection strategy (semantic, word, etc.).
 
+use crate::config::smart_selection::SmartSelectionConfig;
 use crate::crosswords::grid::Dimensions;
 use crate::crosswords::pos::{Direction, Pos};
 use crate::crosswords::search::{Match, RegexIter, RegexSearch};
@@ -39,6 +40,48 @@ impl SmartRule {
             regex: RegexSearch::new(pattern)?,
             precision,
         })
+    }
+}
+
+/// Owns the compiled rule list and exposes the two operations the
+/// rest of the app needs: select-at-click and reload-from-config.
+/// Splitting the recompile out of `Screen::update_config` keeps the
+/// hot-reload path testable without spinning up a window.
+#[derive(Debug)]
+pub struct SmartSelector {
+    rules: Vec<SmartRule>,
+}
+
+impl SmartSelector {
+    pub fn new(config: &SmartSelectionConfig) -> Self {
+        Self {
+            rules: config.compile(),
+        }
+    }
+
+    /// Replace the rule set with one freshly compiled from `config`.
+    /// Called on config reload; cheap relative to a click, but heavy
+    /// enough (compiles every regex) to be off the click hot path.
+    pub fn reload(&mut self, config: &SmartSelectionConfig) {
+        self.rules = config.compile();
+    }
+
+    /// Resolve the click against the active rule set.
+    pub fn select_at<T: EventListener>(
+        &mut self,
+        term: &Crosswords<T>,
+        click: Pos,
+    ) -> Option<SelectionRange> {
+        smart_select_at(term, &mut self.rules, click)
+    }
+
+    /// Number of active rules. Useful for assertions; not on a hot path.
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
     }
 }
 
@@ -275,5 +318,99 @@ mod tests {
         // URL ends on a later row, at the last URL char before the space.
         assert!(r.end.row > Line(0));
         assert!(r.end > r.start);
+    }
+
+    // --- reload-path tests (the "hot-reload D" check from the manual
+    // sampler, asserted directly so a regression in the reload wiring
+    // shows up in CI instead of needing a windowed integration run).
+    use crate::config::smart_selection::{SmartSelectionConfig, UserRule};
+
+    fn url_click_setup() -> (Crosswords<VoidListener>, Pos) {
+        let mut term = cw(80, 5);
+        write(&mut term, b"see https://cli.github.com/manual end");
+        // Click on the `g` of `github` (inside the URL).
+        let click = Pos::new(Line(0), Column(15));
+        (term, click)
+    }
+
+    #[test]
+    fn selector_picks_up_master_disable_on_reload() {
+        let (term, click) = url_click_setup();
+        let mut sel = SmartSelector::new(&SmartSelectionConfig::default());
+        assert!(
+            sel.select_at(&term, click).is_some(),
+            "defaults should match the URL",
+        );
+
+        sel.reload(&SmartSelectionConfig {
+            enabled: false,
+            rules: vec![],
+        });
+        assert!(
+            sel.select_at(&term, click).is_none(),
+            "after disabling the engine the URL must no longer smart-select",
+        );
+
+        // Re-enable and confirm the URL match returns — proves reload
+        // isn't a one-shot.
+        sel.reload(&SmartSelectionConfig::default());
+        assert!(sel.select_at(&term, click).is_some());
+    }
+
+    #[test]
+    fn selector_picks_up_rule_disable_on_reload() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"trace src/main.rs:42:7 here");
+        let click = Pos::new(Line(0), Column(15));
+
+        let mut sel = SmartSelector::new(&SmartSelectionConfig::default());
+        let r = sel.select_at(&term, click).expect("file_line should match");
+        // Full `src/main.rs:42:7` (cols 6..=21).
+        assert_eq!(r.end, Pos::new(Line(0), Column(21)));
+
+        sel.reload(&SmartSelectionConfig {
+            enabled: true,
+            rules: vec![UserRule {
+                name: "file_line".into(),
+                regex: None,
+                precision: None,
+                enabled: false,
+            }],
+        });
+        // After disabling the file_line rule, no other default matches
+        // `src/main.rs:42:7` (URL needs a scheme, ipv4 needs all
+        // dotted numbers, etc.) — so smart-select returns None and
+        // the click falls through to semantic.
+        assert!(sel.select_at(&term, click).is_none());
+    }
+
+    #[test]
+    fn selector_picks_up_added_user_rule_on_reload() {
+        let mut term = cw(80, 5);
+        // Phabricator-style ticket containing a `:` so semantic
+        // can't catch it. Without the user rule no built-in matches.
+        write(&mut term, b"see T:1234 today");
+        let click = Pos::new(Line(0), Column(6));
+
+        let mut sel = SmartSelector::new(&SmartSelectionConfig::default());
+        assert!(
+            sel.select_at(&term, click).is_none(),
+            "no default rule should match a `T:1234` token",
+        );
+
+        sel.reload(&SmartSelectionConfig {
+            enabled: true,
+            rules: vec![UserRule {
+                name: "phab".into(),
+                regex: Some(r"T:\d+".into()),
+                precision: Some(120),
+                enabled: true,
+            }],
+        });
+        let r = sel
+            .select_at(&term, click)
+            .expect("after reload the user rule should match");
+        assert_eq!(r.start, Pos::new(Line(0), Column(4)));
+        assert_eq!(r.end, Pos::new(Line(0), Column(9)));
     }
 }

--- a/rio-backend/src/crosswords/smart_select.rs
+++ b/rio-backend/src/crosswords/smart_select.rs
@@ -1,0 +1,279 @@
+//! iTerm2-style smart selection.
+//!
+//! Given a click position, evaluate a list of precision-tagged regex
+//! rules against the surrounding logical line and pick the
+//! highest-precision match that contains the click. Falls back to
+//! `None` when nothing matches, leaving the caller free to use a
+//! plainer selection strategy (semantic, word, etc.).
+
+use crate::crosswords::grid::Dimensions;
+use crate::crosswords::pos::{Direction, Pos};
+use crate::crosswords::search::{Match, RegexIter, RegexSearch};
+use crate::crosswords::Crosswords;
+use crate::event::EventListener;
+use crate::selection::SelectionRange;
+
+/// Skip smart selection when the logical line exceeds this many cells.
+/// 6 regexes over a multi-megabyte line is not worth the click-to-paint
+/// latency; the caller falls back to semantic selection instead.
+pub const MAX_SCAN_CELLS: usize = 8192;
+
+/// One precision-tagged regex rule.
+#[derive(Debug)]
+pub struct SmartRule {
+    pub name: String,
+    pub regex: RegexSearch,
+    /// Higher wins. Length is the tiebreaker among equal-precision
+    /// matches, so e.g. an IPv4 inside a URL gets shadowed by the URL.
+    pub precision: u8,
+}
+
+impl SmartRule {
+    pub fn new(
+        name: impl Into<String>,
+        pattern: &str,
+        precision: u8,
+    ) -> Result<Self, Box<regex_automata::hybrid::BuildError>> {
+        Ok(Self {
+            name: name.into(),
+            regex: RegexSearch::new(pattern)?,
+            precision,
+        })
+    }
+}
+
+/// Run the rules against the logical line containing `click` and
+/// return the best matching span, or `None` if no rule covers the
+/// click position.
+pub fn smart_select_at<T: EventListener>(
+    term: &Crosswords<T>,
+    rules: &mut [SmartRule],
+    click: Pos,
+) -> Option<SelectionRange> {
+    let start = term.line_search_left(click);
+    let end = term.line_search_right(click);
+
+    if span_cells(term, start, end) > MAX_SCAN_CELLS {
+        return None;
+    }
+
+    let mut best: Option<(u8, usize, Match)> = None;
+    for rule in rules.iter_mut() {
+        for m in RegexIter::new(start, end, Direction::Right, term, &mut rule.regex) {
+            if !m.contains(&click) {
+                continue;
+            }
+            let len = span_cells(term, *m.start(), *m.end());
+            let better = match &best {
+                None => true,
+                Some((p, l, _)) => {
+                    rule.precision > *p || (rule.precision == *p && len > *l)
+                }
+            };
+            if better {
+                best = Some((rule.precision, len, m));
+            }
+            // RegexIter yields non-overlapping matches, so at most one
+            // match per rule contains the click — no point scanning the
+            // rest of the line for this rule.
+            break;
+        }
+    }
+    best.map(|(_, _, m)| SelectionRange {
+        start: *m.start(),
+        end: *m.end(),
+        is_block: false,
+    })
+}
+
+/// Inclusive cell count between two ordered positions. Used both as
+/// the early-out guard against pathologically long lines and as the
+/// length tiebreaker between equal-precision matches.
+fn span_cells<T: EventListener>(term: &Crosswords<T>, start: Pos, end: Pos) -> usize {
+    let cols = term.grid.columns();
+    let row_diff = (end.row.0 - start.row.0).max(0) as usize;
+    let col_diff = end.col.0 as isize - start.col.0 as isize;
+    let base = row_diff * cols;
+    if col_diff >= 0 {
+        base + col_diff as usize + 1
+    } else {
+        base.saturating_sub((-col_diff) as usize) + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ansi::CursorShape;
+    use crate::crosswords::pos::{Column, Line};
+    use crate::crosswords::{Crosswords, CrosswordsSize};
+    use crate::event::{VoidListener, WindowId};
+    use crate::performer::handler::Processor;
+
+    fn cw(cols: usize, lines: usize) -> Crosswords<VoidListener> {
+        let size = CrosswordsSize::new(cols, lines);
+        Crosswords::new(
+            size,
+            CursorShape::Block,
+            VoidListener {},
+            WindowId::from(0),
+            0,
+            10_000,
+        )
+    }
+
+    fn default_rules() -> Vec<SmartRule> {
+        crate::config::smart_selection::compile_default_rules()
+    }
+
+    fn write(term: &mut Crosswords<VoidListener>, bytes: &[u8]) {
+        let mut p = Processor::default();
+        p.advance(term, bytes);
+    }
+
+    fn find_col(term: &Crosswords<VoidListener>, row: Line, needle: char) -> Column {
+        let cols = term.grid.columns();
+        for c in 0..cols {
+            if term.grid[row][Column(c)].c() == needle {
+                return Column(c);
+            }
+        }
+        panic!("char {:?} not found on row {}", needle, row.0);
+    }
+
+    #[test]
+    fn url_selected_in_full_including_scheme() {
+        let mut term = cw(80, 5);
+        // "go to " = 6 cols, URL = 29 chars (cols 6..=34), " end" follows.
+        write(&mut term, b"go to https://cli.github.com/manual end");
+        let mut rules = default_rules();
+        // Click on 'g' in "github" (mid-URL).
+        let click = Pos::new(Line(0), Column(17));
+        let r = smart_select_at(&term, &mut rules, click).expect("URL should match");
+        assert_eq!(r.start, Pos::new(Line(0), Column(6)));
+        assert_eq!(r.end, Pos::new(Line(0), Column(34)));
+    }
+
+    #[test]
+    fn url_next_to_bracket_stops_at_bracket() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"see [https://example.com] for details");
+        let mut rules = default_rules();
+        let click = Pos::new(Line(0), Column(10));
+        let r = smart_select_at(&term, &mut rules, click).expect("URL should match");
+        // Selection starts at 'h' of https (col 5) and stops before the ']'.
+        assert_eq!(r.start, Pos::new(Line(0), Column(5)));
+        // Find the ']' column; URL ends at the cell just before it.
+        let close = find_col(&term, Line(0), ']');
+        assert_eq!(r.end.col.0, close.0 - 1);
+    }
+
+    #[test]
+    fn file_line_reference_includes_line_and_column() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"  at src/main.rs:42:7 in trace");
+        let mut rules = default_rules();
+        let click = Pos::new(Line(0), Column(10));
+        let r = smart_select_at(&term, &mut rules, click)
+            .expect("file:line:col should match");
+        assert_eq!(r.start, Pos::new(Line(0), Column(5)));
+        // `src/main.rs:42:7` ends at the `7` (col 20).
+        assert_eq!(r.end, Pos::new(Line(0), Column(20)));
+    }
+
+    #[test]
+    fn ipv4_matches_when_standalone() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"host 192.168.1.1 up");
+        let mut rules = default_rules();
+        let click = Pos::new(Line(0), Column(8));
+        let r = smart_select_at(&term, &mut rules, click).expect("IPv4 should match");
+        assert_eq!(r.start, Pos::new(Line(0), Column(5)));
+        assert_eq!(r.end, Pos::new(Line(0), Column(15)));
+    }
+
+    #[test]
+    fn url_wins_over_ipv4_inside_it() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"goto https://192.168.1.1/admin now");
+        let mut rules = default_rules();
+        // Click inside `192` — URL (200) should beat IPv4 (130).
+        let click = Pos::new(Line(0), Column(14));
+        let r = smart_select_at(&term, &mut rules, click).expect("URL should win");
+        assert_eq!(r.start, Pos::new(Line(0), Column(5)));
+        // Ends just before the trailing space.
+        assert_eq!(r.end, Pos::new(Line(0), Column(29)));
+    }
+
+    #[test]
+    fn git_sha_matches() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"see commit abc1234567 today");
+        let mut rules = default_rules();
+        let click = Pos::new(Line(0), Column(13));
+        let r = smart_select_at(&term, &mut rules, click).expect("git sha should match");
+        assert_eq!(r.start, Pos::new(Line(0), Column(11)));
+        assert_eq!(r.end, Pos::new(Line(0), Column(20)));
+    }
+
+    #[test]
+    fn uuid_matches() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"id 550e8400-e29b-41d4-a716-446655440000 done");
+        let mut rules = default_rules();
+        let click = Pos::new(Line(0), Column(10));
+        let r = smart_select_at(&term, &mut rules, click).expect("UUID should match");
+        assert_eq!(r.start, Pos::new(Line(0), Column(3)));
+        assert_eq!(r.end, Pos::new(Line(0), Column(38)));
+    }
+
+    #[test]
+    fn email_matches() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"mail alice@example.com please");
+        let mut rules = default_rules();
+        let click = Pos::new(Line(0), Column(8));
+        let r = smart_select_at(&term, &mut rules, click).expect("email should match");
+        assert_eq!(r.start, Pos::new(Line(0), Column(5)));
+        assert_eq!(r.end, Pos::new(Line(0), Column(21)));
+    }
+
+    #[test]
+    fn no_match_on_plain_word_returns_none() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"hello world goodbye");
+        let mut rules = default_rules();
+        let click = Pos::new(Line(0), Column(6));
+        assert!(smart_select_at(&term, &mut rules, click).is_none());
+    }
+
+    #[test]
+    fn click_on_whitespace_returns_none() {
+        let mut term = cw(80, 5);
+        write(&mut term, b"foo bar 192.168.1.1 baz");
+        let mut rules = default_rules();
+        // Click on the space at column 7 (between "bar" and "192...").
+        assert_eq!(term.grid[Line(0)][Column(7)].c(), ' ');
+        let click = Pos::new(Line(0), Column(7));
+        assert!(smart_select_at(&term, &mut rules, click).is_none());
+    }
+
+    #[test]
+    fn url_split_across_soft_wrap_is_selected() {
+        // 10-col grid — write a URL that wraps mid-host.
+        let mut term = cw(10, 4);
+        write(&mut term, b"see https://example.com/x ok");
+        // Confirm we wrapped softly.
+        assert!(term.grid[Line(0)][Column(9)].wrapline());
+
+        let mut rules = default_rules();
+        // Click on the 'a' of "example" on the wrapped row.
+        let click = Pos::new(Line(1), Column(2));
+        let r = smart_select_at(&term, &mut rules, click).expect("URL should match");
+        // URL begins on row 0 at col 4 (h of https).
+        assert_eq!(r.start, Pos::new(Line(0), Column(4)));
+        // URL ends on a later row, at the last URL char before the space.
+        assert!(r.end.row > Line(0));
+        assert!(r.end > r.start);
+    }
+}

--- a/rio-backend/src/crosswords/smart_select.rs
+++ b/rio-backend/src/crosswords/smart_select.rs
@@ -385,6 +385,56 @@ mod tests {
     }
 
     #[test]
+    fn worst_case_select_stays_under_budget() {
+        // The engine has to be cheap enough for a worst-case logical
+        // line not to introduce visible click-to-paint latency. Cap
+        // the budget at 50 ms — typical is sub-millisecond, so 50× is
+        // a regression sentinel (e.g. an accidental per-click DFA
+        // recompile, an O(n²) sneaking in) not a tight bound that
+        // CI noise would trip.
+        use std::time::Instant;
+
+        let cols = MAX_SCAN_CELLS;
+        let mut term = cw(cols, 1);
+
+        // Repeating filler that frequently *starts* a match for each
+        // built-in rule (hex char → git_sha, digit+dot → ipv4, dot+
+        // alnum → file_line, `@` → email) without ever completing,
+        // forcing the DFAs to do real work. One real URL sits
+        // mid-line so the chosen-match path also executes.
+        let chunk = b"abc123.de4@xy5 ";
+        let url = b"https://example.com/path";
+        let mut body = Vec::with_capacity(cols);
+        while body.len() + chunk.len() + url.len() < cols / 2 {
+            body.extend_from_slice(chunk);
+        }
+        let url_start = body.len();
+        body.extend_from_slice(url);
+        while body.len() + chunk.len() < cols {
+            body.extend_from_slice(chunk);
+        }
+        write(&mut term, &body);
+
+        let mut sel = SmartSelector::new(&SmartSelectionConfig::default());
+        let click = Pos::new(Line(0), Column(url_start + url.len() / 2));
+
+        // Warm up — first call may pay one-shot lazy-DFA caching cost.
+        let _ = sel.select_at(&term, click);
+
+        let start = Instant::now();
+        let r = sel.select_at(&term, click);
+        let elapsed = start.elapsed();
+
+        assert!(r.is_some(), "URL should still match on a long line");
+        assert!(
+            elapsed.as_millis() < 50,
+            "smart_select_at took {:?} on a {}-cell line (budget: 50ms)",
+            elapsed,
+            cols,
+        );
+    }
+
+    #[test]
     fn selector_picks_up_added_user_rule_on_reload() {
         let mut term = cw(80, 5);
         // Phabricator-style ticket containing a `:` so semantic

--- a/rio-backend/src/crosswords/smart_select.rs
+++ b/rio-backend/src/crosswords/smart_select.rs
@@ -59,11 +59,9 @@ impl SmartSelector {
         }
     }
 
-    /// Replace the rule set with one freshly compiled from `config`.
-    /// Called on config reload; cheap relative to a click, but heavy
-    /// enough (compiles every regex) to be off the click hot path.
+    /// Recompile the rule set after a config edit.
     pub fn reload(&mut self, config: &SmartSelectionConfig) {
-        self.rules = config.compile();
+        *self = Self::new(config);
     }
 
     /// Resolve the click against the active rule set.
@@ -73,15 +71,6 @@ impl SmartSelector {
         click: Pos,
     ) -> Option<SelectionRange> {
         smart_select_at(term, &mut self.rules, click)
-    }
-
-    /// Number of active rules. Useful for assertions; not on a hot path.
-    pub fn len(&self) -> usize {
-        self.rules.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.rules.is_empty()
     }
 }
 


### PR DESCRIPTION
## Summary

Makes double-click selection URL- and token-aware so it stops truncating at
semantic boundary characters (`:` in particular). Implements #1621.

## Details

Two layers in front of the existing semantic selection:

1. **OSC 8 fast path** — double-clicking inside an OSC 8 hyperlink span selects
   the whole link across soft-wrapped rows. The span walk lives in
   `crosswords::hyperlink::hyperlink_span_at` and is now shared with the hint path
   so both agree on link boundaries.
2. **Smart-selection rules** — six precision-tagged regex rules ship as defaults
   (URL, `file:line:col`, UUID, IPv4, email, git SHA). The engine scans the
   soft-wrapped logical line containing the click and returns the highest-precision
   match covering it, falling back to the previous semantic behavior on no match.
   URL precision sits above IPv4 so `https://192.168.1.1/admin` selects whole.

A `[smart-selection]` config table lets users disable the engine, remove/override
built-in rules, or append their own (e.g. JIRA tickets) with hot reload. The
runtime rule list is the merge of defaults and user `[[smart-selection.rules]]`
layered by name (same name replaces, `enabled = false` removes, fresh name
appends); bad regexes log a warning and skip just that rule. `SmartSelector` owns
the compiled rules and the reload step, so a config change swaps the rule set
without rebuilding `Screen`. Documented in rio.5.

## Testing

`cargo test -p rio-backend` — rule merge/disable/override on reload, plus a
worst-case timing sentinel that fills an 8192-cell line and asserts one
`select_at()` stays well under budget.

Closes #1621

🤖 Generated with [Claude Code](https://claude.com/claude-code)
