### PR TITLE
fix: trigger font fallback discovery on Linux/Windows shape paths

### DIFF
--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -1211,7 +1211,7 @@ impl GridGlyphRasterizer {
     }
 
     #[inline]
-    fn resolve_font(
+    pub(crate) fn resolve_font(
         &mut self,
         ch: char,
         style_flags: u8,
@@ -1245,15 +1245,8 @@ impl GridGlyphRasterizer {
             .entry((ch, style_flags, route_id))
             .or_insert_with(|| {
                 let span_style = span_style_for_flags(style_flags);
-                #[cfg(target_os = "macos")]
                 let (id, emoji) =
                     font_library.resolve_font_for_char(ch, &span_style, Some(route_id));
-                #[cfg(not(target_os = "macos"))]
-                let (id, emoji) = {
-                    let lib = font_library.inner.read();
-                    lib.find_best_font_match(ch, &span_style, Some(route_id))
-                        .unwrap_or((0, false))
-                };
                 (id as u32, emoji)
             })
     }
@@ -2495,4 +2488,62 @@ fn font_library_hinting(_r: &GridGlyphRasterizer) -> bool {
     // For now the lock on swash rasterize is a small fraction of
     // render time; optimise if profiling flags it.
     true
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod resolve_font_cascade_tests {
+    use super::*;
+    use rio_backend::sugarloaf::font::constants::FONT_CASCADIA_CODE_NF;
+    use rio_backend::sugarloaf::font::{FontData, FontLibrary, FontLibraryData};
+    use rio_backend::sugarloaf::SpanStyle;
+    use std::sync::Arc;
+
+    fn make_lib_with_primary_only() -> FontLibrary {
+        let mut data = FontLibraryData::default();
+        data.insert(
+            FontData::from_static_slice(FONT_CASCADIA_CODE_NF).expect("load primary"),
+        );
+        FontLibrary {
+            inner: Arc::new(parking_lot::RwLock::new(data)),
+        }
+    }
+
+    /// Regression test for the bug where Linux/Windows shape paths
+    /// called `find_best_font_match` instead of `resolve_font_for_char`,
+    /// pinning codepoints absent from CascadiaCodeNF (e.g. U+23BF
+    /// "DENTISTRY SYMBOL LIGHT VERTICAL AND TOP RIGHT", used in Claude
+    /// Code output) to font_id 0 and rendering them as tofu. The fix
+    /// unified both call sites on `resolve_font_for_char`, which
+    /// triggers fontconfig cascade discovery on a primary-font miss.
+    ///
+    /// Linux-only because the cascade goes through fontconfig and
+    /// needs a system font covering U+23BF (FreeMono / Adwaita Mono /
+    /// IosevkaTerm Nerd Font Mono / Symbola are common matches). A
+    /// probe library establishes whether the host can cascade at all;
+    /// if not, the test skips — the bug it's guarding against isn't
+    /// reproducible there either way. If the host *can* cascade, the
+    /// assertion is unconditional: returning font_id 0 then is exactly
+    /// the regression.
+    #[test]
+    fn grid_resolve_font_cascades_for_char_outside_primary_font() {
+        const PROBE_CH: char = '\u{23BF}';
+
+        let probe = make_lib_with_primary_only();
+        let (probe_id, _) =
+            probe.resolve_font_for_char(PROBE_CH, &SpanStyle::default(), None);
+        if probe_id == 0 {
+            return;
+        }
+
+        let lib = make_lib_with_primary_only();
+        let mut rast = GridGlyphRasterizer::new();
+        let (font_id, _is_emoji) = rast.resolve_font(PROBE_CH, 0, &lib, 0);
+
+        assert_ne!(
+            font_id, 0,
+            "U+23BF is not in CascadiaCodeNF and the host can cascade-discover it \
+             (verified by probe). The grid resolver must reach `resolve_font_for_char` \
+             so the cascade fires — `find_best_font_match` alone would pin to 0 (tofu)."
+        );
+    }
 }

--- a/sugarloaf/src/font/mod.rs
+++ b/sugarloaf/src/font/mod.rs
@@ -2107,6 +2107,62 @@ mod postscript_resolver_tests {
     }
 }
 
+#[cfg(all(test, target_os = "linux"))]
+mod linux_cascade_tests {
+    use super::*;
+
+    /// Linux mirror of `resolve_font_for_char_lazy_discovers_cascade_font`.
+    /// Verifies fontconfig cascade discovery fires on a primary-font
+    /// miss and registers the discovered font. Uses U+23BF (the actual
+    /// regression character: missing-glyph rendering of `⎿` from
+    /// Claude Code's CLI output) — broadly covered on Linux by
+    /// FreeMono / Adwaita Mono / IosevkaTerm Nerd Font / Symbola.
+    ///
+    /// Skips when fontconfig can't find any covering font (true on
+    /// some minimal CI images) — the cascade can't fire there so the
+    /// test has nothing to assert.
+    #[test]
+    fn resolve_font_for_char_lazy_discovers_cascade_font_linux() {
+        use crate::SpanStyle;
+        use std::sync::Arc;
+
+        let make_lib = || {
+            let mut data = FontLibraryData::default();
+            data.insert(
+                FontData::from_static_slice(FONT_CASCADIA_CODE_NF).expect("load"),
+            );
+            FontLibrary {
+                inner: Arc::new(parking_lot::RwLock::new(data)),
+            }
+        };
+
+        let style = SpanStyle::default();
+        let probe = make_lib();
+        let (probe_id, _) = probe.resolve_font_for_char('\u{23BF}', &style, None);
+        if probe_id == 0 {
+            return;
+        }
+
+        let lib = make_lib();
+        let starting_len = lib.inner.read().inner.len();
+        let (font_id, _is_emoji) = lib.resolve_font_for_char('\u{23BF}', &style, None);
+
+        assert_ne!(
+            font_id, 0,
+            "lazy discovery should register a new font_id distinct from primary"
+        );
+        assert_eq!(
+            lib.inner.read().inner.len(),
+            starting_len + 1,
+            "lazy discovery should have registered exactly one new font"
+        );
+        assert!(
+            font_id < lib.inner.read().inner.len(),
+            "returned font_id should index into the library"
+        );
+    }
+}
+
 #[cfg(test)]
 mod glyph_registry_install_tests {
     use super::*;

--- a/sugarloaf/src/text.rs
+++ b/sugarloaf/src/text.rs
@@ -380,16 +380,8 @@ impl Text {
                     FontStyle::Normal
                 };
                 ss.font_attrs = Attributes::new(Stretch::NORMAL, weight, fstyle);
-                #[cfg(target_os = "macos")]
                 let resolved =
                     self.font_library.resolve_font_for_char(first_ch, &ss, None);
-
-                #[cfg(not(target_os = "macos"))]
-                let resolved = {
-                    let lib = self.font_library.inner.read();
-                    lib.find_best_font_match(first_ch, &ss, None)
-                        .unwrap_or((0, false))
-                };
                 let v = (resolved.0 as u32, resolved.1);
                 e.insert(v);
                 v


### PR DESCRIPTION
## Summary

Codepoints absent from the bundled CascadiaCodeNF (e.g. U+23BF `⎿`, surfaced by
Claude Code's output) rendered as tofu on Linux/Windows because the grid- and
UI-text shape paths used `find_best_font_match`, which only walks
already-registered fonts and returns `(0, false)` on a miss.

## Details

macOS already used `resolve_font_for_char`, which falls back to cascade discovery
(fontconfig on Linux, font-kit on Windows) and registers the discovered font. The
macOS/non-macOS split was incidental refactoring, not a deliberate platform
difference — the width-measurement path in `sugarloaf::font_cache` already used
the cross-platform resolver. This unifies both shape call sites on
`resolve_font_for_char`, which also removes a window-vs-window race where one
route's `font_resolve` cache could lock in font_id 0.

## Testing

`cargo test -p rioterm` — adds a Linux regression test that probes a fresh
`FontLibrary` to confirm the host can cascade-discover U+23BF (probe-first to
avoid false-failing on minimal CI), then asserts the grid resolver returns a
non-zero font_id.

Refs #1468, #1587

🤖 Generated with [Claude Code](https://claude.com/claude-code)
