### PR TITLE
feat: add IPC support (unix only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +784,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1392,18 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -1972,6 +2008,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2051,20 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -3549,6 +3608,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4053,6 +4125,7 @@ dependencies = [
  "objc-rs 0.3.1",
  "onig",
  "parking_lot",
+ "postcard",
  "pretty_assertions",
  "rapidhash",
  "raw-window-handle",
@@ -4071,6 +4144,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width-16",
  "url",
+ "uzers",
  "wgpu",
  "windows-sys 0.60.2",
 ]
@@ -4485,6 +4559,15 @@ dependencies = [
  "web-sys",
  "windows-sys 0.61.2",
  "x11rb",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5125,6 +5208,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uzers"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8275fb1afee25b4111d2dc8b5c505dbbc4afd0b990cb96deb2d88bff8be18d"
+dependencies = [
+ "libc",
+ "log 0.4.32",
+]
 
 [[package]]
 name = "valuable"

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -57,6 +57,10 @@ cpal = { version = "0.15", optional = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+uzers = "0.12.2"
+postcard = { version = "1.1.3", features = ["alloc"] }
+
 [target.'cfg(windows)'.dependencies]
 ahash = { version = "0.8.12", default-features = false, features = ["std"] }
 dunce = "1.0.5"

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -36,6 +36,8 @@ pub struct Application<'a> {
     router: Router<'a>,
     scheduler: Scheduler,
     app_id: Option<String>,
+    // Used for IPC Single-Instance handy window creation
+    last_working_dir: Option<std::path::PathBuf>,
 }
 
 impl Application<'_> {
@@ -75,6 +77,7 @@ impl Application<'_> {
             router,
             scheduler,
             app_id,
+            last_working_dir: None,
         }
     }
 
@@ -365,6 +368,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         timer_id,
                     );
                 }
+            }
+            RioEventType::Rio(RioEvent::UpdateLastWorkingDirectory(working_dir)) => {
+                tracing::info!("Updated last working directory: {:?}", working_dir);
+                self.last_working_dir = Some(working_dir);
             }
             RioEventType::Rio(RioEvent::ReportToAssistant(error)) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
@@ -748,6 +755,8 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::CreateWindow) => {
+                // println!("Working Dir: {:?}", self.);
+                // self.config.curr
                 self.router.create_window(
                     event_loop,
                     self.event_proxy.clone(),

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -81,6 +81,10 @@ impl Application<'_> {
         }
     }
 
