### PR TITLE
fix: render hint labels and correct match column offsets

### DIFF
--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -1006,18 +1006,26 @@ pub fn build_row_bg(
     term_colors: &TermColors,
     row_sel: Option<RowSelection>,
     row_hints: &[RowHint],
+    // Columns on this row that carry a hint label glyph. These cells
+    // get `hint_background` painted over the match highlight so the
+    // label letter (overlaid in `build_row_fg`) stays readable. Sorted
+    // is not required — scanned linearly, matches the small-N case
+    // (hint labels are bounded by visible matches).
+    row_label_cols: &[u16],
     bg_scratch: &mut Vec<CellBg>,
 ) {
     bg_scratch.clear();
 
-    // Fast path: row has no selection and no color-changing hints
-    // (HyperlinkHover only contributes an underline, never bg). The
-    // overwhelming majority of rows in idle terminals hit this path —
-    // strip the per-cell `cell_in_row_sel` / `cell_in_row_hints`
-    // checks and just walk cells.
+    // Fast path: row has no selection, no color-changing hints, and no
+    // hint labels (HyperlinkHover only contributes an underline, never
+    // bg). The overwhelming majority of rows in idle terminals hit this
+    // path — strip the per-cell `cell_in_row_sel` /
+    // `cell_in_row_hints` / `cell_in_label_cols` checks and just walk
+    // cells.
     let has_sel = row_sel.is_some();
     let has_color_hints = row_hints.iter().any(|rh| rh.tag != HintTag::HyperlinkHover);
-    if !has_sel && !has_color_hints {
+    let has_labels = !row_label_cols.is_empty();
+    if !has_sel && !has_color_hints && !has_labels {
         bg_scratch.reserve(cols);
         for x in 0..cols {
             let sq = row[Column(x)];
@@ -1046,6 +1054,11 @@ pub fn build_row_bg(
     } else {
         (None, None)
     };
+    let label_bg = if has_labels {
+        Some(normalized_to_u8(renderer.named_colors.hint_background))
+    } else {
+        None
+    };
     for x in 0..cols {
         let sq = row[Column(x)];
         let style = resolve_style(style_table, sq);
@@ -1055,6 +1068,10 @@ pub fn build_row_bg(
             // matching `generic.zig:2775-2800` (selection check
             // runs before highlight check).
             sel_bg.unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors))
+        } else if cell_in_label_cols(row_label_cols, col) {
+            // Hint label bg wins over the match-highlight bg so the
+            // overlaid label letter has its configured background.
+            label_bg.unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors))
         } else if let Some(tag) = cell_in_row_hints(row_hints, col) {
             match tag {
                 HintTag::Focused => focused_bg
@@ -1072,6 +1089,11 @@ pub fn build_row_bg(
         };
         bg_scratch.push(CellBg { rgba });
     }
+}
+
+#[inline]
+fn cell_in_label_cols(row_label_cols: &[u16], col: u16) -> bool {
+    row_label_cols.contains(&col)
 }
 
 // Run-shaping infrastructure (platform-agnostic types)
@@ -1502,6 +1524,10 @@ pub fn build_row_fg(
     cell_h: f32,
     row_sel: Option<RowSelection>,
     row_hints: &[RowHint],
+    // Hint labels whose glyph should overlay cells on this row. Each
+    // entry is `(column, label_char)`. Drawn as the final fg phase so
+    // the label letter paints over the underlying matched text.
+    row_label_cols: &[(u16, char)],
     font_library: &FontLibrary,
     route_id: usize,
     // Column of the cursor on this row, or `None` if the cursor isn't
@@ -2089,6 +2115,25 @@ pub fn build_row_fg(
         row_hints,
         fg_scratch,
     );
+
+    // Phase 4: hint label overlay. Drawn on top of everything so the
+    // label letter replaces the underlying cell glyph. The label cells
+    // already received `hint_background` in `build_row_bg`; here we
+    // shape each label char as a one-cell run and emit its glyph with
+    // `hint_foreground`.
+    emit_hint_label_glyphs(
+        row_label_cols,
+        y,
+        cols,
+        renderer,
+        rasterizer,
+        grid,
+        size_px,
+        cell_h,
+        font_library,
+        route_id,
+        fg_scratch,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2217,6 +2262,121 @@ fn emit_strikethroughs(
             page: slot.page,
             _pad: 0,
         });
+    }
+}
+
+/// Final fg phase: overlay hint label glyphs on top of the matched
+/// cells. Each entry in `row_label_cols` is `(column, label_char)` for
+/// a label falling on visible row `y`.
+///
+/// The label cells already received `hint_background` via
+/// `build_row_bg`; here we shape each label char as a one-cell run and
+/// emit its glyph at the cell's grid position with `hint_foreground`.
+/// This runs after the main glyph + strikethrough passes so the label
+/// letter visually replaces the underlying text.
+///
+/// Reuses the rasterizer's per-run scratch buffers (`run_str_scratch`
+/// on non-macOS, `run_utf16_scratch` on macOS). Safe because the main
+/// `build_row_fg` run loop has finished by the time this is called —
+/// nothing upstream reads those buffers afterwards in this row.
+#[allow(clippy::too_many_arguments)]
+fn emit_hint_label_glyphs(
+    row_label_cols: &[(u16, char)],
+    y: u16,
+    cols: usize,
+    renderer: &Renderer,
+    rasterizer: &mut GridGlyphRasterizer,
+    grid: &mut GridRenderer,
+    size_px: f32,
+    cell_h: f32,
+    font_library: &FontLibrary,
+    route_id: usize,
+    fg_scratch: &mut Vec<CellText>,
+) {
+    if row_label_cols.is_empty() {
+        return;
+    }
+    let size_bucket = (size_px * 4.0).round().clamp(0.0, u16::MAX as f32) as u16;
+    let size_u16 = size_px.round().clamp(1.0, u16::MAX as f32) as u16;
+    let label_fg = normalized_to_u8(renderer.named_colors.hint_foreground);
+
+    for &(col, ch) in row_label_cols {
+        if col as usize >= cols {
+            continue;
+        }
+        let (font_id, is_emoji) = rasterizer.resolve_font(ch, 0, font_library, route_id);
+
+        // Shape a single-character run into the scratch buffers.
+        #[cfg(target_os = "macos")]
+        {
+            rasterizer.run_utf16_scratch.clear();
+            let mut buf = [0u16; 2];
+            rasterizer
+                .run_utf16_scratch
+                .extend_from_slice(ch.encode_utf16(&mut buf));
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            rasterizer.run_str_scratch.clear();
+            rasterizer.run_str_scratch.push(ch);
+        }
+
+        let shaped_opt = {
+            #[cfg(target_os = "macos")]
+            {
+                shape_run_ct(rasterizer, font_id, size_u16, size_bucket, font_library)
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                shape_run_swash(rasterizer, font_id, size_u16, size_bucket, font_library)
+            }
+        };
+        let Some((glyphs, ascent_px)) = shaped_opt else {
+            continue;
+        };
+        let (synthetic_bold, synthetic_italic) =
+            rasterizer.get_synthesis(font_id, font_library);
+
+        // Emit every shaped glyph for the label char at the same
+        // column. A single ASCII codepoint typically yields one glyph,
+        // but the shaper can split a codepoint into multiple glyphs
+        // (rare for alphabet chars); all of them belong at `col`.
+        for g in glyphs {
+            let Some((_, slot, is_color)) = ensure_glyph_by_id(
+                rasterizer,
+                grid,
+                font_id,
+                g.id,
+                size_bucket,
+                size_u16,
+                cell_h,
+                ascent_px,
+                is_emoji,
+                synthetic_italic,
+                synthetic_bold,
+            ) else {
+                continue;
+            };
+            if slot.w == 0 || slot.h == 0 {
+                continue;
+            }
+            let (atlas, color) = if is_color {
+                (CellText::ATLAS_COLOR, [255, 255, 255, 255])
+            } else {
+                (CellText::ATLAS_GRAYSCALE, label_fg)
+            };
+            fg_scratch.push(CellText {
+                glyph_pos: [slot.x as u32, slot.y as u32],
+                glyph_size: [slot.w as u32, slot.h as u32],
+                bearings: [slot.bearing_x, slot.bearing_y],
+                grid_pos: [col, y],
+                color,
+                atlas,
+                bools: 0,
+                page: slot.page,
+                _pad: 0,
+            });
+        }
     }
 }
 

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -232,8 +232,7 @@ impl HintState {
             // `Column(byte)` drifted the match right by the cumulative
             // UTF-8 width surplus.
             for (start, end) in regex.find_iter(&line_text) {
-                let start_col =
-                    Column(line_text[..start].chars().count());
+                let start_col = Column(line_text[..start].chars().count());
                 let mut match_text = line_text[start..end].to_string();
 
                 // Apply post-processing if enabled
@@ -244,10 +243,8 @@ impl HintState {
                 // End column tracks the post-processed text length in
                 // chars (post-processing only trims trailing
                 // punctuation, so the start is unaffected).
-                let end_col = Column(
-                    start_col.0
-                        + match_text.chars().count().saturating_sub(1),
-                );
+                let end_col =
+                    Column(start_col.0 + match_text.chars().count().saturating_sub(1));
 
                 let hint_match = HintMatch {
                     text: match_text,

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -222,10 +222,18 @@ impl HintState {
             // Extract text from the line
             let line_text = self.extract_line_text(term, line);
 
-            // Find all matches in this line. Onig yields (byte_start, byte_end);
-            // we slice the source ourselves.
+            // Find all matches in this line. Onig yields (byte_start,
+            // byte_end); we slice the source ourselves. The byte
+            // offsets must be converted to column indices via char
+            // count — `extract_line_text` pushes one char per cell, so
+            // `line_text[..byte].chars().count()` == column. Non-ASCII
+            // cells (e.g. nerd-font PUA icons in oh-my-posh prompts)
+            // make the byte offset exceed the column, so the naive
+            // `Column(byte)` drifted the match right by the cumulative
+            // UTF-8 width surplus.
             for (start, end) in regex.find_iter(&line_text) {
-                let start_col = Column(start);
+                let start_col =
+                    Column(line_text[..start].chars().count());
                 let mut match_text = line_text[start..end].to_string();
 
                 // Apply post-processing if enabled
@@ -233,8 +241,13 @@ impl HintState {
                     match_text = post_process_hyperlink_uri(&match_text);
                 }
 
-                // Calculate the correct end position based on the processed text length
-                let end_col = Column(start + match_text.len().saturating_sub(1));
+                // End column tracks the post-processed text length in
+                // chars (post-processing only trims trailing
+                // punctuation, so the start is unaffected).
+                let end_col = Column(
+                    start_col.0
+                        + match_text.chars().count().saturating_sub(1),
+                );
 
                 let hint_match = HintMatch {
                     text: match_text,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2049,10 +2049,17 @@ impl Screen<'_> {
         let line_text = line_text.trim_end();
 
         // Find all matches in this line and check if point is within any of them.
-        // Onig yields (byte_start, byte_end); we slice the source ourselves.
+        // Onig yields (byte_start, byte_end); convert to column via char count
+        // (`line_text` is built one char per cell, so char count == column).
+        // Non-ASCII cells (nerd-font icons etc.) make byte offset > column, so
+        // the naive `Column(byte)` mis-positioned both the hit-test and the
+        // returned match span.
         for (start, end) in regex.find_iter(line_text) {
-            let start_col = rio_backend::crosswords::pos::Column(start);
-            let end_col = rio_backend::crosswords::pos::Column(end.saturating_sub(1));
+            let start_col =
+                rio_backend::crosswords::pos::Column(line_text[..start].chars().count());
+            let end_col = rio_backend::crosswords::pos::Column(
+                line_text[..end].chars().count().saturating_sub(1),
+            );
 
             // Check if the point is within this match
             if point.col >= start_col && point.col <= end_col {
@@ -3681,6 +3688,13 @@ impl Screen<'_> {
                     rio_backend::crosswords::pos::Pos,
                     rio_backend::crosswords::pos::Pos,
                 )>,
+                /// Hint labels to overlay on this panel's cells.
+                /// Populated only while hint mode is active. Each
+                /// `HintLabel` is a single character at a single grid
+                /// position; `build_row_bg` paints `hint_background`
+                /// on labeled cells and `build_row_fg` overlays the
+                /// label glyph in `hint_foreground`.
+                hint_labels: Vec<crate::context::renderable::HintLabel>,
             }
 
             let (active_key, scaled_margin) = {
@@ -3745,6 +3759,7 @@ impl Screen<'_> {
                     rio_backend::event::TerminalDamage::Noop,
                 );
                 let hint_matches = ctx.renderable_content.hint_matches.clone();
+                let hint_labels = ctx.renderable_content.hint_labels.clone();
                 let is_active = *key == active_key;
                 // `focused_match` lives on `Screen::search_state` — it's
                 // a per-window state tied to whichever panel has search
@@ -3807,6 +3822,7 @@ impl Screen<'_> {
                     hint_matches,
                     focused_match,
                     hovered_hyperlink,
+                    hint_labels,
                 });
             }
 
@@ -3914,6 +3930,28 @@ impl Screen<'_> {
                             p.display_offset,
                             &mut hint_scratch,
                         );
+                        // Collect the hint labels that fall on this
+                        // visible row. `HintLabel.position.row` is an
+                        // absolute grid line; viewport row `y` maps to
+                        // `(y as i32) - display_offset` (same convention
+                        // as `row_hints_for`). Each `HintLabel` carries
+                        // exactly one label char, so we flatten to
+                        // `(col, char)` for the fg overlay and to just
+                        // `col` for the bg tint.
+                        let absolute_line = (y as i32) - p.display_offset;
+                        let mut label_cols_with_char: Vec<(u16, char)> = Vec::new();
+                        for hl in &p.hint_labels {
+                            if hl.position.row.0 == absolute_line {
+                                if let Some(&ch) = hl.label.first() {
+                                    label_cols_with_char
+                                        .push((hl.position.col.0 as u16, ch));
+                                }
+                            }
+                        }
+                        let label_cols: Vec<u16> = label_cols_with_char
+                            .iter()
+                            .map(|(c, _)| *c)
+                            .collect();
                         crate::grid_emit::build_row_bg(
                             row,
                             cols,
@@ -3922,6 +3960,7 @@ impl Screen<'_> {
                             &p.term_colors,
                             row_sel,
                             &hint_scratch,
+                            &label_cols,
                             &mut bg_scratch,
                         );
                         let cursor_col_for_row = if p.cursor_visible
@@ -3947,6 +3986,7 @@ impl Screen<'_> {
                             p.cell_h,
                             row_sel,
                             &hint_scratch,
+                            &label_cols_with_char,
                             &font_library,
                             p.route_id,
                             cursor_col_for_row,
@@ -4405,24 +4445,39 @@ impl Screen<'_> {
                         TerminalDamage::Full
                     });
             }
