### PR TITLE
fix: repaint immediately when a tab closes on shell exit

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -512,6 +512,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     } else {
                         let size = route.window.screen.context_manager.len();
                         route.window.screen.resize_top_or_bottom_line(size);
+                        // Force a repaint of the post-close state. The PTY
+                        // thread also queues a separate Render, but if that is
+                        // processed before this CloseTerminal (or coalesced),
+                        // the closed tab lingers on screen until some later
+                        // event — looking "frozen" until you click another
+                        // tab. mark_dirty + redraw makes the close show now.
+                        route.window.screen.mark_dirty();
+                        route.request_redraw();
                     }
                 }
             }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -668,6 +668,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     } else {
                         let size = route.window.screen.context_manager.len();
                         route.window.screen.resize_top_or_bottom_line(size);
+                        // Force a repaint of the post-close state. The PTY
+                        // thread also queues a separate Render, but if that is
+                        // processed before this CloseTerminal (or coalesced),
+                        // the closed tab lingers on screen until some later
+                        // event — looking "frozen" until you click another
+                        // tab. mark_dirty + redraw makes the close show now.
+                        route.window.screen.mark_dirty();
+                        route.request_redraw();
                     }
                 }
             }


### PR DESCRIPTION
With several tabs open, typing `exit` in a tab sometimes closed it instantly and sometimes left it frozen on screen (showing the dead shell) until you clicked another tab.

On shell exit the PTY thread sends `CloseTerminal(route_id)` **and** a separate `Render`. The `CloseTerminal` handler closed the tab and resized the strip but never requested a redraw itself — it relied on that separate `Render`. If the `Render` was processed before `CloseTerminal` (or coalesced away), the post-close state was never painted, so the closed tab lingered until a later event forced a repaint.

Fix: `mark_dirty()` + `request_redraw()` in the `CloseTerminal` handler so the close is shown immediately, regardless of event ordering.

Standalone, based on main.