### PR TITLE
feat: add bindable togglemaximized action

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1011,6 +1011,12 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
             }
+            RioEventType::Rio(RioEvent::ToggleMaximized) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    let maximized = route.window.winit_window.is_maximized();
+                    route.window.winit_window.set_maximized(!maximized);
+                }
+            }
             RioEventType::Rio(RioEvent::ToggleAppearanceTheme) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     use rio_backend::config::theme::AppearanceTheme;

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -852,6 +852,12 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
             }
+            RioEventType::Rio(RioEvent::ToggleMaximized) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    let maximized = route.window.winit_window.is_maximized();
+                    route.window.winit_window.set_maximized(!maximized);
+                }
+            }
             RioEventType::Rio(RioEvent::ToggleAppearanceTheme) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     use rio_backend::config::theme::AppearanceTheme;

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -265,6 +265,7 @@ impl From<String> for Action {
             "togglevimode" => Some(Action::ToggleViMode),
             "toggleappearancetheme" => Some(Action::ToggleAppearanceTheme),
             "togglefullscreen" => Some(Action::ToggleFullscreen),
+            "togglemaximized" => Some(Action::ToggleMaximized),
             "opencommandpalette" => Some(Action::OpenCommandPalette),
             "none" => Some(Action::None),
             _ => None,

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -269,6 +269,7 @@ impl From<String> for Action {
             "togglevimode" => Some(Action::ToggleViMode),
             "toggleappearancetheme" => Some(Action::ToggleAppearanceTheme),
             "togglefullscreen" => Some(Action::ToggleFullscreen),
+            "togglemaximized" => Some(Action::ToggleMaximized),
             "opencommandpalette" => Some(Action::OpenCommandPalette),
             "none" => Some(Action::None),
             _ => None,

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -655,6 +655,12 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     }
 
     #[inline]
+    pub fn toggle_maximize_window(&mut self) {
+        self.event_proxy
+            .send_event(RioEvent::ToggleMaximized, self.window_id);
+    }
+
+    #[inline]
     pub fn toggle_appearance_theme(&mut self) {
         self.event_proxy
             .send_event(RioEvent::ToggleAppearanceTheme, self.window_id);

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -669,6 +669,12 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     }
 
     #[inline]
+    pub fn toggle_maximize_window(&mut self) {
+        self.event_proxy
+            .send_event(RioEvent::ToggleMaximized, self.window_id);
+    }
+
+    #[inline]
     pub fn toggle_appearance_theme(&mut self) {
         self.event_proxy
             .send_event(RioEvent::ToggleAppearanceTheme, self.window_id);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1228,6 +1228,7 @@ impl Screen<'_> {
                         self.mark_dirty();
                     }
                     Act::ToggleFullscreen => self.context_manager.toggle_full_screen(),
+                    Act::ToggleMaximized => self.context_manager.toggle_maximize_window(),
                     Act::ToggleAppearanceTheme => {
                         self.context_manager.toggle_appearance_theme();
                     }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1311,6 +1311,7 @@ impl Screen<'_> {
                         self.mark_dirty();
                     }
                     Act::ToggleFullscreen => self.context_manager.toggle_full_screen(),
+                    Act::ToggleMaximized => self.context_manager.toggle_maximize_window(),
                     Act::ToggleAppearanceTheme => {
                         self.context_manager.toggle_appearance_theme();
                     }

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -112,6 +112,7 @@ pub enum RioEvent {
     UpdateFontSize(u8),
     Scroll(Scroll),
     ToggleFullScreen,
+    ToggleMaximized,
     ToggleAppearanceTheme,
     Minimize(bool),
     Hide,
@@ -297,6 +298,7 @@ impl Debug for RioEvent {
                 write!(f, "ReportToAssistant({})", error_report.report)
             }
             RioEvent::ToggleFullScreen => write!(f, "FullScreen"),
+            RioEvent::ToggleMaximized => write!(f, "ToggleMaximized"),
             RioEvent::ToggleAppearanceTheme => write!(f, "ToggleAppearanceTheme"),
             RioEvent::BlinkCursor(timeout, route_id) => {
                 write!(f, "BlinkCursor {timeout} {route_id}")

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -112,6 +112,7 @@ pub enum RioEvent {
     UpdateFontSize(u8),
     Scroll(Scroll),
     ToggleFullScreen,
+    ToggleMaximized,
     ToggleAppearanceTheme,
     Minimize(bool),
     Hide,
@@ -299,6 +300,7 @@ impl Debug for RioEvent {
                 write!(f, "ReportToAssistant({})", error_report.report)
             }
             RioEvent::ToggleFullScreen => write!(f, "FullScreen"),
+            RioEvent::ToggleMaximized => write!(f, "ToggleMaximized"),
             RioEvent::ToggleAppearanceTheme => write!(f, "ToggleAppearanceTheme"),
             RioEvent::BlinkCursor(timeout, route_id) => {
                 write!(f, "BlinkCursor {timeout} {route_id}")


### PR DESCRIPTION
`Action::ToggleMaximized` existed but was never wired up — it had no action-string mapping (so `[bindings]` couldn't reference it) and no handler. This adds:
- `"togglemaximized"` in the action-string parser
- `toggle_maximize_window()` emitting `RioEvent::ToggleMaximized`
- the `Act::ToggleMaximized` arm
- an application handler that flips `winit_window.set_maximized()` (works on Wayland)

So users can bind window maximize/restore, e.g. `{ key = "m", with = "super", action = "togglemaximized" }`.

Standalone, based on main.