### PR TITLE
fix: apply kitty X=/Y= sub-cell pixel offset to placements

### DIFF
--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -438,8 +438,13 @@ impl Renderer {
                         }
                         overlays.push(rio_backend::sugarloaf::GraphicOverlay {
                             image_id: p.image_id,
-                            x: origin_x + p.dest_col as f32 * cell_width,
-                            y: origin_y + screen_row as f32 * cell_height,
+                            // kitty X=/Y= offset, supports sub-cell positioning
+                            x: origin_x
+                                + p.dest_col as f32 * cell_width
+                                + p.cell_x_offset as f32,
+                            y: origin_y
+                                + screen_row as f32 * cell_height
+                                + p.cell_y_offset as f32,
                             width: p.pixel_width as f32,
                             height: p.pixel_height as f32,
                             z_index: p.z_index,

--- a/rio-backend/src/ansi/kitty_graphics_protocol.rs
+++ b/rio-backend/src/ansi/kitty_graphics_protocol.rs
@@ -111,6 +111,9 @@ pub struct PlacementRequest {
     /// the uppercase `U=1` flag). Currently informational only.
     pub unicode_placeholder: u32,
     pub cursor_movement: u8, // 0 = move cursor to after image (default), 1 = don't move cursor
+    /// kitty `X=`/`Y=` pixel offset, supports sub-cell positioning.
+    pub cell_x_offset: u32,
+    pub cell_y_offset: u32,
 }
 
 #[derive(Debug)]
@@ -631,6 +634,8 @@ pub fn parse(
                     virtual_placement: cmd.virtual_placement,
                     unicode_placeholder: cmd.unicode_placeholder,
                     cursor_movement: cmd.cursor_movement,
+                    cell_x_offset: cmd.cell_x_offset,
+                    cell_y_offset: cmd.cell_y_offset,
                 })
             } else {
                 None
@@ -659,6 +664,8 @@ pub fn parse(
                 virtual_placement: cmd.virtual_placement,
                 unicode_placeholder: cmd.unicode_placeholder,
                 cursor_movement: cmd.cursor_movement,
+                cell_x_offset: cmd.cell_x_offset,
+                cell_y_offset: cmd.cell_y_offset,
             };
             let response = if cmd.implicit_id {
                 None
@@ -1551,6 +1558,33 @@ mod tests {
         assert_eq!(placement.columns, 5);
         assert_eq!(placement.rows, 3);
         assert_eq!(placement.z_index, 2);
+    }
+
+    #[test]
+    fn test_parse_placement_subcell_offset() {
+        // `X=`/`Y=` are the sub-cell pixel offset within the placement's
+        // first cell. They must flow through to the PlacementRequest so the
+        // renderer can position the image at pixel (not just cell)
+        // granularity, for smooth sub-cell scrolling.
+        let result = parse_kitty_graphics_protocol("a=p,i=1,X=7,Y=9", "");
+        let placement = result
+            .expect("parse ok")
+            .placement_request
+            .expect("placement");
+        assert_eq!(placement.cell_x_offset, 7);
+        assert_eq!(placement.cell_y_offset, 9);
+    }
+
+    #[test]
+    fn test_parse_placement_subcell_offset_defaults_zero() {
+        // Omitting `X=`/`Y=` leaves the offset at the cell boundary.
+        let result = parse_kitty_graphics_protocol("a=p,i=1", "");
+        let placement = result
+            .expect("parse ok")
+            .placement_request
+            .expect("placement");
+        assert_eq!(placement.cell_x_offset, 0);
+        assert_eq!(placement.cell_y_offset, 0);
     }
 
     #[test]

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -4454,8 +4454,8 @@ impl<U: EventListener> Crosswords<U> {
             rows,
             pixel_width: display_w as u32,
             pixel_height: display_h as u32,
-            cell_x_offset: 0,
-            cell_y_offset: 0,
+            cell_x_offset: placement.cell_x_offset,
+            cell_y_offset: placement.cell_y_offset,
             z_index: placement.z_index,
             transmit_time,
         };
@@ -6640,6 +6640,8 @@ mod tests {
             virtual_placement: true,
             unicode_placeholder: 0,
             cursor_movement: 0,
+            cell_x_offset: 0,
+            cell_y_offset: 0,
         };
 
         cw.place_graphic(placement);

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -414,6 +414,8 @@ fn test_cursor_movement_default() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -492,6 +494,8 @@ fn test_cursor_movement_no_move() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 1, // Don't move cursor
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -597,6 +601,8 @@ fn test_image_row_occupation_exact_fit() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -665,6 +671,8 @@ fn test_image_row_occupation_single_row() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -732,6 +740,8 @@ fn test_image_row_occupation_three_rows() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -804,6 +814,8 @@ fn test_image_row_occupation_from_middle() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -916,6 +928,8 @@ fn test_place_nonexistent_graphic() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     // Should not panic, just warn
@@ -2606,6 +2620,8 @@ fn test_swap_alt_isolates_placements() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 1,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
     assert!(
@@ -3065,6 +3081,8 @@ fn test_resize_widen_unwraps_command_image_follows() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 1,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3143,6 +3161,8 @@ fn test_resize_narrow_wraps_command_image_follows() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 1,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3261,6 +3281,8 @@ fn test_debug_widen_visible_layout() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3319,6 +3341,8 @@ fn test_debug_narrow_visible_layout() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3379,6 +3403,8 @@ fn test_resize_narrow_combined_col_and_row_change() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3476,6 +3502,8 @@ fn test_resize_narrow_with_multi_row_image() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0, // Default: cursor moves to last row of image
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3588,6 +3616,8 @@ fn test_resize_narrow_with_cursor_at_bottom_of_screen() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3688,6 +3718,8 @@ fn test_resize_narrow_with_prompt_after_image() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0, // Default kitty behaviour: cursor stays on the last row of image
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 


### PR DESCRIPTION
I was trying out Rio for its kitty image support (Rio is the only term emulator that works on Windows AND has good KIP support!) and I noticed that the sub-cell pixel offsets were not wired in yet.

Was this by accident?

Easy to wire in, connecting it from the parser (that already parses it) to the renderer. I tested this locally.
