### PR TITLE
fix: enable rio-window platform features in sugarloaf dev-deps

### DIFF
--- a/sugarloaf/Cargo.toml
+++ b/sugarloaf/Cargo.toml
@@ -121,7 +121,13 @@ ash = "0.38.0"
 # higher-level `windows` crate isn't in Debian at all.
 
 [dev-dependencies]
-rio-window = { workspace = true }
+# x11/wayland enable the platform cfg aliases rio-window's build.rs
+# sets — without one of them rio-window's platform_impl emits a
+# compile_error on Linux. The workspace declaration sets
+# default-features = false, so we re-enable them explicitly here.
+# Transitive x11/wayland deps are target.'cfg(free_unix)'-gated, so
+# this is a no-op on macOS/Windows.
+rio-window = { workspace = true, features = ["x11", "wayland", "wayland-dlopen"] }
 png = "0.17.16"
 deflate = "1.0.0"
 criterion = { workspace = true }


### PR DESCRIPTION
## Summary

`cargo test -p sugarloaf` (and any sugarloaf example importing `rio_window::...`)
failed to compile on Linux with rio-window's "platform not supported by winit"
`compile_error!`.

## Details

The workspace declares rio-window with `default-features = false`, so sugarloaf's
dev-dependency inherited no platform features and `platform_impl/mod.rs` tripped
its `compile_error!`. rioterm avoids this by re-enabling x11/wayland through its
own feature flags; sugarloaf had no equivalent. This enables the rio-window
x11/wayland platform features in sugarloaf's dev-deps.

## Testing

`cargo test -p sugarloaf` now compiles and runs on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
