### PR TITLE
fix: dismiss quit confirmation dialog on a single n/Esc press

### DIFF
--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -334,9 +334,16 @@ impl Route<'_> {
                 match &key_event.logical_key {
                     Key::Character(c) if c.as_str() == "n" || c.as_str() == "N" => {
                         self.path = RoutePath::Terminal;
+                        // Repaint so the dialog clears on this keypress.
+                        // Otherwise the terminal is idle, the frame is
+                        // discarded (should_present == false), and the stale
+                        // dialog lingers until some later event forces a
+                        // redraw -- making it look like `n` needs two presses.
+                        self.request_overlay_redraw();
                     }
                     Key::Named(NamedKey::Escape) => {
                         self.path = RoutePath::Terminal;
+                        self.request_overlay_redraw();
                     }
                     Key::Character(c) if c.as_str() == "y" || c.as_str() == "Y" => {
                         self.quit();


### PR DESCRIPTION
Pressing **n** (or Esc) in the quit-confirmation dialog required two presses to actually cancel, while **y** worked on the first press.

Cause: the `n`/`Escape` branches set the route back to `Terminal` but never requested a redraw. On an idle terminal the next frame is discarded (`should_present == false`), so the dialog stayed painted until some later event forced a repaint — making the first press look ignored. `y` was unaffected because `quit()` tears the window down.

Fix: call `request_overlay_redraw()` on dismiss (matching the assistant/command-palette dismiss paths) so the dialog clears on the first press.

Standalone, based on main.