### PR TITLE
[Bug] Fix macOS titlebar behavior when the tab island is hidden for a single tab.

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1411,17 +1411,17 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     return;
                 }
 
-                // Only force the default cursor while the island is
-                // visible — when it's hidden (hide_if_single + single
-                // tab on macOS) the band at the top has no tabs to
-                // hover, and the I-beam from the terminal grid below
-                // should stay during top-edge drags.
+                // Use the arrow over Rio's top chrome. On macOS this
+                // remains a titlebar/traffic-light band even when the
+                // island is hidden for a single tab.
                 use crate::renderer::island::ISLAND_HEIGHT;
                 let scale_factor = route.window.screen.sugarloaf.scale_factor();
                 let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
                 let num_tabs = route.window.screen.ctx().len();
                 let nav = &route.window.screen.renderer.navigation;
-                if nav.island_visible(num_tabs) && y <= island_height_px {
+                let top_chrome_uses_arrow = nav.island_visible(num_tabs)
+                    || (cfg!(target_os = "macos") && nav.is_enabled());
+                if top_chrome_uses_arrow && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
                 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2622,9 +2622,18 @@ impl Screen<'_> {
             return false;
         }
 
-        // Island isn't painted (hide_if_single + single tab on macOS).
-        // Nothing to click on, so let the caller route the event to the
-        // grid for selection / double-click maximize at the OS title bar.
+        #[cfg(target_os = "macos")]
+        if !island_visible && !is_right_click {
+            if let ClickState::DoubleClick = self.mouse.click_state {
+                let is_maximized = window.is_maximized();
+                window.set_maximized(!is_maximized);
+                return true;
+            }
+        }
+
+        // Island isn't painted (hide_if_single + single tab). On macOS,
+        // single clicks still fall through to the manual titlebar drag
+        // path in the caller.
         if !island_visible {
             return false;
         }


### PR DESCRIPTION

  ## Summary

  Fix macOS titlebar behavior when the tab island is hidden for a single tab.

  When Rio had only one tab, the hidden island/titlebar area still behaved like terminal text for some mouse interactions. This made the cursor show incorrectly over the traffic-light/titlebar area and prevented
  double-click maximize/restore from working there.

  This updates the macOS top chrome handling so:

  - the cursor stays as the arrow over the titlebar/traffic-light band
  - double-clicking the hidden single-tab top chrome toggles maximize/restore
  - single-click dragging still falls through to the existing manual window drag path

  ## Testing

  ```sh
  cargo fmt -- --check
  cargo check -p rioterm --features wgpu
  ```

 ## Manual test:

  - launched Rio with one tab
  - hovered over the macOS titlebar/traffic-light area
  - confirmed the cursor stays as an arrow
  - double-clicked the top chrome and confirmed the window maximizes/restores
  
### Before

https://github.com/user-attachments/assets/46aa560a-f362-4322-8599-109ecf4b7573



### After


https://github.com/user-attachments/assets/d520a0a0-8c23-4255-8739-2b74e144dc41

