### PR TITLE
feat: integrate the Linux bell with the desktop environment, and coalesce BEL floods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,6 +4048,7 @@ dependencies = [
  "futures",
  "image",
  "libc",
+ "libloading",
  "lru",
  "notify",
  "objc-rs 0.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock_instant"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,6 +3943,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
+ "mock_instant",
  "onig",
  "parking_lot",
  "raw-window-handle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,6 +4092,7 @@ dependencies = [
  "global-hotkey",
  "image",
  "libc",
+ "libloading",
  "lru",
  "notify",
  "objc-rs 0.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,6 +2757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock_instant"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,6 +3985,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
+ "mock_instant",
  "onig",
  "parking_lot",
  "raw-window-handle",

--- a/extra/man/rio.5.scd
+++ b/extra/man/rio.5.scd
@@ -315,6 +315,41 @@ This section documents the *[scroll]* table of the configuration file.
 
 	Default: _1.0_
 
+# BELL
+
+This section documents the *[bell]* table of the configuration file, which
+controls how the terminal bell (BEL, _\\a_) signals attention.
+
+*audio* = _false_ | _true_ | _"system"_
+
+	Audible bell.
+
+	- _false_ — no sound.
+	- _true_ — a self-synthesized tone (on macOS/Windows the native system beep).
+	- _"system"_ — the desktop environment's event sound. On Linux this uses the
+	  freedesktop sound theme via libcanberra (loaded at runtime; no-op if
+	  unavailable), respecting the configured sound theme, output routing,
+	  volume, mute and Do-Not-Disturb. On macOS/Windows this is the native
+	  system beep.
+
+	Default: _"system"_ on Linux/BSD, _true_ on macOS/Windows
+
+*urgency* = _true_ | _false_
+
+	Set the window urgency / attention hint when the bell fires in an unfocused
+	window, flashing the taskbar/dock entry. Uses the X11 _WM_HINTS_ urgency
+	flag or the Wayland _xdg-activation_ protocol. The hint is cleared when the
+	window regains focus.
+
+	Default: _true_ on Linux/BSD, _false_ on macOS/Windows
+
+*notification* = _true_ | _false_
+
+	Raise a desktop notification (_org.freedesktop.Notifications_) when the bell
+	fires in an unfocused window.
+
+	Default: _false_
+
 # NAVIGATION
 
 This section documents the *[navigation]* table of the configuration file.

--- a/extra/man/rio.5.scd
+++ b/extra/man/rio.5.scd
@@ -300,6 +300,41 @@ This section documents the *[scroll]* table of the configuration file.
 
 	Default: _1.0_
 
+# BELL
+
+This section documents the *[bell]* table of the configuration file, which
+controls how the terminal bell (BEL, _\\a_) signals attention.
+
+*audio* = _false_ | _true_ | _"system"_
+
+	Audible bell.
+
+	- _false_ — no sound.
+	- _true_ — a self-synthesized tone (on macOS/Windows the native system beep).
+	- _"system"_ — the desktop environment's event sound. On Linux this uses the
+	  freedesktop sound theme via libcanberra (loaded at runtime; no-op if
+	  unavailable), respecting the configured sound theme, output routing,
+	  volume, mute and Do-Not-Disturb. On macOS/Windows this is the native
+	  system beep.
+
+	Default: _"system"_ on Linux/BSD, _true_ on macOS/Windows
+
+*urgency* = _true_ | _false_
+
+	Set the window urgency / attention hint when the bell fires in an unfocused
+	window, flashing the taskbar/dock entry. Uses the X11 _WM_HINTS_ urgency
+	flag or the Wayland _xdg-activation_ protocol. The hint is cleared when the
+	window regains focus.
+
+	Default: _true_ on Linux/BSD, _false_ on macOS/Windows
+
+*notification* = _true_ | _false_
+
+	Raise a desktop notification (_org.freedesktop.Notifications_) when the bell
+	fires in an unfocused window.
+
+	Default: _false_
+
 # NAVIGATION
 
 This section documents the *[navigation]* table of the configuration file.

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -53,6 +53,9 @@ rio-notifier = { workspace = true }
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "windows")))'.dependencies]
 cpal = { version = "0.15", optional = true }
+# Loaded at runtime via dlopen for the freedesktop event-sound theme
+# (libcanberra). No build-time dependency; degrades gracefully if absent.
+libloading = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = { workspace = true }

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -54,6 +54,9 @@ rio-notifier = { workspace = true }
 
 [target.'cfg(all(not(target_os = "macos"), not(target_os = "windows")))'.dependencies]
 cpal = { version = "0.15", optional = true }
+# Loaded at runtime via dlopen for the freedesktop event-sound theme
+# (libcanberra). No build-time dependency; degrades gracefully if absent.
+libloading = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = { workspace = true }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -5,14 +5,9 @@ use crate::router::{routes::RoutePath, Router};
 use crate::scheduler::{Scheduler, TimerId, Topic};
 use crate::screen::touch::on_touch;
 use crate::watcher::configuration_file_updates;
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use raw_window_handle::HasDisplayHandle;
 use rio_backend::clipboard::{Clipboard, ClipboardType};
+use rio_backend::config::bell::AudioBell;
 use rio_backend::config::colors::{ColorRgb, NamedColor};
 use rio_window::application::ApplicationHandler;
 use rio_window::event::{
@@ -26,7 +21,7 @@ use rio_window::platform::macos::ActiveEventLoopExtMacOS;
 #[cfg(target_os = "macos")]
 use rio_window::platform::macos::WindowExtMacOS;
 use rio_window::window::WindowId;
-use rio_window::window::{CursorIcon, Fullscreen};
+use rio_window::window::{CursorIcon, Fullscreen, UserAttentionType};
 use std::error::Error;
 use std::time::{Duration, Instant};
 
@@ -99,41 +94,40 @@ impl Application<'_> {
         )
     }
 
