### PR TITLE
fix: hot-reload window.decorations without restart

### DIFF
--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -257,4 +257,10 @@ pub fn configure_window(winit_window: &Window, config: &Config) {
     }
 
     winit_window.set_blur(config.window.blur.into());
+
+    // Toggle decorations at runtime so `window.decorations` hot-reloads
+    // without a restart. Mirrors the build-time mapping: only `Disabled`
+    // turns the server-side decorations off.
+    winit_window
+        .set_decorations(!matches!(config.window.decorations, Decorations::Disabled));
 }

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -269,4 +269,10 @@ pub fn configure_window(winit_window: &Window, config: &Config) {
     }
 
     winit_window.set_blur(config.window.blur.into());
+
+    // Toggle decorations at runtime so `window.decorations` hot-reloads
+    // without a restart. Mirrors the build-time mapping: only `Disabled`
+    // turns the server-side decorations off.
+    winit_window
+        .set_decorations(!matches!(config.window.decorations, Decorations::Disabled));
 }


### PR DESCRIPTION
`configure_window()` runs on every config reload and re-applies window settings (opacity, blur, transparency, title, corner preference, …) — but it never re-applied `decorations`, so toggling `window.decorations` only took effect at window creation and required a restart.

Add a `set_decorations()` call there, mirroring the build-time mapping (only `Disabled` turns server-side decorations off), so the setting hot-reloads live like the others.

Standalone, based on main.