### PR TITLE
fix: restore font fallback discovery on Linux/Windows

### DIFF
--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -1245,15 +1245,17 @@ impl GridGlyphRasterizer {
             .entry((ch, style_flags, route_id))
             .or_insert_with(|| {
                 let span_style = span_style_for_flags(style_flags);
-                #[cfg(target_os = "macos")]
+                // Lazy cascade discovery on every platform: on a miss in
+                // the loaded library, resolve_font_for_char asks the OS
+                // (fontconfig on Linux, CoreText on macOS, font-kit on
+                // Windows) for a font that covers `ch` and registers it.
+                // Without this, codepoints absent from the user's primary
+                // font (Nerd Font icons, CJK, emoji) render as the
+                // primary font's .notdef tofu. Result is memoized in the
+                // font_resolve cache, so the OS query fires at most once
+                // per (ch, style, route).
                 let (id, emoji) =
                     font_library.resolve_font_for_char(ch, &span_style, Some(route_id));
-                #[cfg(not(target_os = "macos"))]
-                let (id, emoji) = {
-                    let lib = font_library.inner.read();
-                    lib.find_best_font_match(ch, &span_style, Some(route_id))
-                        .unwrap_or((0, false))
-                };
                 (id as u32, emoji)
             })
     }

--- a/sugarloaf/src/font/mod.rs
+++ b/sugarloaf/src/font/mod.rs
@@ -2108,6 +2108,104 @@ mod postscript_resolver_tests {
 }
 
 #[cfg(test)]
+mod cascade_contract_tests {
+    use super::*;
+    use crate::SpanStyle;
+
+    /// Regression guard for the Linux/Windows "Nerd Font icons render as
+    /// tofu" bug — the `ls --icons` folder/file glyphs (and any CJK or
+    /// emoji outside the primary font) showing the primary font's
+    /// `.notdef`. The render path (`rioterm` grid_emit + sugarloaf text)
+    /// must resolve glyphs through `resolve_font_for_char`, whose miss
+    /// path lazily discovers a covering system font. The defect was
+    /// calling `find_best_font_match` there, which masks a miss as the
+    /// primary font (`font_id` 0) and never triggers discovery.
+    ///
+    /// This pins the two-method contract `resolve_font_for_char` is built
+    /// on, deterministically and with no dependency on installed system
+    /// fonts: only the bundled Cascadia Code is registered, and U+6C34
+    /// (水) — a CJK ideograph Cascadia does not carry — stands in for any
+    /// glyph absent from the primary font.
+    #[test]
+    fn missing_glyph_strict_reports_miss_nonstrict_masks_as_primary() {
+        let mut data = FontLibraryData::default();
+        data.insert(
+            FontData::from_static_slice(FONT_CASCADIA_CODE_NF)
+                .expect("load bundled font"),
+        );
+        let absent = '\u{6C34}';
+        let style = SpanStyle::default();
+
+        assert_eq!(
+            data.find_best_font_match_strict(absent, &style, None),
+            None,
+            "strict lookup must surface a true miss so cascade discovery fires \
+             instead of silently rendering the primary font's notdef",
+        );
+        assert_eq!(
+            data.find_best_font_match(absent, &style, None),
+            Some((0, false)),
+            "non-strict lookup masks the miss as the primary font — the tofu path \
+             the render code must NOT take for fallback glyphs",
+        );
+    }
+}
+
+#[cfg(all(test, unix, not(target_os = "macos"), not(target_os = "android")))]
+mod linux_cascade_discovery_tests {
+    use super::*;
+    use crate::SpanStyle;
+    use std::sync::Arc;
+
+    /// End-to-end Linux fallback discovery: a bare library holding only
+    /// the bundled Cascadia Code is asked for a glyph Cascadia lacks.
+    /// `resolve_font_for_char` must consult fontconfig, find a covering
+    /// font, register it, and return its non-zero id — the path that was
+    /// dead on Linux (the render code called `find_best_font_match`,
+    /// which never discovers) and made Nerd Font icons render as tofu.
+    ///
+    /// Discovery needs the host to actually have a font covering the
+    /// codepoint, which minimal CI images may lack. A fontconfig probe
+    /// gates the assertion so the test is a no-op pass on a font-bare
+    /// host rather than a flake.
+    #[test]
+    fn resolve_font_for_char_discovers_cascade_font_on_linux() {
+        let missing = '\u{6C34}'; // CJK 水 — absent from Cascadia Code.
+
+        // Probe: is there anything to discover on this host?
+        if crate::font::linux::discover_fallback("monospace", missing, true, false, false)
+            .is_none()
+        {
+            return; // font-bare environment; nothing to assert.
+        }
+
+        let mut data = FontLibraryData::default();
+        data.insert(
+            FontData::from_static_slice(FONT_CASCADIA_CODE_NF)
+                .expect("load bundled font"),
+        );
+        let lib = FontLibrary {
+            inner: Arc::new(parking_lot::RwLock::new(data)),
+        };
+        let starting_len = lib.inner.read().inner.len();
+
+        let (font_id, _is_emoji) =
+            lib.resolve_font_for_char(missing, &SpanStyle::default(), None);
+
+        assert_ne!(
+            font_id, 0,
+            "lazy discovery must register and return a fallback font, not the \
+             primary font's notdef tofu",
+        );
+        assert_eq!(
+            lib.inner.read().inner.len(),
+            starting_len + 1,
+            "discovery should register exactly one new font",
+        );
+    }
+}
+
+#[cfg(test)]
 mod glyph_registry_install_tests {
     use super::*;
     use crate::font::glyph_registry::GlyphRegistry;

--- a/sugarloaf/src/text.rs
+++ b/sugarloaf/src/text.rs
@@ -380,16 +380,14 @@ impl Text {
                     FontStyle::Normal
                 };
                 ss.font_attrs = Attributes::new(Stretch::NORMAL, weight, fstyle);
-                #[cfg(target_os = "macos")]
+                // Lazy cascade discovery on every platform — see the
+                // matching note in rioterm grid_emit::resolve_font. On a
+                // miss the OS is queried for a covering font and it is
+                // registered, so UI text (tab titles, search bar, …) in
+                // glyphs outside the primary font doesn't fall back to
+                // .notdef tofu.
                 let resolved =
                     self.font_library.resolve_font_for_char(first_ch, &ss, None);
-
-                #[cfg(not(target_os = "macos"))]
-                let resolved = {
-                    let lib = self.font_library.inner.read();
-                    lib.find_best_font_match(first_ch, &ss, None)
-                        .unwrap_or((0, false))
-                };
                 let v = (resolved.0 as u32, resolved.1);
                 e.insert(v);
                 v


### PR DESCRIPTION
The terminal render path (rioterm grid_emit::resolve_font) and the UI text path (sugarloaf text) resolved each glyph's font through find_best_font_match, which only consults already-loaded fonts and returns the primary font (font_id 0) on a miss, it never triggers cascade discovery. So on Linux/Windows any codepoint absent from the user's primary font (Nerd Font icons from `ls --icons`, CJK, ...) rendered as the primary font's .notdef tofu.