-    fn handle_audio_bell(&mut self) {
-        #[cfg(target_os = "macos")]
-        {
-            // Use system bell sound on macOS
-            unsafe {
-                #[link(name = "AppKit", kind = "framework")]
-                extern "C" {
-                    fn NSBeep();
-                }
-                NSBeep();
-            }
+    fn handle_bell(&mut self, window_id: WindowId) {
+        tracing::debug!("bell fired: audio={:?}", self.config.bell.audio);
+        match self.config.bell.audio {
+            AudioBell::Off => {}
+            AudioBell::Beep => crate::bell::beep(),
+            AudioBell::System => crate::bell::system_sound(),
         }
 
-        #[cfg(target_os = "windows")]
-        {
-            // Use MessageBeep on Windows with MB_OK (0x00000000) for default beep
-            unsafe {
-                windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(0x00000000);
-            }
+        let urgency = self.config.bell.urgency.is_enabled();
+        let notify = self.config.bell.notification.is_enabled();
+        if !urgency && !notify {
+            return;
         }
 
-        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
-        {
-            #[cfg(feature = "audio")]
-            {
-                std::thread::spawn(|| {
-                    if let Err(e) = play_bell_sound() {
-                        tracing::warn!("Failed to play bell sound: {}", e);
-                    }
-                });
-            }
-            #[cfg(not(feature = "audio"))]
-            {
-                tracing::debug!("Audio bell requested but audio feature is not enabled");
-            }
+        let Some(route) = self.router.routes.get(&window_id) else {
+            return;
+        };
+        // Urgency and notifications only matter when the window is unfocused;
+        // that is the case where a background bell would otherwise be missed.
+        if route.window.is_focused {
+            return;
+        }
+
+        if urgency {
+            route
+                .window
+                .winit_window
+                .request_user_attention(Some(UserAttentionType::Informational));
+        }
+
+        if notify {
+            let title = route.window.screen.ctx().current_title();
+            let title = if title.is_empty() { "Rio" } else { &title };
+            self.handle_desktop_notification(title, "Terminal bell");
         }
     }
 
@@ -545,10 +539,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::Bell) => {
-                // Handle audio bell
-                if self.config.bell.audio {
-                    self.handle_audio_bell();
-                }
+                self.handle_bell(window_id);
             }
             RioEventType::Rio(RioEvent::DesktopNotification { title, body }) => {
                 self.handle_desktop_notification(&title, &body);
@@ -1699,6 +1690,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 route.window.is_focused = focused;
 
                 if has_regained_focus {
+                    // Clear any bell urgency hint now that the user is back; X11
+                    // only clears it on request (Wayland treats `None` as a no-op).
+                    route.window.winit_window.request_user_attention(None);
                     route.request_redraw();
                 }
 
@@ -1923,76 +1917,4 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
         std::process::exit(0);
     }
-}
-
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn play_bell_sound() -> Result<(), Box<dyn Error>> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or("No output device available")?;
-
-    let config = device.default_output_config()?;
-
-    match config.sample_format() {
-        cpal::SampleFormat::F32 => run_bell::<f32>(&device, &config.into()),
-        cpal::SampleFormat::I16 => run_bell::<i16>(&device, &config.into()),
-        cpal::SampleFormat::U16 => run_bell::<u16>(&device, &config.into()),
-        _ => Err("Unsupported sample format".into()),
-    }
-}
-
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn run_bell<T>(
-    device: &cpal::Device,
-    config: &cpal::StreamConfig,
-) -> Result<(), Box<dyn Error>>
-where
-    T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
-{
-    let sample_rate = config.sample_rate.0 as f32;
-    let channels = config.channels as usize;
-    let duration_secs = crate::constants::BELL_DURATION.as_secs_f32();
-    let total_samples = (sample_rate * duration_secs) as usize;
-
-    let mut sample_clock = 0f32;
-    let mut samples_played = 0usize;
-
-    let stream = device.build_output_stream(
-        config,
-        move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
-            for frame in data.chunks_mut(channels) {
-                if samples_played >= total_samples {
-                    for sample in frame.iter_mut() {
-                        *sample = T::from_sample(0.0);
-                    }
-                } else {
-                    let value = (sample_clock * 440.0 * 2.0 * std::f32::consts::PI
-                        / sample_rate)
-                        .sin()
-                        * 0.2;
-                    for sample in frame.iter_mut() {
-                        *sample = T::from_sample(value);
-                    }
-                    sample_clock += 1.0;
-                    samples_played += 1;
-                }
-            }
-        },
-        |err| tracing::error!("Audio stream error: {}", err),
-        None,
-    )?;
-
-    stream.play()?;
-    std::thread::sleep(crate::constants::BELL_DURATION);
-
-    Ok(())
 }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -7,7 +7,6 @@ use crate::screen::touch::on_touch;
 use crate::watcher::configuration_file_updates;
 use raw_window_handle::HasDisplayHandle;
 use rio_backend::clipboard::{Clipboard, ClipboardType};
