### PR TITLE
fix: keep quit-confirmation dialog visible on idle frames

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1842,7 +1842,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             );
                         }
 
-                        if let Some(window_update) = route.window.screen.render() {
+                        let force_present = route.path == RoutePath::ConfirmQuit;
+                        if let Some(window_update) =
+                            route.window.screen.render(force_present)
+                        {
                             use crate::context::renderable::{
                                 BackgroundState, WindowUpdate,
                             };

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3488,7 +3488,10 @@ impl Screen<'_> {
         }
     }
 
-    pub(crate) fn render(&mut self) -> Option<crate::context::renderable::WindowUpdate> {
+    pub(crate) fn render(
+        &mut self,
+        force_present: bool,
+    ) -> Option<crate::context::renderable::WindowUpdate> {
         let current_route = self.context_manager.current_route();
         let (grid_cols, grid_rows) = {
             let terminal = self.context_manager.current().terminal.lock();
@@ -3537,7 +3540,11 @@ impl Screen<'_> {
             .renderer
             .run(&mut self.sugarloaf, &mut self.context_manager);
         let has_animation = self.renderer.needs_redraw();
-        let should_present = any_panel_dirty || has_animation;
+        // `force_present` keeps immediate-mode overlays (e.g. the quit
+        // confirmation dialog) on screen: without it an idle terminal has
+        // no panel damage / animation, so the frame would be discarded and
+        // the overlay would flicker out.
+        let should_present = force_present || any_panel_dirty || has_animation;
 
         if self.renderer.custom_mouse_cursor {
             let scale = self.sugarloaf.scale_factor();


### PR DESCRIPTION
The ConfirmQuit dialog is drawn into sugarloaf before `screen.render()`, but `render()` calls `discard_frame()` whenever `should_present` is false — i.e. no panel damage and no animation, which is exactly the case while the dialog is up over an idle terminal. The dialog draws were discarded and only reached the screen on frames a cursor blink (or other animation) happened to force, so the prompt flickered in and out ('sometimes I can't see it').

Add a `force_present` flag to `render()`, set while the route is `ConfirmQuit`, so the dialog frame is always presented.

Standalone, based on main.