### PR TITLE
fix: apply kitty X=/Y= sub-cell pixel offset to placements

### DIFF
--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -438,8 +438,13 @@ impl Renderer {
                         }
                         overlays.push(rio_backend::sugarloaf::GraphicOverlay {
                             image_id: p.image_id,
-                            x: origin_x + p.dest_col as f32 * cell_width,
-                            y: origin_y + screen_row as f32 * cell_height,
+                            // kitty X=/Y= offset, supports sub-cell positioning
+                            x: origin_x
+                                + p.dest_col as f32 * cell_width
+                                + p.cell_x_offset as f32,
+                            y: origin_y
+                                + screen_row as f32 * cell_height
+                                + p.cell_y_offset as f32,
                             width: p.pixel_width as f32,
                             height: p.pixel_height as f32,
                             z_index: p.z_index,

--- a/rio-backend/src/ansi/kitty_graphics_protocol.rs
+++ b/rio-backend/src/ansi/kitty_graphics_protocol.rs
@@ -111,6 +111,9 @@ pub struct PlacementRequest {
     /// the uppercase `U=1` flag). Currently informational only.
     pub unicode_placeholder: u32,
     pub cursor_movement: u8, // 0 = move cursor to after image (default), 1 = don't move cursor
+    /// kitty `X=`/`Y=` pixel offset, supports sub-cell positioning.
+    pub cell_x_offset: u32,
+    pub cell_y_offset: u32,
 }
 
 #[derive(Debug)]
@@ -631,6 +634,8 @@ pub fn parse(
                     virtual_placement: cmd.virtual_placement,
                     unicode_placeholder: cmd.unicode_placeholder,
                     cursor_movement: cmd.cursor_movement,
+                    cell_x_offset: cmd.cell_x_offset,
+                    cell_y_offset: cmd.cell_y_offset,
                 })
             } else {
                 None
@@ -659,6 +664,8 @@ pub fn parse(
                 virtual_placement: cmd.virtual_placement,
                 unicode_placeholder: cmd.unicode_placeholder,
                 cursor_movement: cmd.cursor_movement,
+                cell_x_offset: cmd.cell_x_offset,
+                cell_y_offset: cmd.cell_y_offset,
             };
             let response = if cmd.implicit_id {
                 None
@@ -1551,6 +1558,33 @@ mod tests {
         assert_eq!(placement.columns, 5);
         assert_eq!(placement.rows, 3);
         assert_eq!(placement.z_index, 2);
+    }
+
+    #[test]
+    fn test_parse_placement_subcell_offset() {
+        // `X=`/`Y=` are the sub-cell pixel offset within the placement's
+        // first cell. They must flow through to the PlacementRequest so the
+        // renderer can position the image at pixel (not just cell)
+        // granularity, for smooth sub-cell scrolling.
+        let result = parse_kitty_graphics_protocol("a=p,i=1,X=7,Y=9", "");
+        let placement = result
+            .expect("parse ok")
+            .placement_request
+            .expect("placement");
+        assert_eq!(placement.cell_x_offset, 7);
+        assert_eq!(placement.cell_y_offset, 9);
+    }
+
+    #[test]
+    fn test_parse_placement_subcell_offset_defaults_zero() {
+        // Omitting `X=`/`Y=` leaves the offset at the cell boundary.
+        let result = parse_kitty_graphics_protocol("a=p,i=1", "");
+        let placement = result
+            .expect("parse ok")
+            .placement_request
+            .expect("placement");
+        assert_eq!(placement.cell_x_offset, 0);
+        assert_eq!(placement.cell_y_offset, 0);
     }
 
     #[test]

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -4416,16 +4416,27 @@ impl<U: EventListener> Crosswords<U> {
         // Absolute row = history_size + screen-relative row
         let dest_row = self.history_size() as i64 + cursor_row as i64;
 
-        // Compute cell-based size
+        // kitty spec the `X=`/`Y=` sub-cell offset must be smaller
+        // than the cell size; kitty clamps out-of-range values to the
+        // cell box
+        let cell_x_offset = (placement.cell_x_offset as usize).min(cell_width - 1);
+        let cell_y_offset = (placement.cell_y_offset as usize).min(cell_height - 1);
+
+        // Compute cell-based size.
+        //
+        // the trick is the sub-cell offset shifts the image
+        // within its first cell, so it can spill into one extra
+        // row/column. Include it so cursor movement and row occupation
+        // cover the full image.
         let columns = if placement.columns > 0 {
             placement.columns
         } else {
-            display_w.div_ceil(cell_width) as u32
+            (display_w + cell_x_offset).div_ceil(cell_width) as u32
         };
         let rows = if placement.rows > 0 {
             placement.rows
         } else {
-            display_h.div_ceil(cell_height) as u32
+            (display_h + cell_y_offset).div_ceil(cell_height) as u32
         };
 
         // Create overlay placement.
@@ -4454,8 +4465,8 @@ impl<U: EventListener> Crosswords<U> {
             rows,
             pixel_width: display_w as u32,
             pixel_height: display_h as u32,
-            cell_x_offset: placement.cell_x_offset,
-            cell_y_offset: placement.cell_y_offset,
+            cell_x_offset: cell_x_offset as u32,
+            cell_y_offset: cell_y_offset as u32,
             z_index: placement.z_index,
             transmit_time,
         };

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -4454,8 +4454,8 @@ impl<U: EventListener> Crosswords<U> {
             rows,
             pixel_width: display_w as u32,
             pixel_height: display_h as u32,
-            cell_x_offset: 0,
-            cell_y_offset: 0,
+            cell_x_offset: placement.cell_x_offset,
+            cell_y_offset: placement.cell_y_offset,
             z_index: placement.z_index,
             transmit_time,
         };
@@ -6640,6 +6640,8 @@ mod tests {
             virtual_placement: true,
             unicode_placeholder: 0,
             cursor_movement: 0,
+            cell_x_offset: 0,
+            cell_y_offset: 0,
         };
 
         cw.place_graphic(placement);

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -618,6 +618,163 @@ fn test_image_row_occupation_exact_fit() {
 }
 
 #[test]
+fn test_subcell_offset_forwarded_and_clamped() {
+    let event_listener = TestEventListener;
+    let window_id = unsafe { WindowId::dummy() };
+
+    let mut term: Crosswords<TestEventListener> = Crosswords::new(
+        crate::crosswords::CrosswordsSize::new(80, 24),
+        crate::ansi::CursorShape::Block,
+        event_listener,
+        window_id,
+        0,
+        10_000,
+    );
+
+    term.graphics.cell_width = 10.0;
+    term.graphics.cell_height = 20.0;
+
+    let pixels = vec![255u8; 40 * 40 * 4];
+    let graphic = GraphicData {
+        id: GraphicId::new(1),
+        width: 40,
+        height: 40,
+        color_type: ColorType::Rgba,
+        pixels,
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: std::time::Instant::now(),
+    };
+    term.store_graphic(graphic);
+
+    // In-range `X=`/`Y=` flows through to the stored placement.
+    let placement = kitty_graphics_protocol::PlacementRequest {
+        image_id: 1,
+        placement_id: 7,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        columns: 0,
+        rows: 0,
+        z_index: 0,
+        virtual_placement: false,
+        unicode_placeholder: 0,
+        cursor_movement: 1,
+        cell_x_offset: 7,
+        cell_y_offset: 9,
+    };
+    term.place_graphic(placement);
+
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 7))
+        .expect("placement stored");
+    assert_eq!(stored.cell_x_offset, 7);
+    assert_eq!(stored.cell_y_offset, 9);
+
+    // Per kitty spec the offset must be smaller than the cell size;
+    // out-of-range values are clamped to the cell box.
+    let placement = kitty_graphics_protocol::PlacementRequest {
+        image_id: 1,
+        placement_id: 8,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        columns: 0,
+        rows: 0,
+        z_index: 0,
+        virtual_placement: false,
+        unicode_placeholder: 0,
+        cursor_movement: 1,
+        cell_x_offset: 999,
+        cell_y_offset: 999,
+    };
+    term.place_graphic(placement);
+
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 8))
+        .expect("placement stored");
+    assert_eq!(stored.cell_x_offset, 9, "clamped to cell_width - 1");
+    assert_eq!(stored.cell_y_offset, 19, "clamped to cell_height - 1");
+}
+
+#[test]
+fn test_subcell_offset_extends_row_occupation() {
+    let event_listener = TestEventListener;
+    let window_id = unsafe { WindowId::dummy() };
+
+    let mut term: Crosswords<TestEventListener> = Crosswords::new(
+        crate::crosswords::CrosswordsSize::new(80, 24),
+        crate::ansi::CursorShape::Block,
+        event_listener,
+        window_id,
+        0,
+        10_000,
+    );
+
+    term.graphics.cell_width = 10.0;
+    term.graphics.cell_height = 20.0;
+
+    // 40px tall image on 20px cells: exactly 2 rows without an offset.
+    let pixels = vec![255u8; 40 * 40 * 4];
+    let graphic = GraphicData {
+        id: GraphicId::new(1),
+        width: 40,
+        height: 40,
+        color_type: ColorType::Rgba,
+        pixels,
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: std::time::Instant::now(),
+    };
+    term.store_graphic(graphic);
+
+    // `Y=15` shifts the image down within its first cell, so it spills
+    // into a third row: ceil((40 + 15) / 20) = 3. Cursor movement and
+    // occupation must cover that extra row.
+    let placement = kitty_graphics_protocol::PlacementRequest {
+        image_id: 1,
+        placement_id: 7,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        columns: 0,
+        rows: 0,
+        z_index: 0,
+        virtual_placement: false,
+        unicode_placeholder: 0,
+        cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 15,
+    };
+    term.place_graphic(placement);
+
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 7))
+        .expect("placement stored");
+    assert_eq!(stored.rows, 3, "Y offset spills the image into a 3rd row");
+    assert_eq!(stored.columns, 4, "no X offset: 40px / 10px = 4 columns");
+
+    // C=0: cursor lands on the last row of the image (row index rows - 1).
+    assert_eq!(
+        term.grid.cursor.pos.row.0, 2,
+        "cursor advances to the extra row created by the Y offset"
+    );
+}
+
+#[test]
 fn test_image_row_occupation_single_row() {
     let event_listener = TestEventListener;
     let window_id = unsafe { WindowId::dummy() };

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -414,6 +414,8 @@ fn test_cursor_movement_default() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -492,6 +494,8 @@ fn test_cursor_movement_no_move() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 1, // Don't move cursor
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -597,6 +601,8 @@ fn test_image_row_occupation_exact_fit() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -665,6 +671,8 @@ fn test_image_row_occupation_single_row() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -732,6 +740,8 @@ fn test_image_row_occupation_three_rows() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -804,6 +814,8 @@ fn test_image_row_occupation_from_middle() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     term.place_graphic(placement);
@@ -916,6 +928,8 @@ fn test_place_nonexistent_graphic() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
 
     // Should not panic, just warn
@@ -2606,6 +2620,8 @@ fn test_swap_alt_isolates_placements() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 1,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
     assert!(
@@ -3065,6 +3081,8 @@ fn test_resize_widen_unwraps_command_image_follows() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 1,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3143,6 +3161,8 @@ fn test_resize_narrow_wraps_command_image_follows() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 1,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3261,6 +3281,8 @@ fn test_debug_widen_visible_layout() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3319,6 +3341,8 @@ fn test_debug_narrow_visible_layout() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3379,6 +3403,8 @@ fn test_resize_narrow_combined_col_and_row_change() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3476,6 +3502,8 @@ fn test_resize_narrow_with_multi_row_image() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0, // Default: cursor moves to last row of image
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3588,6 +3616,8 @@ fn test_resize_narrow_with_cursor_at_bottom_of_screen() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 
@@ -3688,6 +3718,8 @@ fn test_resize_narrow_with_prompt_after_image() {
         virtual_placement: false,
         unicode_placeholder: 0,
         cursor_movement: 0, // Default kitty behaviour: cursor stays on the last row of image
+        cell_x_offset: 0,
+        cell_y_offset: 0,
     };
     term.place_graphic(placement);
 


### PR DESCRIPTION
The kitty graphics protocol lets a placement specify X= and Y= pixel offsets to "display from a different origin within the cell" (see "Controlling displayed image layout" in the spec [1]). The wiring for this was half-finished: KittyPlacement already had cell_x_offset/ cell_y_offset fields and the parser already populated them from X=/Y=, but nothing connected the two.

Finish the wiring: thread the offset parser -> PlacementRequest ->
KittyPlacement -> render position.

Adds parser tests for the offset and the default.

[1] https://sw.kovidgoyal.net/kitty/graphics-protocol/