-use rio_backend::config::bell::AudioBell;
 use rio_backend::config::colors::{ColorRgb, NamedColor};
 use rio_window::application::ApplicationHandler;
 use rio_window::event::{
@@ -96,11 +95,12 @@ impl Application<'_> {
 
     fn handle_bell(&mut self, window_id: WindowId) {
         tracing::debug!("bell fired: audio={:?}", self.config.bell.audio);
-        match self.config.bell.audio {
-            AudioBell::Off => {}
-            AudioBell::Beep => crate::bell::beep(),
-            AudioBell::System => crate::bell::system_sound(),
-        }
+
+        // Playback always runs on the bell worker thread, never the window
+        // thread. The flood from `cat`-ing a binary file is already coalesced
+        // upstream in the backend (one bell per `bell.min-interval`), so this
+        // only ever sees the occasional bell.
+        crate::bell::ring(self.config.bell.audio);
 
         let urgency = self.config.bell.urgency.is_enabled();
         let notify = self.config.bell.notification.is_enabled();

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -7,7 +7,6 @@ use crate::screen::touch::on_touch;
 use crate::watcher::configuration_file_updates;
 use raw_window_handle::HasDisplayHandle;
 use rio_backend::clipboard::{Clipboard, ClipboardType};
-use rio_backend::config::bell::AudioBell;
 use rio_backend::config::colors::{ColorRgb, NamedColor};
 use rio_window::application::ApplicationHandler;
 use rio_window::event::{
@@ -104,11 +103,12 @@ impl Application<'_> {
 
     fn handle_bell(&mut self, window_id: WindowId) {
         tracing::debug!("bell fired: audio={:?}", self.config.bell.audio);
-        match self.config.bell.audio {
-            AudioBell::Off => {}
-            AudioBell::Beep => crate::bell::beep(),
-            AudioBell::System => crate::bell::system_sound(),
-        }
+
+        // Playback always runs on the bell worker thread, never the window
+        // thread. The flood from `cat`-ing a binary file is already coalesced
+        // upstream in the backend (one bell per `bell.min-interval`), so this
+        // only ever sees the occasional bell.
+        crate::bell::ring(self.config.bell.audio);
 
         let urgency = self.config.bell.urgency.is_enabled();
         let notify = self.config.bell.notification.is_enabled();

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -5,14 +5,9 @@ use crate::router::{routes::RoutePath, Router};
 use crate::scheduler::{Scheduler, TimerId, Topic};
 use crate::screen::touch::on_touch;
 use crate::watcher::configuration_file_updates;
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use raw_window_handle::HasDisplayHandle;
 use rio_backend::clipboard::{Clipboard, ClipboardType};
+use rio_backend::config::bell::AudioBell;
 use rio_backend::config::colors::{ColorRgb, NamedColor};
 use rio_window::application::ApplicationHandler;
 use rio_window::event::{
@@ -26,7 +21,7 @@ use rio_window::platform::macos::ActiveEventLoopExtMacOS;
 #[cfg(target_os = "macos")]
 use rio_window::platform::macos::WindowExtMacOS;
 use rio_window::window::WindowId;
-use rio_window::window::{CursorIcon, Fullscreen};
+use rio_window::window::{CursorIcon, Fullscreen, UserAttentionType};
 use std::error::Error;
 use std::time::{Duration, Instant};
 
@@ -107,41 +102,40 @@ impl Application<'_> {
         )
     }
 
-    fn handle_audio_bell(&mut self) {
-        #[cfg(target_os = "macos")]
-        {
-            // Use system bell sound on macOS
-            unsafe {
-                #[link(name = "AppKit", kind = "framework")]
-                extern "C" {
-                    fn NSBeep();
-                }
-                NSBeep();
-            }
+    fn handle_bell(&mut self, window_id: WindowId) {
+        tracing::debug!("bell fired: audio={:?}", self.config.bell.audio);
+        match self.config.bell.audio {
+            AudioBell::Off => {}
+            AudioBell::Beep => crate::bell::beep(),
+            AudioBell::System => crate::bell::system_sound(),
         }
 
-        #[cfg(target_os = "windows")]
-        {
-            // Use MessageBeep on Windows with MB_OK (0x00000000) for default beep
-            unsafe {
-                windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(0x00000000);
-            }
+        let urgency = self.config.bell.urgency.is_enabled();
+        let notify = self.config.bell.notification.is_enabled();
+        if !urgency && !notify {
+            return;
         }
 
-        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
-        {
-            #[cfg(feature = "audio")]
-            {
-                std::thread::spawn(|| {
-                    if let Err(e) = play_bell_sound() {
-                        tracing::warn!("Failed to play bell sound: {}", e);
-                    }
-                });
-            }
-            #[cfg(not(feature = "audio"))]
-            {
-                tracing::debug!("Audio bell requested but audio feature is not enabled");
-            }
+        let Some(route) = self.router.routes.get(&window_id) else {
+            return;
+        };
+        // Urgency and notifications only matter when the window is unfocused;
+        // that is the case where a background bell would otherwise be missed.
+        if route.window.is_focused {
+            return;
+        }
+
+        if urgency {
+            route
+                .window
+                .winit_window
+                .request_user_attention(Some(UserAttentionType::Informational));
+        }
+
+        if notify {
+            let title = route.window.screen.ctx().current_title();
+            let title = if title.is_empty() { "Rio" } else { &title };
+            self.handle_desktop_notification(title, "Terminal bell");
         }
     }
 
@@ -714,10 +708,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::Bell) => {
-                // Handle audio bell
-                if self.config.bell.audio {
-                    self.handle_audio_bell();
-                }
+                self.handle_bell(window_id);
             }
             RioEventType::Rio(RioEvent::DesktopNotification { title, body }) => {
                 self.handle_desktop_notification(&title, &body);
@@ -1965,6 +1956,11 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 route.window.is_focused = focused;
 
                 if focus_changed {
+                    if focused {
+                        // Clear any bell urgency hint now that the user is back; X11
+                        // only clears it on request (Wayland treats `None` as a no-op).
+                        route.window.winit_window.request_user_attention(None);
+                    }
                     route.request_redraw();
                 }
 
@@ -2179,76 +2175,4 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
         std::process::exit(0);
     }
-}
-
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn play_bell_sound() -> Result<(), Box<dyn Error>> {
-    let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or("No output device available")?;
-
-    let config = device.default_output_config()?;
-
-    match config.sample_format() {
-        cpal::SampleFormat::F32 => run_bell::<f32>(&device, &config.into()),
-        cpal::SampleFormat::I16 => run_bell::<i16>(&device, &config.into()),
-        cpal::SampleFormat::U16 => run_bell::<u16>(&device, &config.into()),
-        _ => Err("Unsupported sample format".into()),
-    }
-}
-
-#[cfg(all(
-    feature = "audio",
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn run_bell<T>(
-    device: &cpal::Device,
-    config: &cpal::StreamConfig,
-) -> Result<(), Box<dyn Error>>
-where
-    T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
-{
-    let sample_rate = config.sample_rate.0 as f32;
-    let channels = config.channels as usize;
-    let duration_secs = crate::constants::BELL_DURATION.as_secs_f32();
-    let total_samples = (sample_rate * duration_secs) as usize;
-
-    let mut sample_clock = 0f32;
-    let mut samples_played = 0usize;
-
-    let stream = device.build_output_stream(
-        config,
-        move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
-            for frame in data.chunks_mut(channels) {
-                if samples_played >= total_samples {
-                    for sample in frame.iter_mut() {
-                        *sample = T::from_sample(0.0);
-                    }
-                } else {
-                    let value = (sample_clock * 440.0 * 2.0 * std::f32::consts::PI
-                        / sample_rate)
-                        .sin()
-                        * 0.2;
-                    for sample in frame.iter_mut() {
-                        *sample = T::from_sample(value);
-                    }
-                    sample_clock += 1.0;
-                    samples_played += 1;
-                }
-            }
-        },
-        |err| tracing::error!("Audio stream error: {}", err),
-        None,
-    )?;
-
-    stream.play()?;
-    std::thread::sleep(crate::constants::BELL_DURATION);
-
-    Ok(())
 }

--- a/frontends/rioterm/src/bell/canberra.rs
+++ b/frontends/rioterm/src/bell/canberra.rs
@@ -1,0 +1,133 @@
+//! Minimal runtime binding to libcanberra, loaded via `dlopen` so Rio gains no
+//! build-time dependency and degrades gracefully when the library is absent —
+//! matching how the rest of the project loads Linux system libraries (x11-dl,
+//! xkbcommon-dl, wayland-dlopen).
+//!
+//! Playing through libcanberra is what makes the bell respect the user's
+//! freedesktop event-sound theme, output routing, volume, mute and
+//! Do-Not-Disturb state.
+
+use libloading::Library;
+use std::ffi::{c_char, c_int, c_void, CString};
+use std::sync::OnceLock;
+
+type CaContext = c_void;
+type CaProplist = c_void;
+
+type CaContextCreate = unsafe extern "C" fn(*mut *mut CaContext) -> c_int;
+type CaContextChangePropsFull =
+    unsafe extern "C" fn(*mut CaContext, *mut CaProplist) -> c_int;
+type CaContextPlayFull = unsafe extern "C" fn(
+    *mut CaContext,
+    u32,
+    *mut CaProplist,
+    *mut c_void,
+    *mut c_void,
+) -> c_int;
+type CaProplistCreate = unsafe extern "C" fn(*mut *mut CaProplist) -> c_int;
+type CaProplistSets =
+    unsafe extern "C" fn(*mut CaProplist, *const c_char, *const c_char) -> c_int;
+type CaProplistDestroy = unsafe extern "C" fn(*mut CaProplist) -> c_int;
+
+struct Canberra {
+    // Kept alive so the resolved function pointers remain valid.
+    _lib: Library,
+    context: *mut CaContext,
+    play_full: CaContextPlayFull,
+    proplist_create: CaProplistCreate,
+    proplist_sets: CaProplistSets,
+    proplist_destroy: CaProplistDestroy,
+}
+
+// The context is only ever touched from the main event-loop thread, but the
+// `OnceLock` requires the stored value to be `Sync`. The raw pointer and
+// function pointers are valid for the process lifetime.
+unsafe impl Send for Canberra {}
+unsafe impl Sync for Canberra {}
+
+static CANBERRA: OnceLock<Option<Canberra>> = OnceLock::new();
+
+impl Canberra {
+    unsafe fn load() -> Option<Canberra> {
+        let lib = Library::new("libcanberra.so.0")
+            .or_else(|_| Library::new("libcanberra.so"))
+            .ok()?;
+
+        let create: CaContextCreate = *lib.get(b"ca_context_create\0").ok()?;
+        let change_props_full: CaContextChangePropsFull =
+            *lib.get(b"ca_context_change_props_full\0").ok()?;
+        let play_full: CaContextPlayFull = *lib.get(b"ca_context_play_full\0").ok()?;
+        let proplist_create: CaProplistCreate = *lib.get(b"ca_proplist_create\0").ok()?;
+        let proplist_sets: CaProplistSets = *lib.get(b"ca_proplist_sets\0").ok()?;
+        let proplist_destroy: CaProplistDestroy =
+            *lib.get(b"ca_proplist_destroy\0").ok()?;
+
+        let mut context: *mut CaContext = std::ptr::null_mut();
+        let err = create(&mut context);
+        if err != 0 || context.is_null() {
+            tracing::debug!("ca_context_create failed (error {err})");
+            return None;
+        }
+
+        // The PulseAudio/PipeWire backend refuses to open a context that has no
+        // application name (driver_open returns CA_ERROR_STATE), which would
+        // make every play silently fail. Set it up front.
+        let mut props: *mut CaProplist = std::ptr::null_mut();
+        if proplist_create(&mut props) == 0 && !props.is_null() {
+            proplist_sets(props, c"application.name".as_ptr(), c"Rio".as_ptr());
+            proplist_sets(props, c"application.id".as_ptr(), c"rio".as_ptr());
+            proplist_sets(props, c"application.icon_name".as_ptr(), c"rio".as_ptr());
+            change_props_full(context, props);
+            proplist_destroy(props);
+        }
+
+        Some(Canberra {
+            _lib: lib,
+            context,
+            play_full,
+            proplist_create,
+            proplist_sets,
+            proplist_destroy,
+        })
+    }
+}
+
+fn canberra() -> Option<&'static Canberra> {
+    CANBERRA
+        .get_or_init(|| unsafe { Canberra::load() })
+        .as_ref()
+}
+
+/// Play a freedesktop event sound by id (e.g. `"bell"`). Returns immediately;
+/// libcanberra plays the sound asynchronously. No-op if libcanberra cannot be
+/// loaded.
+pub fn play(event_id: &str) {
+    let Some(canberra) = canberra() else {
+        tracing::debug!("libcanberra unavailable; skipping system bell sound");
+        return;
+    };
+    let Ok(id) = CString::new(event_id) else {
+        return;
+    };
+
+    unsafe {
+        let mut proplist: *mut CaProplist = std::ptr::null_mut();
+        if (canberra.proplist_create)(&mut proplist) != 0 || proplist.is_null() {
+            return;
+        }
+        // CA_PROP_EVENT_ID
+        (canberra.proplist_sets)(proplist, c"event.id".as_ptr(), id.as_ptr());
+        let err = (canberra.play_full)(
+            canberra.context,
+            0,
+            proplist,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        (canberra.proplist_destroy)(proplist);
+
+        if err != 0 {
+            tracing::warn!("libcanberra failed to play '{event_id}' (error {err})");
+        }
+    }
+}

--- a/frontends/rioterm/src/bell/mod.rs
+++ b/frontends/rioterm/src/bell/mod.rs
@@ -1,0 +1,135 @@
+//! Terminal bell side effects: the audible beep and the desktop environment's
+//! event sound theme.
+
+#[cfg(all(unix, not(target_os = "macos")))]
+mod canberra;
+
+/// Play the legacy/native beep: the self-synthesized tone on Linux/BSD (behind
+/// the `audio` feature), or the OS system beep on macOS/Windows.
+pub fn beep() {
+    #[cfg(target_os = "macos")]
+    {
+        // Use the system bell sound on macOS.
+        unsafe {
+            #[link(name = "AppKit", kind = "framework")]
+            extern "C" {
+                fn NSBeep();
+            }
+            NSBeep();
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // MB_OK (0x00000000) plays the default system beep.
+        unsafe {
+            windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(0x00000000);
+        }
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        #[cfg(feature = "audio")]
+        {
+            std::thread::spawn(|| {
+                if let Err(e) = tone::play() {
+                    tracing::warn!("Failed to play bell sound: {}", e);
+                }
+            });
+        }
+        #[cfg(not(feature = "audio"))]
+        {
+            tracing::debug!(
+                "Audio bell requested but the `audio` feature is not enabled"
+            );
+        }
+    }
+}
+
+/// Play the desktop environment's configured event sound. On Linux/BSD this is
+/// the freedesktop sound theme (via libcanberra), which respects the user's
+/// theme, output routing, volume, mute and Do-Not-Disturb. On macOS/Windows the
+/// native system beep already is the system sound.
+pub fn system_sound() {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        beep();
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        canberra::play("bell");
+    }
+}
+
+#[cfg(all(
+    feature = "audio",
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+mod tone {
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use std::error::Error;
+
+    pub fn play() -> Result<(), Box<dyn Error>> {
+        let host = cpal::default_host();
+        let device = host
+            .default_output_device()
+            .ok_or("No output device available")?;
+
+        let config = device.default_output_config()?;
+
+        match config.sample_format() {
+            cpal::SampleFormat::F32 => run::<f32>(&device, &config.into()),
+            cpal::SampleFormat::I16 => run::<i16>(&device, &config.into()),
+            cpal::SampleFormat::U16 => run::<u16>(&device, &config.into()),
+            _ => Err("Unsupported sample format".into()),
+        }
+    }
+
+    fn run<T>(
+        device: &cpal::Device,
+        config: &cpal::StreamConfig,
+    ) -> Result<(), Box<dyn Error>>
+    where
+        T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
+    {
+        let sample_rate = config.sample_rate.0 as f32;
+        let channels = config.channels as usize;
+        let duration_secs = crate::constants::BELL_DURATION.as_secs_f32();
+        let total_samples = (sample_rate * duration_secs) as usize;
+
+        let mut sample_clock = 0f32;
+        let mut samples_played = 0usize;
+
+        let stream = device.build_output_stream(
+            config,
+            move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+                for frame in data.chunks_mut(channels) {
+                    if samples_played >= total_samples {
+                        for sample in frame.iter_mut() {
+                            *sample = T::from_sample(0.0);
+                        }
+                    } else {
+                        let value = (sample_clock * 440.0 * 2.0 * std::f32::consts::PI
+                            / sample_rate)
+                            .sin()
+                            * 0.2;
+                        for sample in frame.iter_mut() {
+                            *sample = T::from_sample(value);
+                        }
+                        sample_clock += 1.0;
+                        samples_played += 1;
+                    }
+                }
+            },
+            |err| tracing::error!("Audio stream error: {}", err),
+            None,
+        )?;
+
+        stream.play()?;
+        std::thread::sleep(crate::constants::BELL_DURATION);
+
+        Ok(())
+    }
+}

--- a/frontends/rioterm/src/bell/mod.rs
+++ b/frontends/rioterm/src/bell/mod.rs
@@ -1,12 +1,68 @@
 //! Terminal bell side effects: the audible beep and the desktop environment's
 //! event sound theme.
+//!
+//! Playback always happens on a single dedicated worker thread, so it can never
+//! block the window/event-loop thread — even a synthesized tone that must stay
+//! alive for its full duration, or a system sound that does blocking IPC. A
+//! flood of bells (e.g. `cat`-ing a binary file) is throttled upstream by the
+//! backend's coalescing gate, so this thread only ever sees the occasional
+//! bell.
+
+use rio_backend::config::bell::AudioBell;
+use std::sync::mpsc::{channel, Sender};
+use std::sync::OnceLock;
 
 #[cfg(all(unix, not(target_os = "macos")))]
 mod canberra;
 
+static BELL_TX: OnceLock<Sender<AudioBell>> = OnceLock::new();
+
+/// Sender to the bell worker thread, spawned lazily on first use.
+fn sender() -> &'static Sender<AudioBell> {
+    BELL_TX.get_or_init(|| {
+        let (tx, rx) = channel::<AudioBell>();
+        if let Err(err) =
+            std::thread::Builder::new()
+                .name("rio-bell".into())
+                .spawn(move || {
+                    // Play bells one at a time. Each call blocks only this worker
+                    // thread for as long as the backend needs to keep the sound
+                    // alive; the window thread is never touched.
+                    while let Ok(audio) = rx.recv() {
+                        play(audio);
+                    }
+                })
+        {
+            tracing::warn!("failed to spawn bell worker thread: {err}");
+        }
+        tx
+    })
+}
+
+/// Ring the bell for `audio` on the worker thread. Never blocks the calling
+/// (window) thread, and is a no-op for [`AudioBell::Off`].
+pub fn ring(audio: AudioBell) {
+    if matches!(audio, AudioBell::Off) {
+        return;
+    }
+    if let Err(err) = sender().send(audio) {
+        tracing::warn!("bell worker unavailable: {err}");
+    }
+}
+
+/// Play the bell, blocking the worker thread until the sound has been issued
+/// (and, for the synthesized tone, fully played).
+fn play(audio: AudioBell) {
+    match audio {
+        AudioBell::Off => {}
+        AudioBell::Beep => beep(),
+        AudioBell::System => system_sound(),
+    }
+}
+
 /// Play the legacy/native beep: the self-synthesized tone on Linux/BSD (behind
 /// the `audio` feature), or the OS system beep on macOS/Windows.
-pub fn beep() {
+fn beep() {
     #[cfg(target_os = "macos")]
     {
         // Use the system bell sound on macOS.
@@ -31,11 +87,9 @@ pub fn beep() {
     {
         #[cfg(feature = "audio")]
         {
-            std::thread::spawn(|| {
-                if let Err(e) = tone::play() {
-                    tracing::warn!("Failed to play bell sound: {}", e);
-                }
-            });
+            if let Err(e) = tone::play() {
+                tracing::warn!("Failed to play bell sound: {}", e);
+            }
         }
         #[cfg(not(feature = "audio"))]
         {
@@ -50,7 +104,7 @@ pub fn beep() {
 /// the freedesktop sound theme (via libcanberra), which respects the user's
 /// theme, output routing, volume, mute and Do-Not-Disturb. On macOS/Windows the
 /// native system beep already is the system sound.
-pub fn system_sound() {
+fn system_sound() {
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
         beep();

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -133,6 +133,8 @@ pub struct ContextManagerConfig {
     pub title: rio_backend::config::title::Title,
     pub keyboard: rio_backend::config::keyboard::Keyboard,
     pub scrollback_history_limit: usize,
+    /// Minimum time in milliseconds between two bells (`bell.min-interval`).
+    pub bell_min_interval: u64,
 }
 
 const DEFAULT_CONTEXT_CAPACITY: usize = 28;
@@ -241,6 +243,8 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             config.scrollback_history_limit,
         );
         terminal.blinking_cursor = cursor_state.1;
+        terminal.bell_min_interval =
+            std::time::Duration::from_millis(config.bell_min_interval);
         let terminal: Arc<FairMutex<Crosswords<T>>> = Arc::new(FairMutex::new(terminal));
 
         let pty;
@@ -1026,6 +1030,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             title: config.title,
             keyboard: config.keyboard,
             scrollback_history_limit: config.scrollback_history_limit,
+            bell_min_interval: config.bell.min_interval,
         };
 
         let current = self.current();

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -719,6 +719,14 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
+    pub fn current_title(&self) -> String {
+        self.titles
+            .titles
+            .get(&self.current_index)
+            .map(|title| title.content.clone())
+            .unwrap_or_default()
+    }
+
     pub fn update_titles(&mut self) {
         let interval_time = Duration::from_secs(2);
         if self

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -140,6 +140,8 @@ pub struct ContextManagerConfig {
     pub title: rio_backend::config::title::Title,
     pub keyboard: rio_backend::config::keyboard::Keyboard,
     pub scrollback_history_limit: usize,
+    /// Minimum time in milliseconds between two bells (`bell.min-interval`).
+    pub bell_min_interval: u64,
 }
 
 const DEFAULT_CONTEXT_CAPACITY: usize = 28;
@@ -253,6 +255,8 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             config.scrollback_history_limit,
         );
         terminal.blinking_cursor = cursor_state.1;
+        terminal.bell_min_interval =
+            std::time::Duration::from_millis(config.bell_min_interval);
         let terminal: Arc<FairMutex<Crosswords<T>>> = Arc::new(FairMutex::new(terminal));
 
         let pty;
@@ -1077,6 +1081,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             title: config.title,
             keyboard: config.keyboard,
             scrollback_history_limit: config.scrollback_history_limit,
+            bell_min_interval: config.bell.min_interval,
         };
 
         let current = self.current();

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -767,6 +767,10 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
+    pub fn current_title(&self) -> String {
+        self.current().title.content.clone()
+    }
+
     pub fn update_titles(&mut self) {
         let interval_time = Duration::from_secs(2);
         if self

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -5,6 +5,7 @@
 #![windows_subsystem = "windows"]
 
 mod application;
+mod bell;
 mod bindings;
 mod cli;
 mod constants;

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -228,6 +228,7 @@ impl Screen<'_> {
             title: config.title.clone(),
             keyboard: config.keyboard,
             scrollback_history_limit: config.scrollback_history_limit,
+            bell_min_interval: config.bell.min_interval,
         };
 
         // Allocate a rich_text_id for the new panel. Sugarloaf no
@@ -523,6 +524,8 @@ impl Screen<'_> {
                 terminal.cursor_shape = shape;
                 terminal.default_cursor_shape = shape;
                 terminal.blinking_cursor = config.cursor.blinking;
+                terminal.bell_min_interval =
+                    std::time::Duration::from_millis(config.bell.min_interval);
                 drop(terminal);
             }
         }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -230,6 +230,7 @@ impl Screen<'_> {
             title: config.title.clone(),
             keyboard: config.keyboard,
             scrollback_history_limit: config.scrollback_history_limit,
+            bell_min_interval: config.bell.min_interval,
         };
 
         let rich_text_id = next_rich_text_id();
@@ -494,6 +495,8 @@ impl Screen<'_> {
                 terminal.cursor_shape = shape;
                 terminal.default_cursor_shape = shape;
                 terminal.blinking_cursor = config.cursor.blinking;
+                terminal.bell_min_interval =
+                    std::time::Duration::from_millis(config.bell.min_interval);
                 drop(terminal);
             }
         }

--- a/rio-backend/Cargo.toml
+++ b/rio-backend/Cargo.toml
@@ -63,3 +63,6 @@ wayland = [
 # native Vulkan/Metal backends aren't available, and as an opt-in for
 # librashader CRT/scanline filters on Linux/macOS).
 wgpu = ["dep:wgpu", "sugarloaf/wgpu"]
+
+[dev-dependencies]
+mock_instant = "0.6.0"

--- a/rio-backend/src/config/bell.rs
+++ b/rio-backend/src/config/bell.rs
@@ -1,27 +1,268 @@
+use serde::de::{self, Deserializer};
+use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Bell {
-    #[serde(default = "default_audio_bell")]
-    pub audio: bool,
+    #[serde(default = "default_audio")]
+    pub audio: AudioBell,
+    #[serde(default = "default_urgency")]
+    pub urgency: UrgencyHint,
+    #[serde(default = "default_notification")]
+    pub notification: BellNotification,
+}
+
+/// How the audible bell behaves.
+///
+/// Deserializes from either a bool (`false`/`true`, kept for backwards
+/// compatibility) or a string (`"off"`/`"beep"`/`"system"`):
+/// - `false` / `"off"` — no sound.
+/// - `true` / `"beep"` — legacy self-synthesized tone (macOS/Windows use the
+///   native system beep).
+/// - `"system"` — the desktop environment's event sound theme (Linux:
+///   libcanberra; macOS/Windows: the native system beep).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioBell {
+    Off,
+    Beep,
+    System,
+}
+
+/// Whether the bell sets the window urgency / attention hint (taskbar/dock
+/// flash) when it fires in an unfocused window. Accepts a bool or
+/// `"on"`/`"off"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UrgencyHint {
+    Disabled,
+    Enabled,
+}
+
+/// Whether the bell raises a desktop notification when it fires in an unfocused
+/// window. Accepts a bool or `"on"`/`"off"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BellNotification {
+    Disabled,
+    Enabled,
+}
+
+impl UrgencyHint {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, UrgencyHint::Enabled)
+    }
+}
+
+impl BellNotification {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, BellNotification::Enabled)
+    }
 }
 
 impl Default for Bell {
     fn default() -> Self {
         Bell {
-            audio: default_audio_bell(),
+            audio: default_audio(),
+            urgency: default_urgency(),
+            notification: default_notification(),
         }
     }
 }
 
