### PR TITLE
fix: copy selection to primary buffer for middle-click paste

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1461,12 +1461,21 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                                 return;
                             }
                         } else if matches!(button, MouseButton::Left | MouseButton::Right)
-                            && self.config.copy_on_select
                         {
+                            // Always mirror the selection into the primary
+                            // buffer so middle-click paste works (standard
+                            // X11/Wayland behavior). copy_selection is a
+                            // no-op when the selection is empty.
                             route.window.screen.copy_selection(
-                                ClipboardType::Clipboard,
+                                ClipboardType::Selection,
                                 &mut self.router.clipboard,
                             );
+                            if self.config.copy_on_select {
+                                route.window.screen.copy_selection(
+                                    ClipboardType::Clipboard,
+                                    &mut self.router.clipboard,
+                                );
+                            }
                         }
                     }
                 }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1280,6 +1280,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         }
 
                         if let MouseButton::Left | MouseButton::Right = button {
+                            // Always mirror the selection into the primary
+                            // buffer so middle-click paste works (standard
+                            // X11/Wayland behavior). copy_selection is a
+                            // no-op when the selection is empty.
+                            route.window.screen.copy_selection(
+                                ClipboardType::Selection,
+                                &mut self.router.clipboard,
+                            );
                             if self.config.copy_on_select {
                                 route.window.screen.copy_selection(
                                     ClipboardType::Clipboard,


### PR DESCRIPTION
On mouse drag-release the selection was only copied to the clipboard (and only when `copy-on-select` was enabled), never to the primary selection buffer, so middle-click paste had nothing to paste. Always mirror the selection into the primary buffer on release, matching standard X11/Wayland behavior. `copy_selection` is a no-op on an empty selection.