-        } else if !self.search_active() {
-            // Clear hint state only if search is not active,
-            // since search also uses hint_matches for highlighting
-            self.context_manager
-                .current_mut()
-                .renderable_content
-                .hint_matches = None;
-            self.context_manager
-                .current_mut()
-                .renderable_content
-                .hint_labels
-                .clear();
-            // Force full damage to clear all hint highlights
-            let current = self.context_manager.current_mut();
-            current
-                .renderable_content
-                .pending_update
-                .set_terminal_damage(TerminalDamage::Full);
+        } else {
+            // Hint mode is inactive. `hint_labels` is never used by
+            // search (only `hint_matches` is), so clear it unconditionally
+            // — otherwise leftover labels from a just-exited hint session
+            // get rendered over search results now that the label glyphs
+            // are actually drawn.
+            let had_labels = {
+                let current = self.context_manager.current_mut();
+                let had = !current.renderable_content.hint_labels.is_empty();
+                current.renderable_content.hint_labels.clear();
+                had
+            };
+
+            if !self.search_active() {
+                // Search isn't active either: also drop hint_matches and
+                // force a full repaint to clear all hint highlighting.
+                let current = self.context_manager.current_mut();
+                current.renderable_content.hint_matches = None;
+                current
+                    .renderable_content
+                    .pending_update
+                    .set_terminal_damage(TerminalDamage::Full);
+            } else if had_labels {
+                // Search is still active, so keep hint_matches (search
+                // uses them for highlighting). But we just cleared
+                // labels — trigger a partial repaint so any previously
+                // drawn label glyphs get wiped from the grid buffers.
+                self.context_manager
+                    .current_mut()
+                    .renderable_content
+                    .pending_update
+                    .set_terminal_damage(TerminalDamage::Partial);
+            }
         }
     }
 