-fn default_audio_bell() -> bool {
-    // Enable audio bell by default on macOS and Windows since they use the system sound
+fn default_audio() -> AudioBell {
+    // macOS and Windows beep with the native system sound; Linux integrates
+    // with the freedesktop event-sound theme via libcanberra.
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
-        true
+        AudioBell::Beep
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        false
+        AudioBell::System
+    }
+}
+
+fn default_urgency() -> UrgencyHint {
+    // The window urgency / attention hint is the primary reason a bell is
+    // useful on Linux (taskbar/dock flash when unfocused). Leave the existing
+    // macOS/Windows behavior untouched.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        UrgencyHint::Disabled
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        UrgencyHint::Enabled
+    }
+}
+
+fn default_notification() -> BellNotification {
+    BellNotification::Disabled
+}
+
+impl<'de> Deserialize<'de> for AudioBell {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match BoolOrStr::deserialize(deserializer)? {
+            BoolOrStr::Bool(true) => Ok(AudioBell::Beep),
+            BoolOrStr::Bool(false) => Ok(AudioBell::Off),
+            BoolOrStr::Str(s) => match s.to_ascii_lowercase().as_str() {
+                "off" | "false" | "none" => Ok(AudioBell::Off),
+                "beep" | "true" | "tone" => Ok(AudioBell::Beep),
+                "system" => Ok(AudioBell::System),
+                other => Err(de::Error::custom(format!(
+                    "invalid bell audio value {other:?} (expected false, true, or \"system\")"
+                ))),
+            },
+        }
+    }
+}
+
+impl Serialize for AudioBell {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            AudioBell::Off => serializer.serialize_bool(false),
+            AudioBell::Beep => serializer.serialize_bool(true),
+            AudioBell::System => serializer.serialize_str("system"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UrgencyHint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(if toggle_from(deserializer)? {
+            UrgencyHint::Enabled
+        } else {
+            UrgencyHint::Disabled
+        })
+    }
+}
+
+impl Serialize for UrgencyHint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bool(self.is_enabled())
+    }
+}
+
+impl<'de> Deserialize<'de> for BellNotification {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(if toggle_from(deserializer)? {
+            BellNotification::Enabled
+        } else {
+            BellNotification::Disabled
+        })
+    }
+}
+
+impl Serialize for BellNotification {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bool(self.is_enabled())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum BoolOrStr {
+    Bool(bool),
+    Str(String),
+}
+
+/// Parse an on/off toggle that accepts a TOML bool or a string spelling.
+fn toggle_from<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match BoolOrStr::deserialize(deserializer)? {
+        BoolOrStr::Bool(b) => Ok(b),
+        BoolOrStr::Str(s) => match s.to_ascii_lowercase().as_str() {
+            "on" | "true" | "enabled" | "yes" => Ok(true),
+            "off" | "false" | "disabled" | "no" | "none" => Ok(false),
+            other => Err(de::Error::custom(format!(
+                "invalid toggle value {other:?} (expected true or false)"
+            ))),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> Bell {
+        toml::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn audio_accepts_legacy_bools() {
+        assert_eq!(parse("audio = true").audio, AudioBell::Beep);
+        assert_eq!(parse("audio = false").audio, AudioBell::Off);
+    }
+
+    #[test]
+    fn audio_accepts_strings() {
+        assert_eq!(parse("audio = \"system\"").audio, AudioBell::System);
+        assert_eq!(parse("audio = \"beep\"").audio, AudioBell::Beep);
+        assert_eq!(parse("audio = \"off\"").audio, AudioBell::Off);
+    }
+
+    #[test]
+    fn audio_rejects_unknown_strings() {
+        assert!(toml::from_str::<Bell>("audio = \"loud\"").is_err());
+    }
+
+    #[test]
+    fn toggles_accept_bools_and_strings() {
+        assert!(parse("urgency = true").urgency.is_enabled());
+        assert!(!parse("urgency = false").urgency.is_enabled());
+        assert!(parse("notification = \"on\"").notification.is_enabled());
+        assert!(!parse("notification = \"off\"").notification.is_enabled());
+    }
+
+    #[test]
+    fn defaults_match_platform() {
+        let bell = Bell::default();
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        {
+            assert_eq!(bell.audio, AudioBell::System);
+            assert!(bell.urgency.is_enabled());
+        }
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        {
+            assert_eq!(bell.audio, AudioBell::Beep);
+            assert!(!bell.urgency.is_enabled());
+        }
+        assert!(!bell.notification.is_enabled());
+    }
+
+    #[test]
+    fn missing_fields_use_defaults() {
+        let bell = parse("");
+        assert_eq!(bell, Bell::default());
+    }
+
+    #[test]
+    fn round_trips_through_serialize() {
+        let bell = Bell {
+            audio: AudioBell::System,
+            urgency: UrgencyHint::Enabled,
+            notification: BellNotification::Disabled,
+        };
+        let serialized = toml::to_string(&bell).unwrap();
+        assert_eq!(toml::from_str::<Bell>(&serialized).unwrap(), bell);
     }
 }

--- a/rio-backend/src/config/bell.rs
+++ b/rio-backend/src/config/bell.rs
@@ -10,6 +10,12 @@ pub struct Bell {
     pub urgency: UrgencyHint,
     #[serde(default = "default_notification")]
     pub notification: BellNotification,
+    /// Minimum time in milliseconds between two bells. A burst of BEL bytes
+    /// (e.g. `cat`-ing a binary file) is coalesced down to one bell per this
+    /// window, so the terminal does not ring constantly. Applies to the audible
+    /// sound, the urgency hint and the notification alike.
+    #[serde(default = "default_min_interval", rename = "min-interval")]
+    pub min_interval: u64,
 }
 
 /// How the audible bell behaves.
@@ -63,6 +69,7 @@ impl Default for Bell {
             audio: default_audio(),
             urgency: default_urgency(),
             notification: default_notification(),
+            min_interval: default_min_interval(),
         }
     }
 }
@@ -96,6 +103,12 @@ fn default_urgency() -> UrgencyHint {
 
 fn default_notification() -> BellNotification {
     BellNotification::Disabled
+}
+
+fn default_min_interval() -> u64 {
+    // 3 seconds: comfortably longer than any bell sound, so an accidental
+    // binary `cat` rings at most once every few seconds instead of constantly.
+    3_000
 }
 
 impl<'de> Deserialize<'de> for AudioBell {
@@ -253,6 +266,12 @@ mod tests {
     fn missing_fields_use_defaults() {
         let bell = parse("");
         assert_eq!(bell, Bell::default());
+        assert_eq!(bell.min_interval, 3_000);
+    }
+
+    #[test]
+    fn min_interval_is_configurable() {
+        assert_eq!(parse("min-interval = 500").min_interval, 500);
     }
 
     #[test]
@@ -261,6 +280,7 @@ mod tests {
             audio: AudioBell::System,
             urgency: UrgencyHint::Enabled,
             notification: BellNotification::Disabled,
+            min_interval: 3_000,
         };
         let serialized = toml::to_string(&bell).unwrap();
         assert_eq!(toml::from_str::<Bell>(&serialized).unwrap(), bell);

--- a/rio-backend/src/config/bell.rs
+++ b/rio-backend/src/config/bell.rs
@@ -34,34 +34,27 @@ pub enum AudioBell {
     System,
 }
 
+/// A named on/off switch. Accepts a bool or `"on"`/`"off"` in TOML and
+/// serializes back as a bool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Toggle {
+    Disabled,
+    Enabled,
+}
+
+impl Toggle {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, Toggle::Enabled)
+    }
+}
+
 /// Whether the bell sets the window urgency / attention hint (taskbar/dock
-/// flash) when it fires in an unfocused window. Accepts a bool or
-/// `"on"`/`"off"`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UrgencyHint {
-    Disabled,
-    Enabled,
-}
+/// flash) when it fires in an unfocused window.
+pub type UrgencyHint = Toggle;
 
