### PR TITLE
fix: refresh Taffy root size when scaled margin changes

### DIFF
--- a/frontends/rioterm/src/layout/compute_tests.rs
+++ b/frontends/rioterm/src/layout/compute_tests.rs
@@ -647,3 +647,73 @@ fn test_split_inside_resized_panel_preserves_proportions() {
         "Bottom (bottom half) should be ~400px tall, got {bottom_h}"
     );
 }
+
+// --- update_scaled_margin ------------------------------------------------
+
+fn margin_test_dimension() -> ContextDimension {
+    let dims = TextDimensions {
+        width: 8.0,
+        height: 16.0,
+        scale: 1.0,
+    };
+    ContextDimension::build(
+        800.0,
+        600.0,
+        dims,
+        cell_for(dims),
+        1.0,
+        14.0,
+        Margin::all(0.0),
+    )
+}
+
+/// Build a single-panel grid off sugarloaf (positions come from
+/// `calculate_positions`, not `apply_taffy_layout`).
+fn single_panel_grid() -> ContextGrid<rio_backend::event::VoidListener> {
+    use crate::context::create_mock_context;
+    use rio_backend::event::VoidListener;
+    use rio_window::window::WindowId;
+
+    let first = create_mock_context(
+        VoidListener {},
+        WindowId::from(0),
+        0,
+        margin_test_dimension(),
+    );
+    ContextGrid::new(
+        first,
+        Margin::all(0.0),
+        [0.0; 4],
+        [0.0; 4],
+        rio_backend::config::layout::Panel::default(),
+    )
+}
+
+/// Regression: when the top window margin grows (e.g. the tab bar
+/// becomes visible after a second tab is created), `update_scaled_margin`
+/// must refresh Taffy's root size. Otherwise the next layout pass uses
+/// the stale available area and the panel keeps its old height — leaving
+/// the bottom rows clipped behind the tab bar.
+#[test]
+fn test_update_scaled_margin_shrinks_panel_when_top_margin_grows() {
+    let mut grid = single_panel_grid();
+    let panel = grid.current;
+
+    let initial_height = grid.inner[&panel].layout_rect[3];
+    assert!(
+        initial_height > 0.0,
+        "panel should have a positive initial height"
+    );
+
+    let tab_bar_height = 34.0;
+    grid.update_scaled_margin(Margin::new(tab_bar_height, 0.0, 0.0, 0.0));
+    grid.calculate_positions();
+
+    let new_height = grid.inner[&panel].layout_rect[3];
+    assert!(
+        (initial_height - new_height - tab_bar_height).abs() < 1.0,
+        "panel height should shrink by the new top margin: was {initial_height}, \
+         now {new_height}, expected ~{}",
+        initial_height - tab_bar_height
+    );
+}

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -1169,6 +1169,12 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
     pub fn update_scaled_margin(&mut self, scaled_margin: Margin) {
         self.scaled_margin = scaled_margin;
+        // The Taffy root size is `window - scaled_margin`. Changing the
+        // margin without refreshing it leaves the next `compute_layout`
+        // running against a stale available area, so panels keep their
+        // old size (e.g. the tab bar appearing eats into the terminal
+        // height but the PTY never shrinks).
+        let _ = self.try_update_size(self.width, self.height);
     }
 
     pub fn update_line_height(&mut self, line_height: f32) {


### PR DESCRIPTION
## Summary

Fixes #1495 — on opening a new tab the bottom of the terminal is hidden until the
window is resized.

## Details

When a second tab is created and the tab bar transitions from hidden to visible,
`update_scaled_margin` updated only the stored margin — Taffy's root size still
reflected the old, larger available area. The subsequent layout pass then kept the
panel at its old height and the PTY was never reflowed, so the bottom rows ended up
clipped behind the freshly appeared tab bar. `update_scaled_margin` now refreshes
the Taffy root size so the next layout pass uses the correct available area.

## Testing

`cargo test -p rioterm` — adds a regression test asserting the panel height shrinks
by the new top margin after `update_scaled_margin`.

Closes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