### PR DESCRIPTION
Issue #1668: hint labels not showing up
- Wire hint_labels through PanelFrame into build_row_bg (paints hint_background on labeled cells) and build_row_fg (new emit_hint_label_glyphs phase shapes each label char as a one-cell run and overlays it in hint_foreground, drawn last so it replaces the underlying matched text). The configured hint_foreground / hint_background colors were defined but read by no renderer.

Byte-offset-as-column drift on lines with non-ASCII cells
- find_regex_matches and find_regex_match_at_point converted oniguruma byte offsets to column indices via char count. The previous Column(byte) drifted matches rightward on lines containing non-ASCII cells (e.g. nerd-font PUA icons from oh-my-posh prompts), breaking highlight/label placement and mouse-hover hit-testing. Copy/Command actions still worked because they use the text field, not the Pos.

Stale hint_labels during search
- update_hint_state now clears hint_labels whenever hint mode is inactive (not only when search is also inactive); previously leftover labels could be drawn over search results once the label renderer was wired in.


Fix result (using the same configuration as in the issue)

Before：
<img width="1604" height="1040" alt="image" src="https://github.com/user-attachments/assets/ed1a0862-0aa4-4ce6-b99f-c5861a92c007" />

After：
<img width="1604" height="1040" alt="image" src="https://github.com/user-attachments/assets/fd6370f0-a396-4c58-a484-e8db2b9ca1fd" />
<img width="1604" height="1040" alt="image" src="https://github.com/user-attachments/assets/d2dd2ccc-4bd2-4c7a-98c5-4596994f251d" />