-/// Whether the bell raises a desktop notification when it fires in an unfocused
-/// window. Accepts a bool or `"on"`/`"off"`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BellNotification {
-    Disabled,
-    Enabled,
-}
-
-impl UrgencyHint {
-    pub fn is_enabled(self) -> bool {
-        matches!(self, UrgencyHint::Enabled)
-    }
-}
-
-impl BellNotification {
-    pub fn is_enabled(self) -> bool {
-        matches!(self, BellNotification::Enabled)
-    }
-}
+/// Whether the bell raises a desktop notification when it fires in an
+/// unfocused window.
+pub type BellNotification = Toggle;
 
 impl Default for Bell {
     fn default() -> Self {
@@ -144,42 +137,20 @@ impl Serialize for AudioBell {
     }
 }
 
-impl<'de> Deserialize<'de> for UrgencyHint {
+impl<'de> Deserialize<'de> for Toggle {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(if toggle_from(deserializer)? {
-            UrgencyHint::Enabled
+            Toggle::Enabled
         } else {
-            UrgencyHint::Disabled
+            Toggle::Disabled
         })
     }
 }
 
-impl Serialize for UrgencyHint {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_bool(self.is_enabled())
-    }
-}
-
-impl<'de> Deserialize<'de> for BellNotification {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(if toggle_from(deserializer)? {
-            BellNotification::Enabled
-        } else {
-            BellNotification::Disabled
-        })
-    }
-}
-
-impl Serialize for BellNotification {
+impl Serialize for Toggle {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -59,6 +59,12 @@ use std::ops::{Index, IndexMut, Range};
 use std::option::Option;
 use std::ptr;
 use std::sync::Arc;
+// Bell coalescing reads the clock through this alias so tests can drive a
+// deterministic mock clock; production uses the real monotonic clock.
+#[cfg(test)]
+use mock_instant::thread_local::Instant;
+#[cfg(not(test))]
+use std::time::Instant;
 use sugarloaf::{GraphicData, MAX_GRAPHIC_DIMENSIONS};
 use tracing::{debug, info, trace, warn};
 use vi_mode::{ViModeCursor, ViMotion};
@@ -464,6 +470,16 @@ where
     keyboard_mode_idx: usize,
     inactive_keyboard_mode_stack: [u8; KEYBOARD_MODE_STACK_MAX_DEPTH],
     inactive_keyboard_mode_idx: usize,
+
+    /// When the last `RioEvent::Bell` was emitted. Together with
+    /// [`bell_min_interval`](Self::bell_min_interval) this coalesces a flood of
+    /// BEL bytes (e.g. `cat`-ing a binary file) down to one bell per window, so
+    /// the event loop is not saturated and the terminal does not ring
+    /// constantly.
+    last_bell: Option<Instant>,
+
+    /// Minimum time between two emitted bells. Configured from `bell.min-interval`.
+    pub bell_min_interval: std::time::Duration,
 }
 
 impl<U: EventListener> Crosswords<U> {
@@ -518,6 +534,10 @@ impl<U: EventListener> Crosswords<U> {
             keyboard_mode_idx: 0,
             inactive_keyboard_mode_stack: Default::default(),
             inactive_keyboard_mode_idx: 0,
+            last_bell: None,
+            // Matches the `bell.min-interval` config default (3s); overridden
+            // from config once the terminal is wired up.
+            bell_min_interval: std::time::Duration::from_secs(3),
         }
     }
 
@@ -3188,6 +3208,19 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
     #[inline]
     fn bell(&mut self) {
+        // Coalesce a flood of BEL bytes (e.g. `cat`-ing a binary file): emit at
+        // most one bell per `bell_min_interval`. Otherwise the PTY thread would
+        // emit one event per byte, saturating the event loop and ringing
+        // constantly until the source process dies. The window is much longer
+        // than any bell sound, so this never re-triggers mid-playback.
+        let now = Instant::now();
+        if self
+            .last_bell
+            .is_some_and(|last| now.duration_since(last) < self.bell_min_interval)
+        {
+            return;
+        }
+        self.last_bell = Some(now);
         self.event_proxy.send_event(RioEvent::Bell, self.window_id);
     }
 
@@ -4563,6 +4596,132 @@ mod tests {
         let size = CrosswordsSize::new(4, 4);
         let window_id = crate::event::WindowId::from(0);
         Crosswords::new(size, CursorShape::Block, VoidListener {}, window_id, 0, 10)
+    }
+
+    /// Event listener that just counts how many `RioEvent::Bell` events it
+    /// receives, for the bell-flood regression test below.
+    #[derive(Clone, Default)]
+    struct BellCounter {
+        bells: std::rc::Rc<std::cell::Cell<usize>>,
+    }
+
+    impl crate::event::EventListener for BellCounter {
+        fn event(&self) -> (Option<RioEvent>, bool) {
+            (None, false)
+        }
+
+        fn send_event(&self, event: RioEvent, _id: crate::event::WindowId) {
+            if matches!(event, RioEvent::Bell) {
+                self.bells.set(self.bells.get() + 1);
+            }
+        }
+    }
+
+    /// Regression test for the freeze when `cat`-ing a binary file: a stream
+    /// full of BEL (0x07) bytes used to emit one `RioEvent::Bell` per byte,
+    /// flooding the event loop and ringing constantly. The bell must coalesce
+    /// to one event per `bell_min_interval`, then ring again on its own once
+    /// the window has actually elapsed.
+    ///
+    /// This drives the real production cycle end-to-end: BEL bytes go through
+    /// the parser into `bell()`, which gates purely on elapsed wall-clock time.
+    /// Only the configured interval is set here; the cycle re-arms itself.
+    #[test]
+    fn bell_flood_is_coalesced() {
+        use crate::performer::handler::Processor;
+
+        let listener = BellCounter::default();
+        let size = CrosswordsSize::new(4, 4);
+        let mut term = Crosswords::new(
+            size,
+            CursorShape::Block,
+            listener.clone(),
+            crate::event::WindowId::from(0),
+            0,
+            10,
+        );
+        // Drive a deterministic mock clock (no sleeping). The only thing the
+        // test configures is the window, exactly as `bell.min-interval` does.
+        use mock_instant::thread_local::MockClock;
+        MockClock::set_time(std::time::Duration::ZERO);
+        term.bell_min_interval = std::time::Duration::from_millis(20);
+        let mut processor = Processor::default();
+
+        // `cat`-ing a binary file: tens of thousands of BEL bytes arriving
+        // back-to-back collapse into a single bell.
+        processor.advance(&mut term, &vec![0x07u8; 50_000]);
+        assert_eq!(
+            listener.bells.get(),
+            1,
+            "a BEL flood within the window must coalesce into one bell"
+        );
+
+        // More bells while still inside the window stay coalesced.
+        MockClock::advance(std::time::Duration::from_millis(19));
+        processor.advance(&mut term, &vec![0x07u8; 50_000]);
+        assert_eq!(listener.bells.get(), 1, "no new bell inside the window");
+
+        // Once the window has elapsed, the next BEL rings again — the gate
+        // re-arms purely from elapsed time, with no manual reset.
+        MockClock::advance(std::time::Duration::from_millis(2));
+        processor.advance(&mut term, b"\x07");
+        assert_eq!(
+            listener.bells.get(),
+            2,
+            "bell must ring again once the window has elapsed"
+        );
+    }
+
+    /// Each terminal coalesces independently: flooding or ringing one must
+    /// never suppress (or trigger) another's bell. Guards the per-instance gate
+    /// against a refactor to shared/global bell state, which would let one
+    /// noisy terminal silence the rest.
+    #[test]
+    fn bells_coalesce_per_terminal() {
+        use crate::performer::handler::Processor;
+        use mock_instant::thread_local::MockClock;
+
+        let bells_a = BellCounter::default();
+        let bells_b = BellCounter::default();
+        let new_term = |listener: &BellCounter| {
+            let mut term = Crosswords::new(
+                CrosswordsSize::new(4, 4),
+                CursorShape::Block,
+                listener.clone(),
+                crate::event::WindowId::from(0),
+                0,
+                10,
+            );
+            term.bell_min_interval = std::time::Duration::from_millis(20);
+            term
+        };
+
+        MockClock::set_time(std::time::Duration::ZERO);
+        let mut term_a = new_term(&bells_a);
+        let mut term_b = new_term(&bells_b);
+        let mut processor = Processor::default();
+
+        // Flooding terminal A rings A once and leaves B untouched.
+        processor.advance(&mut term_a, &vec![0x07u8; 50_000]);
+        assert_eq!(bells_a.bells.get(), 1);
+        assert_eq!(bells_b.bells.get(), 0, "A must not suppress or trigger B");
+
+        // B still rings inside A's window — the gates are independent.
+        processor.advance(&mut term_b, b"\x07");
+        assert_eq!(bells_b.bells.get(), 1, "B gates independently of A");
+        assert_eq!(bells_a.bells.get(), 1);
+
+        // Both stay coalesced inside their own (shared-clock) window.
+        MockClock::advance(std::time::Duration::from_millis(10));
+        processor.advance(&mut term_a, b"\x07");
+        processor.advance(&mut term_b, b"\x07");
+        assert_eq!((bells_a.bells.get(), bells_b.bells.get()), (1, 1));
+
+        // After the window elapses, both re-arm on their own.
+        MockClock::advance(std::time::Duration::from_millis(21));
+        processor.advance(&mut term_a, b"\x07");
+        processor.advance(&mut term_b, b"\x07");
+        assert_eq!((bells_a.bells.get(), bells_b.bells.get()), (2, 2));
     }
 
     // Minimum-valid simple glyph: one contour, one on-curve point.

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -57,6 +57,12 @@ use std::ops::{Index, IndexMut, Range};
 use std::option::Option;
 use std::ptr;
 use std::sync::Arc;
+// Bell coalescing reads the clock through this alias so tests can drive a
+// deterministic mock clock; production uses the real monotonic clock.
+#[cfg(test)]
+use mock_instant::thread_local::Instant;
+#[cfg(not(test))]
+use std::time::Instant;
 use sugarloaf::{GraphicData, MAX_GRAPHIC_DIMENSIONS};
 use tracing::{debug, info, trace, warn};
 use vi_mode::{ViModeCursor, ViMotion};
@@ -464,6 +470,16 @@ where
     keyboard_mode_idx: usize,
     inactive_keyboard_mode_stack: [u8; KEYBOARD_MODE_STACK_MAX_DEPTH],
     inactive_keyboard_mode_idx: usize,
+
+    /// When the last `RioEvent::Bell` was emitted. Together with
+    /// [`bell_min_interval`](Self::bell_min_interval) this coalesces a flood of
+    /// BEL bytes (e.g. `cat`-ing a binary file) down to one bell per window, so
+    /// the event loop is not saturated and the terminal does not ring
+    /// constantly.
+    last_bell: Option<Instant>,
+
+    /// Minimum time between two emitted bells. Configured from `bell.min-interval`.
+    pub bell_min_interval: std::time::Duration,
 }
 
 impl<U: EventListener> Crosswords<U> {
@@ -519,6 +535,10 @@ impl<U: EventListener> Crosswords<U> {
             keyboard_mode_idx: 0,
             inactive_keyboard_mode_stack: Default::default(),
             inactive_keyboard_mode_idx: 0,
+            last_bell: None,
+            // Matches the `bell.min-interval` config default (3s); overridden
+            // from config once the terminal is wired up.
+            bell_min_interval: std::time::Duration::from_secs(3),
         }
     }
 
