### PR TITLE
Fix macOS font fallback for bold/italic family resolution

### DIFF
--- a/sugarloaf/src/font/macos.rs
+++ b/sugarloaf/src/font/macos.rs
@@ -589,12 +589,28 @@ pub fn find_font_path(
             unsafe { CFString::wrap_under_get_rule(kCTFontStyleNameAttribute) };
         pairs.push((style_key, CFString::new(name).as_CFType()));
     }
-    let attrs: CFDictionary<CFString, CFType> = CFDictionary::from_CFType_pairs(&pairs);
-    let desc = font_descriptor::new_from_attributes(&attrs);
+    let resolve_candidates = |pairs: &[(CFString, CFType)]| {
+        let attrs: CFDictionary<CFString, CFType> =
+            CFDictionary::from_CFType_pairs(pairs);
+        let desc = font_descriptor::new_from_attributes(&attrs);
+        let descs_arr = CFArray::from_CFTypes(&[desc]);
+        let collection = font_collection::new_from_descriptors(&descs_arr);
+        collection.get_descriptors()
+    };
 
-    let descs_arr = CFArray::from_CFTypes(&[desc]);
-    let collection = font_collection::new_from_descriptors(&descs_arr);
-    let candidates = collection.get_descriptors()?;
+    let mut candidates = resolve_candidates(&pairs);
+    if candidates
+        .as_ref()
+        .is_none_or(|descs| descs.iter().next().is_none())
+        && symbolic != 0
+        && style_name.is_none()
+    {
+        let family_key =
+            unsafe { CFString::wrap_under_get_rule(kCTFontFamilyNameAttribute) };
+        let family_only = vec![(family_key, CFString::new(family).as_CFType())];
+        candidates = resolve_candidates(&family_only);
+    }
+    let candidates = candidates?;
 
     let desired_styles = derive_desired_styles(bold, italic, style_name);
 


### PR DESCRIPTION
## Summary
wrong font rendered because of fallback
<img width="880" height="156" alt="image" src="https://github.com/user-attachments/assets/388637e3-007e-4f56-adf9-f4265de543b0" />
After the fix:
<img width="938" height="152" alt="image" src="https://github.com/user-attachments/assets/e834b480-5485-486d-b6c8-d29af5a323c2" />



  Fix macOS font resolution for families where CoreText returns no candidates for `family + bold/italic trait`.

  When the trait-based lookup fails, Rio now falls back to a family-only lookup and uses the existing scoring logic to pick the best matching face, such as Bold, Italic, or Bold Italic.

  ## Why

  Some installed font families, like `UbuntuMono Nerd Font`, expose their Bold face correctly, but CoreText returns zero candidates when queried with `family + bold trait`.

  This caused bold text to fall through to a different fallback font, which could produce mismatched glyph metrics and visible vertical misalignment for punctuation.