+    pub fn get_event_proxy(&self) -> EventProxy {
+        self.event_proxy.clone()
+    }
+
     fn skip_window_event(event: &WindowEvent) -> bool {
         matches!(
             event,
@@ -755,8 +759,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::CreateWindow) => {
-                // println!("Working Dir: {:?}", self.);
-                // self.config.curr
                 self.router.create_window(
                     event_loop,
                     self.event_proxy.clone(),
@@ -911,6 +913,29 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
             }
+            RioEventType::Rio(RioEvent::IpcCreateWindow(working_dir)) => {
+                let mut config = self.config.clone();
+
+                config.working_dir = working_dir
+                    .or(self.last_working_dir.clone())
+                    .map(|wd| wd.to_string_lossy().into_owned())
+                    .or(config.working_dir);
+
+                // A new window in a different working directory requires spawning a new process
+                // This may be dirty hack
+                if config.working_dir.is_some() {
+                    config.use_fork = false;
+                }
+
+                self.router.create_window(
+                    event_loop,
+                    self.event_proxy.clone(),
+                    &config,
+                    None,
+                    self.app_id.as_deref(),
+                );
+            }
+
             _ => {}
         }
     }

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -46,6 +46,10 @@ pub struct TerminalOptions {
     /// Set the Wayland app_id or X11 WM_CLASS (Linux/BSD only)
     #[clap(long)]
     pub app_id: Option<String>,
+
+    /// Disable IPC single-instance mode (always launch a new process)
+    #[clap(long)]
+    pub no_ipc: bool,
 }
 
 impl TerminalOptions {

--- a/frontends/rioterm/src/ipc/client.rs
+++ b/frontends/rioterm/src/ipc/client.rs
@@ -1,0 +1,46 @@
+#![cfg(unix)]
+
+use std::{io::Write, os::unix::net::UnixStream};
+
+use crate::ipc::protocol::IpcCommand;
+
+use super::*;
+
+pub struct Client {
+    stream: UnixStream,
+}
+
+impl Client {
+    pub fn try_connect() -> Option<Self> {
+        let path = server::get_socket_path();
+
+        match UnixStream::connect(path) {
+            Ok(stream) => Some(Self { stream }),
+            Err(_) => None,
+        }
+    }
+
+    pub fn create_window(
+        &mut self,
+        working_dir: Option<std::path::PathBuf>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.send_request(IpcCommand::CreateWindow { working_dir })
+    }
+
+    fn send_request(
+        &mut self,
+        req: protocol::IpcCommand,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Serialize IpcCommand to Vec<u8>
+        let data = postcard::to_allocvec(&req)?;
+
+        // Send request header (len in u8)
+        let len = (data.len() as u32).to_le_bytes();
+        self.stream.write_all(&len)?;
+
+        // Send request data
+        self.stream.write_all(&data)?;
+
+        Ok(())
+    }
+}

--- a/frontends/rioterm/src/ipc/mod.rs
+++ b/frontends/rioterm/src/ipc/mod.rs
@@ -1,0 +1,5 @@
+mod client;
+mod protocol;
+pub mod server;
+
+pub use client::Client;

--- a/frontends/rioterm/src/ipc/mod.rs
+++ b/frontends/rioterm/src/ipc/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 mod client;
 mod protocol;
 pub mod server;

--- a/frontends/rioterm/src/ipc/protocol.rs
+++ b/frontends/rioterm/src/ipc/protocol.rs
@@ -1,0 +1,6 @@
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub enum IpcCommand {
+    CreateWindow {
+        working_dir: Option<std::path::PathBuf>,
+    },
+}

--- a/frontends/rioterm/src/ipc/server.rs
+++ b/frontends/rioterm/src/ipc/server.rs
@@ -1,0 +1,112 @@
+#![cfg(unix)]
+
+use std::{
+    io::{ErrorKind, Read},
+    os::unix::net::{UnixListener, UnixStream},
+};
+
+use rio_backend::event::EventProxy;
+use rio_window::window::WindowId;
+
+use crate::ipc::protocol::IpcCommand;
+
+const SOCKET_FILE_NAME: &str = "rioterm";
+
+pub fn start(event_proxy: EventProxy) -> Result<(), std::io::Error> {
+    let path = get_socket_path();
+
+    // Check if socket file already exists. Remove it if so
+    match std::fs::remove_file(&path) {
+        Ok(_) => {}
+        Err(e) if e.kind() == ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+
+    let listener = UnixListener::bind(path)?;
+
+    // Create server listener at background thread
+    let _ = std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => {
+                    let event_proxy = event_proxy.clone();
+                    std::thread::spawn(move || {
+                        if let Err(e) = handle_connection(stream, event_proxy) {
+                            tracing::error!("Error while processing IPC Request: {}", e);
+                        }
+                    })
+                }
+
+                Err(err) => match err.kind() {
+                    ErrorKind::ConnectionAborted | ErrorKind::Interrupted => {
+                        tracing::debug!("IPC server error: {}", err);
+                        continue;
+                    }
+
+                    _ => {
+                        tracing::error!(
+                            "IPC server critical error: {}. IPC server is stopping!",
+                            err
+                        );
+                        break;
+                    }
+                },
+            };
+        }
+    });
+
+    Ok(())
+}
+
+fn handle_connection(
+    mut stream: UnixStream,
+    event_proxy: EventProxy,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Set read timeout to 500 millis to prevent thread stucking
+    stream.set_read_timeout(Some(std::time::Duration::from_millis(500)))?;
+
+    // Read request header (len in u8)
+    let mut len_bytes = [0u8; 4];
+    stream.read_exact(&mut len_bytes)?;
+    let len = u32::from_le_bytes(len_bytes);
+
+    // Read request data
+    let mut buf = vec![0u8; len as usize];
+    stream.read_exact(&mut buf)?;
+
+    // Parse data to IpcCommand (protocol)
+    let command = postcard::from_bytes::<IpcCommand>(&buf)?;
+
+    match command {
+        IpcCommand::CreateWindow { working_dir } => {
+            event_proxy.send_event(
+                rio_backend::event::RioEventType::Rio(
+                    rio_backend::event::RioEvent::IpcCreateWindow(working_dir),
+                ),
+                unsafe { WindowId::dummy() },
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub fn get_socket_path() -> std::path::PathBuf {
+    let mut base_dir = match std::env::var("XDG_RUNTIME_DIR") {
+        Ok(dir) => std::path::PathBuf::from(dir),
+        Err(_) => std::env::temp_dir(),
+    };
+
+    base_dir.push(get_socket_filename());
+    base_dir
+}
+
+fn get_socket_filename() -> String {
+    let uid = uzers::get_current_uid();
+    let display = std::env::var("WAYLAND_DISPLAY")
+        .or_else(|_| std::env::var("DISPLAY"))
+        .unwrap_or_else(|_| "default".to_string());
+    let display = display.replace('/', "-");
+
+    format!("{}-{}-{}.sock", SOCKET_FILE_NAME, uid, display)
+}

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -12,6 +12,7 @@ mod context;
 mod grid_emit;
 mod hints;
 mod ime;
+mod ipc;
 mod layout;
 mod messenger;
 mod mouse;
@@ -186,7 +187,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             config.use_fork = false;
         }
 
-        if let Some(working_dir_cli) = args.window_options.terminal_options.working_dir {
+        if let Some(working_dir_cli) =
+            args.window_options.terminal_options.working_dir.clone()
+        {
             // Use dunce::canonicalize on Windows to avoid UNC paths (\\?\)
             // which break many tools like Neovim and Bun
             #[cfg(target_os = "windows")]
@@ -239,11 +242,42 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_id = args.window_options.terminal_options.app_id;
 
     let mut application = crate::application::Application::new(
-        config,
+        config.clone(),
         config_error,
         &window_event_loop,
         app_id,
     );
+
+    // IPC
+    // First, try to create a window in an already running instance via IPC
+    // Otherwise, start an IPC server
+    #[cfg(unix)]
+    {
+        if !args.window_options.terminal_options.no_ipc && config.enable_ipc {
+            if let Some(mut client) = ipc::Client::try_connect() {
+                let working_dir = args
+                    .window_options
+                    .terminal_options
+                    .working_dir
+                    .as_ref()
+                    .map(|p| std::path::PathBuf::from(p.clone()));
+
+                if let Err(e) = client.create_window(working_dir) {
+                    tracing::error!("IPC sending request error: {}", e);
+                }
+
+                return Ok(());
+            } else {
+                // Start IPC server
+                ipc::server::start(application.get_event_proxy()).unwrap_or_else(|err| {
+                    tracing::error!("IPC server creation error: {}", err);
+                });
+
+                tracing::info!("IPC server successfully started!")
+            }
+        }
+    }
+
     let _ = application.run(window_event_loop);
 
     #[cfg(windows)]

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -12,6 +12,7 @@ mod context;
 mod grid_emit;
 mod hints;
 mod ime;
+#[cfg(unix)]
 mod ipc;
 mod layout;
 mod messenger;

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -72,6 +72,19 @@ pub fn default_use_fork() -> bool {
 }
 
 #[inline]
+pub fn default_enable_ipc() -> bool {
+    #[cfg(unix)]
+    {
+        true
+    }
+
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+#[inline]
 pub fn default_working_dir() -> Option<String> {
     None
 }

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -97,6 +97,8 @@ pub struct Config {
     pub platform: Platform,
     #[serde(default = "default_use_fork", rename = "use-fork")]
     pub use_fork: bool,
+    #[serde(default = "default_enable_ipc", rename = "enable-ipc")]
+    pub enable_ipc: bool,
     #[serde(default = "Keyboard::default")]
     pub keyboard: Keyboard,
     #[serde(default = "Title::default")]
@@ -652,6 +654,7 @@ impl Default for Config {
             platform: Platform::default(),
             theme: String::default(),
             use_fork: default_use_fork(),
+            enable_ipc: default_enable_ipc(),
             window: Window::default(),
             working_dir: default_working_dir(),
             ignore_selection_fg_color: false,

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -2553,6 +2553,11 @@ impl<U: EventListener> Handler for Crosswords<U> {
     }
 
     fn set_current_directory(&mut self, path: std::path::PathBuf) {
+        // Update last working direcotry in Application Singleton (need for IPC)
+        self.event_proxy.send_event(
+            RioEvent::UpdateLastWorkingDirectory(path.clone()),
+            self.window_id,
+        );
         trace!("Setting working directory {:?}", path);
         self.current_directory = Some(path);
     }

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -222,6 +222,9 @@ pub enum RioEvent {
     /// Color index: 0 for foreground, 1 for background, 2 for cursor color.
     ColorChange(usize, usize, Option<ColorRgb>),
 
+    // IPC
+    IpcCreateWindow(Option<std::path::PathBuf>),
+
     // No operation
     Noop,
 }
@@ -317,6 +320,9 @@ impl Debug for RioEvent {
             }
             RioEvent::ColorChange(route_id, color, rgb) => {
                 write!(f, "ColorChange({route_id}, {color:?}, {rgb:?})")
+            }
+            RioEvent::IpcCreateWindow(working_dir) => {
+                write!(f, "IpcCreateWindow({:?})", working_dir)
             }
         }
     }

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -126,6 +126,8 @@ pub enum RioEvent {
     SelectNativeTabNext,
     SelectNativeTabPrev,
 
+    UpdateLastWorkingDirectory(std::path::PathBuf),
+
     ReportToAssistant(RioError),
 
     /// Grid has changed possibly requiring a mouse cursor shape change.
@@ -293,6 +295,9 @@ impl Debug for RioEvent {
             RioEvent::SelectNativeTabPrev => write!(f, "SelectNativeTabPrev"),
             RioEvent::CreateConfigEditor => write!(f, "CreateConfigEditor"),
             RioEvent::UpdateConfig => write!(f, "ReloadConfiguration"),
+            RioEvent::UpdateLastWorkingDirectory(working_dir) => {
+                write!(f, "UpdateLastWorkingDirectory({:?})", working_dir)
+            }
             RioEvent::ReportToAssistant(error_report) => {
                 write!(f, "ReportToAssistant({})", error_report.report)
             }


### PR DESCRIPTION
Hello!

I've just added support for the IPC via Unix sockets. At this moment it supports only window creation, but you can easily add new functionality. Also added '--no-ipc' cli flag to prevent any IPC and start as normal process (even if it enabled in config). And added 'enable_ipc' config option.

On startup, Rio tries to connect to the existing IPC server. Otherwise, it starts the IPC server.

New windows started in the last working directory, just Quality of Life. Same behave I saw in Ghostty and it really handy.

Also, it brights significant RAM usage improvement. On my machine, 50 windows only consume 500 MiB (and start soooo fast)

P.S. Sorry for grammar mistakes in this PR and code comments, I'm not native English

Closes #868 