@@ -3520,6 +3540,19 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
     #[inline]
     fn bell(&mut self) {
+        // Coalesce a flood of BEL bytes (e.g. `cat`-ing a binary file): emit at
+        // most one bell per `bell_min_interval`. Otherwise the PTY thread would
+        // emit one event per byte, saturating the event loop and ringing
+        // constantly until the source process dies. The window is much longer
+        // than any bell sound, so this never re-triggers mid-playback.
+        let now = Instant::now();
+        if self
+            .last_bell
+            .is_some_and(|last| now.duration_since(last) < self.bell_min_interval)
+        {
+            return;
+        }
+        self.last_bell = Some(now);
         self.event_proxy.send_event(RioEvent::Bell, self.window_id);
     }
 
@@ -5005,6 +5038,132 @@ mod tests {
         let size = CrosswordsSize::new(4, 4);
         let window_id = crate::event::WindowId::from(0);
         Crosswords::new(size, CursorShape::Block, VoidListener {}, window_id, 0, 10)
+    }
+
+    /// Event listener that just counts how many `RioEvent::Bell` events it
+    /// receives, for the bell-flood regression test below.
+    #[derive(Clone, Default)]
+    struct BellCounter {
+        bells: std::rc::Rc<std::cell::Cell<usize>>,
+    }
+
+    impl crate::event::EventListener for BellCounter {
+        fn event(&self) -> (Option<RioEvent>, bool) {
+            (None, false)
+        }
+
+        fn send_event(&self, event: RioEvent, _id: crate::event::WindowId) {
+            if matches!(event, RioEvent::Bell) {
+                self.bells.set(self.bells.get() + 1);
+            }
+        }
+    }
+
+    /// Regression test for the freeze when `cat`-ing a binary file: a stream
+    /// full of BEL (0x07) bytes used to emit one `RioEvent::Bell` per byte,
+    /// flooding the event loop and ringing constantly. The bell must coalesce
+    /// to one event per `bell_min_interval`, then ring again on its own once
+    /// the window has actually elapsed.
+    ///
+    /// This drives the real production cycle end-to-end: BEL bytes go through
+    /// the parser into `bell()`, which gates purely on elapsed wall-clock time.
+    /// Only the configured interval is set here; the cycle re-arms itself.
+    #[test]
+    fn bell_flood_is_coalesced() {
+        use crate::performer::handler::Processor;
+
+        let listener = BellCounter::default();
+        let size = CrosswordsSize::new(4, 4);
+        let mut term = Crosswords::new(
+            size,
+            CursorShape::Block,
+            listener.clone(),
+            crate::event::WindowId::from(0),
+            0,
+            10,
+        );
+        // Drive a deterministic mock clock (no sleeping). The only thing the
+        // test configures is the window, exactly as `bell.min-interval` does.
+        use mock_instant::thread_local::MockClock;
+        MockClock::set_time(std::time::Duration::ZERO);
+        term.bell_min_interval = std::time::Duration::from_millis(20);
+        let mut processor = Processor::default();
+
+        // `cat`-ing a binary file: tens of thousands of BEL bytes arriving
+        // back-to-back collapse into a single bell.
+        processor.advance(&mut term, &vec![0x07u8; 50_000]);
+        assert_eq!(
+            listener.bells.get(),
+            1,
+            "a BEL flood within the window must coalesce into one bell"
+        );
+
+        // More bells while still inside the window stay coalesced.
+        MockClock::advance(std::time::Duration::from_millis(19));
+        processor.advance(&mut term, &vec![0x07u8; 50_000]);
+        assert_eq!(listener.bells.get(), 1, "no new bell inside the window");
+
+        // Once the window has elapsed, the next BEL rings again — the gate
+        // re-arms purely from elapsed time, with no manual reset.
+        MockClock::advance(std::time::Duration::from_millis(2));
+        processor.advance(&mut term, b"\x07");
+        assert_eq!(
+            listener.bells.get(),
+            2,
+            "bell must ring again once the window has elapsed"
+        );
+    }
+
+    /// Each terminal coalesces independently: flooding or ringing one must
+    /// never suppress (or trigger) another's bell. Guards the per-instance gate
+    /// against a refactor to shared/global bell state, which would let one
+    /// noisy terminal silence the rest.
+    #[test]
+    fn bells_coalesce_per_terminal() {
+        use crate::performer::handler::Processor;
+        use mock_instant::thread_local::MockClock;
+
+        let bells_a = BellCounter::default();
+        let bells_b = BellCounter::default();
+        let new_term = |listener: &BellCounter| {
+            let mut term = Crosswords::new(
+                CrosswordsSize::new(4, 4),
+                CursorShape::Block,
+                listener.clone(),
+                crate::event::WindowId::from(0),
+                0,
+                10,
+            );
+            term.bell_min_interval = std::time::Duration::from_millis(20);
+            term
+        };
+
+        MockClock::set_time(std::time::Duration::ZERO);
+        let mut term_a = new_term(&bells_a);
+        let mut term_b = new_term(&bells_b);
+        let mut processor = Processor::default();
+
+        // Flooding terminal A rings A once and leaves B untouched.
+        processor.advance(&mut term_a, &vec![0x07u8; 50_000]);
+        assert_eq!(bells_a.bells.get(), 1);
+        assert_eq!(bells_b.bells.get(), 0, "A must not suppress or trigger B");
+
+        // B still rings inside A's window — the gates are independent.
+        processor.advance(&mut term_b, b"\x07");
+        assert_eq!(bells_b.bells.get(), 1, "B gates independently of A");
+        assert_eq!(bells_a.bells.get(), 1);
+
+        // Both stay coalesced inside their own (shared-clock) window.
+        MockClock::advance(std::time::Duration::from_millis(10));
+        processor.advance(&mut term_a, b"\x07");
+        processor.advance(&mut term_b, b"\x07");
+        assert_eq!((bells_a.bells.get(), bells_b.bells.get()), (1, 1));
+
+        // After the window elapses, both re-arm on their own.
+        MockClock::advance(std::time::Duration::from_millis(21));
+        processor.advance(&mut term_a, b"\x07");
+        processor.advance(&mut term_b, b"\x07");
+        assert_eq!((bells_a.bells.get(), bells_b.bells.get()), (2, 2));
     }
 
     // Minimum-valid simple glyph: one contour, one on-curve point.


### PR DESCRIPTION
This bundles two related bell changes. They are not strictly atomic, but the second builds directly on the first, so they are submitted together.

## 1. Integrate the Linux bell with the desktop environment (closes #1616)

On Linux the terminal bell now integrates with native DE attention mechanisms instead of only a synthesized 440 Hz tone:

- `[bell] audio` accepts `"system"` (default on Linux) to play the freedesktop event-sound theme via **libcanberra**, respecting the user's sound theme, output routing, volume, mute and Do-Not-Disturb. libcanberra is loaded at runtime via `dlopen`, so there is no build-time dependency and it degrades gracefully when absent. `true`/`false` stay backwards-compatible (legacy tone / off).
- `[bell] urgency` (default `true` on Linux) sets the window urgency / attention hint (X11 `WM_HINTS`, Wayland `xdg-activation`) when the bell fires in an unfocused window, and clears it on focus regain.
- `[bell] notification` (default `false`) raises an `org.freedesktop.Notifications` notification for an unfocused window.

The audio/urgency/notification config values use named enums rather than bare bools. The cpal tone moves into a new `bell` module alongside the libcanberra binding. The new keys are documented in the `rio.5` man page.

## 2. Coalesce BEL floods so a binary `cat` can't freeze the app

`cat`-ing a binary file streams thousands of BEL (`0x07`) bytes. Each one emitted a `RioEvent::Bell`, which flooded the event loop and — on Linux — ran the libcanberra/`NSBeep` call **synchronously on the window thread** per byte, freezing the whole app and ringing constantly until the source process was killed.

- **Coalesce in the backend `bell()`**: emit at most one bell per `bell_min_interval` (new `[bell] min-interval` config, default `3000` ms). This is the only place that can stop the per-byte event flood before it reaches the event loop. The window is far longer than any bell sound, so it never re-triggers mid-playback without assuming the sound's length.
- **Move audio playback to a dedicated `rio-bell` worker thread**, so the window thread is never blocked by audio I/O.

### Tests

- A regression test drives real BEL bytes through the parser into `bell()` and advances a deterministic mock clock (`mock_instant`, a **dev-dependency** only — production keeps `std::time::Instant` via a one-line `cfg`-gated alias) to prove the gate re-arms purely from elapsed time. It fails (50 000 bells) without the gate.
- A second test asserts the gate is **per-terminal**, so one noisy terminal can never silence the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)