### PR TITLE
feat: terminal triggers (iTerm2-style regex → action rules)

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -59,6 +59,17 @@ impl Application<'_> {
         if let Some(error) = config_error {
             router.propagate_error_to_next_route(error.into());
         }
+        // A broken triggers.toml must be as visible as a broken
+        // config.toml; a config error and a triggers error can't both
+        // be pending here (a failed config load never loads triggers).
+        if let Some(message) = &config.triggers_load_error {
+            router.propagate_error_to_next_route(rio_backend::error::RioError {
+                report: rio_backend::error::RioErrorType::InvalidTriggersFormat(
+                    message.clone(),
+                ),
+                level: rio_backend::error::RioErrorLevel::Warning,
+            });
+        }
 
         let proxy = event_loop.create_proxy();
         let event_proxy = EventProxy::new(proxy.clone());
@@ -145,8 +156,8 @@ impl Application<'_> {
         }
     }
 
-    fn handle_desktop_notification(&self, title: &str, body: &str) {
-        rio_notifier::send_notification(title, body);
+    fn handle_desktop_notification(&self, title: &str, body: &str, urgency: u8) {
+        rio_notifier::send_notification(title, body, urgency);
     }
 
     pub fn run(
@@ -539,7 +550,23 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     None
                 };
 
+                // A triggers.toml typo mid-edit must not silently wipe the
+                // live rules (and their highlights): the failed load left
+                // the fresh config's triggers empty, so keep the running
+                // ones until the file parses again, and surface the parse
+                // error the same way a config.toml one is surfaced.
+                let previous_triggers = if config.triggers_load_error.is_some() {
+                    Some(std::mem::take(&mut self.config.triggers))
+                } else {
+                    None
+                };
                 self.config = config;
+                if let Some(triggers) = previous_triggers {
+                    tracing::warn!(
+                        "triggers.toml failed to parse; keeping the previous rules"
+                    );
+                    self.config.triggers = triggers;
+                }
 
                 // Dropping the old manager unregisters its hotkeys, so
                 // ToggleQuake binding edits apply without restarting.
@@ -587,6 +614,23 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
 
                     route.request_redraw();
+                }
+
+                // After clear_errors and the renderer rebuilds above, or
+                // the overlay would be wiped by the very reload that
+                // should show it: a triggers.toml typo must be as visible
+                // as a config.toml one.
+                if let Some(message) = &self.config.triggers_load_error {
+                    let error = rio_backend::error::RioError {
+                        report: rio_backend::error::RioErrorType::InvalidTriggersFormat(
+                            message.clone(),
+                        ),
+                        level: rio_backend::error::RioErrorLevel::Warning,
+                    };
+                    for (_id, route) in self.router.routes.iter_mut() {
+                        route.report_error(&error);
+                        route.request_redraw();
+                    }
                 }
             }
             RioEventType::Rio(RioEvent::Exit | RioEvent::Quit) => {
@@ -647,6 +691,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         .sugarloaf
                         .font_library()
                         .remove_glyph_registry(route_id);
+
+                    // Drop this route's trigger dedup state so it doesn't
+                    // accumulate for the window's lifetime.
+                    route.window.screen.triggers.forget_route(route_id);
 
                     if route
                         .window
@@ -720,7 +768,136 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::DesktopNotification { title, body }) => {
-                self.handle_desktop_notification(&title, &body);
+                self.handle_desktop_notification(&title, &body, 1);
+            }
+            RioEventType::Rio(RioEvent::TriggerFired { route_id, action }) => {
+                use rio_backend::event::TriggerEventAction as Action;
+                match action {
+                    Action::Notify {
+                        title,
+                        body,
+                        urgency,
+                    } => {
+                        self.handle_desktop_notification(&title, &body, urgency);
+                    }
+                    Action::Run { program, args } => {
+                        if let Some(route) = self.router.routes.get(&window_id) {
+                            route.window.screen.exec(&program, &args);
+                        }
+                    }
+                    Action::SendText { text } => {
+                        if let Some(route) = self.router.routes.get_mut(&window_id) {
+                            if let Some(item) = route
+                                .window
+                                .screen
+                                .context_manager
+                                .get_by_route_id(route_id)
+                            {
+                                item.val.messenger.send_bytes(text.into_bytes());
+                            }
+                        }
+                    }
+                    Action::Coprocess {
+                        program,
+                        args,
+                        stdin,
+                    } => {
+                        // Capture stdout off-thread so a slow command never
+                        // blocks the UI, then write it into the PTY. When
+                        // `stdin` is set, the visible screen is piped to the
+                        // command (small payload, no deadlock risk). The
+                        // child is bounded by a deadline: a hung coprocess
+                        // would otherwise leak this thread + pipes forever,
+                        // and its eventual stdout would be typed into
+                        // whatever runs in the pane much later.
+                        const COPROCESS_DEADLINE: std::time::Duration =
+                            std::time::Duration::from_secs(10);
+                        let proxy = self.event_proxy.clone();
+                        std::thread::spawn(move || {
+                            use std::io::{Read, Write};
+                            use std::process::Stdio;
+                            let mut command = std::process::Command::new(&program);
+                            command
+                                .args(&args)
+                                .stdout(Stdio::piped())
+                                .stderr(Stdio::null());
+                            if stdin.is_some() {
+                                command.stdin(Stdio::piped());
+                            }
+                            let mut child = match command.spawn() {
+                                Ok(child) => child,
+                                Err(err) => {
+                                    tracing::warn!(
+                                        "trigger coprocess {program:?} failed: {err}"
+                                    );
+                                    return;
+                                }
+                            };
+                            // Write stdin on its own thread so we can drain
+                            // stdout concurrently: a coprocess that emits more
+                            // than one pipe buffer before reading its input
+                            // would otherwise deadlock against a blocking
+                            // write_all here.
+                            if let Some(input) = stdin {
+                                if let Some(mut pipe) = child.stdin.take() {
+                                    std::thread::spawn(move || {
+                                        let _ = pipe.write_all(input.as_bytes());
+                                    });
+                                }
+                            }
+                            // Drain stdout on its own thread too, so the
+                            // deadline loop below never blocks on a pipe;
+                            // the reader finishes when the pipe closes
+                            // (child exit or kill).
+                            let stdout_rx = child.stdout.take().map(|mut pipe| {
+                                let (tx, rx) = std::sync::mpsc::channel();
+                                std::thread::spawn(move || {
+                                    let mut buf = Vec::new();
+                                    let _ = pipe.read_to_end(&mut buf);
+                                    let _ = tx.send(buf);
+                                });
+                                rx
+                            });
+                            let deadline = std::time::Instant::now() + COPROCESS_DEADLINE;
+                            let timed_out = loop {
+                                match child.try_wait() {
+                                    Ok(Some(_)) => break false,
+                                    Ok(None) => {}
+                                    Err(err) => {
+                                        tracing::warn!(
+                                            "trigger coprocess {program:?} failed: {err}"
+                                        );
+                                        break true;
+                                    }
+                                }
+                                if std::time::Instant::now() >= deadline {
+                                    tracing::warn!(
+                                        "trigger coprocess {program:?} exceeded {COPROCESS_DEADLINE:?}; killing"
+                                    );
+                                    let _ = child.kill();
+                                    let _ = child.wait();
+                                    break true;
+                                }
+                                std::thread::sleep(std::time::Duration::from_millis(50));
+                            };
+                            if timed_out {
+                                return;
+                            }
+                            if let Some(rx) = stdout_rx {
+                                if let Ok(buf) = rx.recv() {
+                                    if !buf.is_empty() {
+                                        let text =
+                                            String::from_utf8_lossy(&buf).into_owned();
+                                        proxy.send_event(
+                                            RioEvent::PtyWrite(route_id, text).into(),
+                                            window_id,
+                                        );
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
             }
             RioEventType::Rio(RioEvent::PrepareRender(millis)) => {
                 if let Some(route) = self.router.routes.get(&window_id) {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -592,15 +592,42 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             }
                         }
                     }
-                    Action::Coprocess { program, args } => {
+                    Action::Coprocess {
+                        program,
+                        args,
+                        stdin,
+                    } => {
                         // Capture stdout off-thread so a slow command never
-                        // blocks the UI, then write it into the PTY.
+                        // blocks the UI, then write it into the PTY. When
+                        // `stdin` is set, the visible screen is piped to the
+                        // command (small payload, no deadlock risk).
                         let proxy = self.event_proxy.clone();
                         std::thread::spawn(move || {
-                            match std::process::Command::new(&program)
+                            use std::io::Write;
+                            use std::process::Stdio;
+                            let mut command = std::process::Command::new(&program);
+                            command
                                 .args(&args)
-                                .output()
-                            {
+                                .stdout(Stdio::piped())
+                                .stderr(Stdio::null());
+                            if stdin.is_some() {
+                                command.stdin(Stdio::piped());
+                            }
+                            let mut child = match command.spawn() {
+                                Ok(child) => child,
+                                Err(err) => {
+                                    tracing::warn!(
+                                        "trigger coprocess {program:?} failed: {err}"
+                                    );
+                                    return;
+                                }
+                            };
+                            if let Some(input) = stdin {
+                                if let Some(mut pipe) = child.stdin.take() {
+                                    let _ = pipe.write_all(input.as_bytes());
+                                }
+                            }
+                            match child.wait_with_output() {
                                 Ok(output) if !output.stdout.is_empty() => {
                                     let text = String::from_utf8_lossy(&output.stdout)
                                         .into_owned();

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -137,8 +137,8 @@ impl Application<'_> {
         }
     }
 
-    fn handle_desktop_notification(&self, title: &str, body: &str) {
-        rio_notifier::send_notification(title, body);
+    fn handle_desktop_notification(&self, title: &str, body: &str, urgency: u8) {
+        rio_notifier::send_notification(title, body, urgency);
     }
 
     pub fn run(
@@ -563,13 +563,17 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::DesktopNotification { title, body }) => {
-                self.handle_desktop_notification(&title, &body);
+                self.handle_desktop_notification(&title, &body, 1);
             }
             RioEventType::Rio(RioEvent::TriggerFired { route_id, action }) => {
                 use rio_backend::event::TriggerEventAction as Action;
                 match action {
-                    Action::Notify { title, body } => {
-                        self.handle_desktop_notification(&title, &body);
+                    Action::Notify {
+                        title,
+                        body,
+                        urgency,
+                    } => {
+                        self.handle_desktop_notification(&title, &body, urgency);
                     }
                     Action::Run { program, args } => {
                         if let Some(route) = self.router.routes.get(&window_id) {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -565,6 +565,57 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             RioEventType::Rio(RioEvent::DesktopNotification { title, body }) => {
                 self.handle_desktop_notification(&title, &body);
             }
+            RioEventType::Rio(RioEvent::TriggerFired { route_id, action }) => {
+                use rio_backend::event::TriggerEventAction as Action;
+                match action {
+                    Action::Notify { title, body } => {
+                        self.handle_desktop_notification(&title, &body);
+                    }
+                    Action::Run { program, args } => {
+                        if let Some(route) = self.router.routes.get(&window_id) {
+                            route.window.screen.exec(&program, &args);
+                        }
+                    }
+                    Action::SendText { text } => {
+                        if let Some(route) = self.router.routes.get_mut(&window_id) {
+                            if let Some(item) = route
+                                .window
+                                .screen
+                                .context_manager
+                                .get_by_route_id(route_id)
+                            {
+                                item.val.messenger.send_bytes(text.into_bytes());
+                            }
+                        }
+                    }
+                    Action::Coprocess { program, args } => {
+                        // Capture stdout off-thread so a slow command never
+                        // blocks the UI, then write it into the PTY.
+                        let proxy = self.event_proxy.clone();
+                        std::thread::spawn(move || {
+                            match std::process::Command::new(&program)
+                                .args(&args)
+                                .output()
+                            {
+                                Ok(output) if !output.stdout.is_empty() => {
+                                    let text = String::from_utf8_lossy(&output.stdout)
+                                        .into_owned();
+                                    proxy.send_event(
+                                        RioEvent::PtyWrite(route_id, text).into(),
+                                        window_id,
+                                    );
+                                }
+                                Ok(_) => {}
+                                Err(err) => {
+                                    tracing::warn!(
+                                        "trigger coprocess {program:?} failed: {err}"
+                                    );
+                                }
+                            }
+                        });
+                    }
+                }
+            }
             RioEventType::Rio(RioEvent::PrepareRender(millis)) => {
                 if let Some(route) = self.router.routes.get(&window_id) {
                     let timer_id = TimerId::new(

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -231,6 +231,7 @@ impl From<String> for Action {
                 Some(Action::Search(SearchAction::SearchHistoryPrevious))
             }
             "clearhistory" => Some(Action::ClearHistory),
+            "resettriggers" => Some(Action::ResetTriggers),
             "resetfontsize" => Some(Action::ResetFontSize),
             "increasefontsize" => Some(Action::IncreaseFontSize),
             "decreasefontsize" => Some(Action::DecreaseFontSize),
@@ -385,6 +386,12 @@ pub enum Action {
 
     /// Clear the display buffer(s) to remove history.
     ClearHistory,
+
+    /// Re-arm `once` terminal triggers so one-shot rules can fire again on
+    /// the next fresh occurrence (e.g. to re-run a login automation) without
+    /// reloading the config. The per-line dedup is kept so stale on-screen
+    /// content is not re-fired.
+    ResetTriggers,
 
     /// Hide the Rio window.
     #[allow(dead_code)]

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -232,6 +232,7 @@ impl From<String> for Action {
                 Some(Action::Search(SearchAction::SearchHistoryPrevious))
             }
             "clearhistory" => Some(Action::ClearHistory),
+            "resettriggers" => Some(Action::ResetTriggers),
             "resetfontsize" => Some(Action::ResetFontSize),
             "increasefontsize" => Some(Action::IncreaseFontSize),
             "decreasefontsize" => Some(Action::DecreaseFontSize),
@@ -389,6 +390,12 @@ pub enum Action {
 
     /// Clear the display buffer(s) to remove history.
     ClearHistory,
+
+    /// Re-arm `once` terminal triggers so one-shot rules can fire again on
+    /// the next fresh occurrence (e.g. to re-run a login automation) without
+    /// reloading the config. The per-line dedup is kept so stale on-screen
+    /// content is not re-fired.
+    ResetTriggers,
 
     /// Hide the Rio window.
     #[allow(dead_code)]

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -889,6 +889,16 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     }
 
     #[inline]
+    pub fn event_proxy(&self) -> &T {
+        &self.event_proxy
+    }
+
+    #[inline]
+    pub fn window_id(&self) -> WindowId {
+        self.window_id
+    }
+
+    #[inline]
     pub fn current_route(&self) -> usize {
         self.current_route
     }

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -875,6 +875,16 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     }
 
     #[inline]
+    pub fn event_proxy(&self) -> &T {
+        &self.event_proxy
+    }
+
+    #[inline]
+    pub fn window_id(&self) -> WindowId {
+        self.window_id
+    }
+
+    #[inline]
     pub fn current_route(&self) -> usize {
         self.current_route
     }

--- a/frontends/rioterm/src/context/renderable.rs
+++ b/frontends/rioterm/src/context/renderable.rs
@@ -48,6 +48,9 @@ pub struct RenderableContent {
     pub hint_labels: Vec<HintLabel>,
     pub highlighted_hint: Option<crate::hints::HintMatch>,
     pub hint_matches: Option<Vec<rio_backend::crosswords::search::Match>>,
+    /// Trigger highlight ranges with their per-rule background color.
+    pub trigger_highlights:
+        Option<Vec<(rio_backend::crosswords::search::Match, [u8; 4])>>,
     pub last_typing: Option<Instant>,
     pub last_blink_toggle: Option<Instant>,
     pub pending_update: PendingUpdate,
@@ -110,6 +113,7 @@ impl RenderableContent {
             hint_labels: Vec::new(),
             highlighted_hint: None,
             hint_matches: None,
+            trigger_highlights: None,
             last_typing: None,
             last_blink_toggle: None,
             hyperlink_range: None,

--- a/frontends/rioterm/src/context/renderable.rs
+++ b/frontends/rioterm/src/context/renderable.rs
@@ -48,6 +48,9 @@ pub struct RenderableContent {
     pub hint_labels: Option<Vec<HintLabel>>,
     pub highlighted_hint: Option<crate::hints::HintMatch>,
     pub hint_matches: Option<Vec<rio_backend::crosswords::search::Match>>,
+    /// Trigger highlight ranges with their per-rule background color.
+    pub trigger_highlights:
+        Option<Vec<(rio_backend::crosswords::search::Match, [u8; 4])>>,
     pub last_typing: Option<Instant>,
     pub last_blink_toggle: Option<Instant>,
     pub pending_update: PendingUpdate,
@@ -115,6 +118,7 @@ impl RenderableContent {
             hint_labels: None,
             highlighted_hint: None,
             hint_matches: None,
+            trigger_highlights: None,
             last_typing: None,
             last_blink_toggle: None,
             hyperlink_range: None,

--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -127,6 +127,7 @@ pub enum HintTag {
     Focused,
     HyperlinkHover,
     Label,
+    TriggerHighlight,
 }
 
 /// Per-row hint interval, closed on both ends. Several `RowHint`s may
@@ -136,6 +137,9 @@ pub struct RowHint {
     pub lo: u16,
     pub hi: u16,
     pub tag: HintTag,
+    /// Per-hint background override (trigger highlights carry their own
+    /// color); `None` means use the tag's configured color.
+    pub color: Option<[u8; 4]>,
 }
 
 /// Compute the hint-match intervals (if any) for visible row `y`.
@@ -147,10 +151,12 @@ pub struct RowHint {
 /// iteration order when it overlaps another match — same precedence
 /// as (`generic.zig:1330-1353`: "The order below matters.
 /// Highlights added earlier will take priority").
+#[allow(clippy::too_many_arguments)]
 pub fn row_hints_for(
     hint_matches: Option<&[Match]>,
     focused_match: Option<&Match>,
     hover_hyperlink: Option<(Pos, Pos)>,
+    trigger_highlights: Option<&[(Match, [u8; 4])]>,
     y: usize,
     cols: usize,
     display_offset: i32,
@@ -181,6 +187,7 @@ pub fn row_hints_for(
             lo: lo.min(cols_max),
             hi: hi.min(cols_max),
             tag,
+            color: None,
         })
     };
 
@@ -201,6 +208,19 @@ pub fn row_hints_for(
     if let Some((start, end)) = hover_hyperlink {
         if let Some(rh) = pos_pair_to_row_hint(start, end, HintTag::HyperlinkHover) {
             out.push(rh);
+        }
+    }
+
+    // Trigger highlights are independent of search; emit them before the
+    // hint_matches early-return so they show without an active search.
+    if let Some(highlights) = trigger_highlights {
+        for (m, color) in highlights {
+            if let Some(mut rh) =
+                pos_pair_to_row_hint(*m.start(), *m.end(), HintTag::TriggerHighlight)
+            {
+                rh.color = Some(*color);
+                out.push(rh);
+            }
         }
     }
 
@@ -287,6 +307,7 @@ pub fn overlay_hint_labels(
                 lo: col as u16,
                 hi: col as u16,
                 tag: HintTag::Label,
+                color: None,
             },
         );
     }
@@ -295,10 +316,10 @@ pub fn overlay_hint_labels(
 
 #[inline]
 fn cell_in_row_hints(row_hints: &[RowHint], col: u16) -> Option<HintTag> {
-    // Skip HyperlinkHover for the color paths — it only contributes
-    // an underline (handled separately in `emit_underlines`).
+    // Skip HyperlinkHover (underline only) and TriggerHighlight (background
+    // only — handled by `cell_bg_hint`) so matched text keeps its own fg.
     for rh in row_hints {
-        if rh.tag == HintTag::HyperlinkHover {
+        if rh.tag == HintTag::HyperlinkHover || rh.tag == HintTag::TriggerHighlight {
             continue;
         }
         if col >= rh.lo && col <= rh.hi {
@@ -306,6 +327,15 @@ fn cell_in_row_hints(row_hints: &[RowHint], col: u16) -> Option<HintTag> {
         }
     }
     None
+}
+
+/// Background-affecting hint covering `col` (search/hint matches and trigger
+/// highlights; skips the underline-only HyperlinkHover).
+#[inline]
+fn cell_bg_hint(row_hints: &[RowHint], col: u16) -> Option<&RowHint> {
+    row_hints
+        .iter()
+        .find(|rh| rh.tag != HintTag::HyperlinkHover && col >= rh.lo && col <= rh.hi)
 }
 
 /// Whether a cell should receive a forced underline from a hovered
@@ -329,9 +359,9 @@ fn cell_fg_hinted(tag: HintTag, renderer: &Renderer) -> [u8; 4] {
         }
         HintTag::Match => normalized_to_u8(renderer.named_colors.search_match_foreground),
         HintTag::Label => normalized_to_u8(renderer.named_colors.hint_foreground),
-        // Hover doesn't change fg color; defensive — `cell_in_row_hints`
-        // already filters this tag out, so this arm shouldn't fire.
-        HintTag::HyperlinkHover => [0, 0, 0, 0],
+        // Hover and trigger highlights don't change fg; `cell_in_row_hints`
+        // filters them out, so these arms are defensive.
+        HintTag::HyperlinkHover | HintTag::TriggerHighlight => [0, 0, 0, 0],
     }
 }
 
@@ -1108,17 +1138,19 @@ pub fn build_row_bg(
             // matching `generic.zig:2775-2800` (selection check
             // runs before highlight check).
             sel_bg.unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors))
-        } else if let Some(tag) = cell_in_row_hints(row_hints, col) {
-            match tag {
+        } else if let Some(rh) = cell_bg_hint(row_hints, col) {
+            match rh.tag {
                 HintTag::Focused => focused_bg
                     .unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors)),
                 HintTag::Match => {
                     match_bg.unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors))
                 }
                 HintTag::Label => cell_bg(sq, style, renderer, term_colors),
-                // `cell_in_row_hints` filters HyperlinkHover out, but
-                // make the match exhaustive so a future caller can't
-                // accidentally hit a panic.
+                HintTag::TriggerHighlight => rh
+                    .color
+                    .unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors)),
+                // `cell_bg_hint` filters HyperlinkHover out, but keep the
+                // match exhaustive.
                 HintTag::HyperlinkHover => cell_bg(sq, style, renderer, term_colors),
             }
         } else {
@@ -2677,6 +2709,7 @@ mod hint_label_tests {
             lo: 0,
             hi: 9,
             tag: HintTag::Match,
+            color: None,
         }];
         overlay_hint_labels(&row, &labels, 3, 0, 5, &mut hints).unwrap();
         assert_eq!(cell_in_row_hints(&hints, 2), Some(HintTag::Label));

--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -126,6 +126,7 @@ pub enum HintTag {
     Match,
     Focused,
     HyperlinkHover,
+    TriggerHighlight,
 }
 
 /// Per-row hint interval, closed on both ends. Several `RowHint`s may
@@ -135,6 +136,9 @@ pub struct RowHint {
     pub lo: u16,
     pub hi: u16,
     pub tag: HintTag,
+    /// Per-hint background override (trigger highlights carry their own
+    /// color); `None` means use the tag's configured color.
+    pub color: Option<[u8; 4]>,
 }
 
 /// Compute the hint-match intervals (if any) for visible row `y`.
@@ -146,10 +150,12 @@ pub struct RowHint {
 /// iteration order when it overlaps another match — same precedence
 /// as (`generic.zig:1330-1353`: "The order below matters.
 /// Highlights added earlier will take priority").
+#[allow(clippy::too_many_arguments)]
 pub fn row_hints_for(
     hint_matches: Option<&[Match]>,
     focused_match: Option<&Match>,
     hover_hyperlink: Option<(Pos, Pos)>,
+    trigger_highlights: Option<&[(Match, [u8; 4])]>,
     y: usize,
     cols: usize,
     display_offset: i32,
@@ -180,6 +186,7 @@ pub fn row_hints_for(
             lo: lo.min(cols_max),
             hi: hi.min(cols_max),
             tag,
+            color: None,
         })
     };
 
@@ -200,6 +207,19 @@ pub fn row_hints_for(
     if let Some((start, end)) = hover_hyperlink {
         if let Some(rh) = pos_pair_to_row_hint(start, end, HintTag::HyperlinkHover) {
             out.push(rh);
+        }
+    }
+
+    // Trigger highlights are independent of search; emit them before the
+    // hint_matches early-return so they show without an active search.
+    if let Some(highlights) = trigger_highlights {
+        for (m, color) in highlights {
+            if let Some(mut rh) =
+                pos_pair_to_row_hint(*m.start(), *m.end(), HintTag::TriggerHighlight)
+            {
+                rh.color = Some(*color);
+                out.push(rh);
+            }
         }
     }
 
@@ -231,10 +251,10 @@ fn pos_eq(a: Pos, b: Pos) -> bool {
 
 #[inline]
 fn cell_in_row_hints(row_hints: &[RowHint], col: u16) -> Option<HintTag> {
-    // Skip HyperlinkHover for the color paths — it only contributes
-    // an underline (handled separately in `emit_underlines`).
+    // Skip HyperlinkHover (underline only) and TriggerHighlight (background
+    // only — handled by `cell_bg_hint`) so matched text keeps its own fg.
     for rh in row_hints {
-        if rh.tag == HintTag::HyperlinkHover {
+        if rh.tag == HintTag::HyperlinkHover || rh.tag == HintTag::TriggerHighlight {
             continue;
         }
         if col >= rh.lo && col <= rh.hi {
@@ -242,6 +262,15 @@ fn cell_in_row_hints(row_hints: &[RowHint], col: u16) -> Option<HintTag> {
         }
     }
     None
+}
+
+/// Background-affecting hint covering `col` (search/hint matches and trigger
+/// highlights; skips the underline-only HyperlinkHover).
+#[inline]
+fn cell_bg_hint(row_hints: &[RowHint], col: u16) -> Option<&RowHint> {
+    row_hints
+        .iter()
+        .find(|rh| rh.tag != HintTag::HyperlinkHover && col >= rh.lo && col <= rh.hi)
 }
 
 /// Whether a cell should receive a forced underline from a hovered
@@ -264,9 +293,9 @@ fn cell_fg_hinted(tag: HintTag, renderer: &Renderer) -> [u8; 4] {
             normalized_to_u8(renderer.named_colors.search_focused_match_foreground)
         }
         HintTag::Match => normalized_to_u8(renderer.named_colors.search_match_foreground),
-        // Hover doesn't change fg color; defensive — `cell_in_row_hints`
-        // already filters this tag out, so this arm shouldn't fire.
-        HintTag::HyperlinkHover => [0, 0, 0, 0],
+        // Hover and trigger highlights don't change fg; `cell_in_row_hints`
+        // filters them out, so these arms are defensive.
+        HintTag::HyperlinkHover | HintTag::TriggerHighlight => [0, 0, 0, 0],
     }
 }
 
@@ -1055,16 +1084,18 @@ pub fn build_row_bg(
             // matching `generic.zig:2775-2800` (selection check
             // runs before highlight check).
             sel_bg.unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors))
-        } else if let Some(tag) = cell_in_row_hints(row_hints, col) {
-            match tag {
+        } else if let Some(rh) = cell_bg_hint(row_hints, col) {
+            match rh.tag {
                 HintTag::Focused => focused_bg
                     .unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors)),
                 HintTag::Match => {
                     match_bg.unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors))
                 }
-                // `cell_in_row_hints` filters HyperlinkHover out, but
-                // make the match exhaustive so a future caller can't
-                // accidentally hit a panic.
+                HintTag::TriggerHighlight => rh
+                    .color
+                    .unwrap_or_else(|| cell_bg(sq, style, renderer, term_colors)),
+                // `cell_bg_hint` filters HyperlinkHover out, but keep the
+                // match exhaustive.
                 HintTag::HyperlinkHover => cell_bg(sq, style, renderer, term_colors),
             }
         } else {

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -5,6 +5,22 @@ use rio_backend::event::EventListener;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+/// Extract the trimmed text of a single grid line. Shared by hint matching
+/// and trigger scanning.
+pub(crate) fn extract_line_text<T: EventListener>(
+    term: &rio_backend::crosswords::Crosswords<T>,
+    line: Line,
+) -> String {
+    let grid = &term.grid;
+    let mut text = String::new();
+    for col in 0..grid.columns() {
+        text.push(grid[line][Column(col)].c());
+    }
+    // Unwritten cells read back as NUL, which `trim_end` leaves in place.
+    text.trim_end_matches(|c: char| c == '\0' || c.is_whitespace())
+        .to_string()
+}
+
 /// State for hint selection mode
 pub struct HintState {
     /// Currently active hint configuration
@@ -220,7 +236,7 @@ impl HintState {
             }
 
             // Extract text from the line
-            let line_text = self.extract_line_text(term, line);
+            let line_text = extract_line_text(term, line);
 
             // Find all matches in this line. Onig yields (byte_start, byte_end);
             for (start, end) in regex.find_iter(&line_text) {
@@ -307,22 +323,6 @@ impl HintState {
                 col = end_col;
             }
         }
-    }
-
-    fn extract_line_text<T: EventListener>(
-        &self,
-        term: &rio_backend::crosswords::Crosswords<T>,
-        line: Line,
-    ) -> String {
-        let grid = &term.grid;
-        let mut text = String::new();
-
-        for col in 0..grid.columns() {
-            let cell = &grid[line][Column(col)];
-            text.push(cell.c());
-        }
-
-        text.trim_end().to_string()
     }
 
     fn generate_labels(&mut self) {

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -5,6 +5,20 @@ use rio_backend::event::EventListener;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+/// Extract the trimmed text of a single grid line. Shared by hint matching
+/// and trigger scanning.
+pub(crate) fn extract_line_text<T: EventListener>(
+    term: &rio_backend::crosswords::Crosswords<T>,
+    line: Line,
+) -> String {
+    let grid = &term.grid;
+    let mut text = String::new();
+    for col in 0..grid.columns() {
+        text.push(grid[line][Column(col)].c());
+    }
+    text.trim_end().to_string()
+}
+
 /// State for hint selection mode
 pub struct HintState {
     /// Currently active hint configuration
@@ -220,7 +234,7 @@ impl HintState {
             }
 
             // Extract text from the line
-            let line_text = self.extract_line_text(term, line);
+            let line_text = extract_line_text(term, line);
 
             // Find all matches in this line. Onig yields (byte_start, byte_end);
             // we slice the source ourselves.
@@ -308,22 +322,6 @@ impl HintState {
                 col = end_col;
             }
         }
-    }
-
-    fn extract_line_text<T: EventListener>(
-        &self,
-        term: &rio_backend::crosswords::Crosswords<T>,
-        line: Line,
-    ) -> String {
-        let grid = &term.grid;
-        let mut text = String::new();
-
-        for col in 0..grid.columns() {
-            let cell = &grid[line][Column(col)];
-            text.push(cell.c());
-        }
-
-        text.trim_end().to_string()
     }
 
     fn generate_labels(&mut self) {

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -16,7 +16,9 @@ pub(crate) fn extract_line_text<T: EventListener>(
     for col in 0..grid.columns() {
         text.push(grid[line][Column(col)].c());
     }
-    text.trim_end().to_string()
+    // Unwritten cells read back as NUL, which `trim_end` leaves in place.
+    text.trim_end_matches(|c: char| c == '\0' || c.is_whitespace())
+        .to_string()
 }
 
 /// State for hint selection mode

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -22,6 +22,7 @@ mod renderer;
 mod router;
 mod scheduler;
 mod screen;
+mod triggers;
 mod watcher;
 
 use clap::Parser;

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -23,6 +23,7 @@ mod renderer;
 mod router;
 mod scheduler;
 mod screen;
+mod triggers;
 mod watcher;
 
 use clap::Parser;

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -69,6 +69,7 @@ pub struct Screen<'screen> {
     pub touchpurpose: TouchPurpose,
     pub search_state: SearchState,
     pub hint_state: HintState,
+    pub triggers: crate::triggers::Triggers,
     pub renderer: Renderer,
     pub sugarloaf: Sugarloaf<'screen>,
     pub context_manager: context::ContextManager<EventProxy>,
@@ -277,6 +278,7 @@ impl Screen<'_> {
         Ok(Screen {
             search_state: SearchState::default(),
             hint_state: HintState::new(config.hints.alphabet.clone()),
+            triggers: crate::triggers::Triggers::new(&config.triggers),
             hints_config: config
                 .hints
                 .rules
@@ -401,6 +403,8 @@ impl Screen<'_> {
             config.window.macos_use_unified_titlebar,
         );
         let padding_y_bottom = config.margin.bottom;
+
+        self.triggers.rebuild(&config.triggers);
 
         if should_update_font_library {
             self.sugarloaf.update_font(font_library);
@@ -3488,8 +3492,64 @@ impl Screen<'_> {
         }
     }
 
+    /// Scan the focused route's new output against the configured triggers
+    /// and dispatch their actions. No-op when no triggers are configured.
+    fn run_triggers(&mut self) {
+        if self.triggers.is_empty() {
+            return;
+        }
+
+        // The focused context's real route id (the value get_by_route_id
+        // matches), not the cached current_route which is unset until the
+        // first tab switch.
+        let route_id = self.context_manager.current().route_id;
+
+        let (actions, highlights) = {
+            let terminal = self.context_manager.current().terminal.lock();
+            let actions = self.triggers.scan(route_id, &terminal);
+            let highlights = self.triggers.highlights(&terminal);
+            (actions, highlights)
+        };
+
+        self.context_manager
+            .current_mut()
+            .renderable_content
+            .trigger_highlights = if highlights.is_empty() {
+            None
+        } else {
+            Some(highlights)
+        };
+
+        use crate::triggers::ResolvedAction as Action;
+        use rio_backend::event::{RioEvent, TriggerEventAction as Event};
+        let window_id = self.context_manager.window_id();
+        let tab_index = self.context_manager.current_index();
+        for action in actions {
+            let event = match action {
+                Action::Notify { title, body } => Event::Notify { title, body },
+                Action::Run { program, args } => Event::Run { program, args },
+                Action::SendText(text) => Event::SendText { text },
+                Action::Coprocess { program, args } => Event::Coprocess { program, args },
+                Action::TabColor(color) => {
+                    self.context_manager
+                        .set_custom_color(tab_index, Some(color));
+                    continue;
+                }
+            };
+            self.context_manager.event_proxy().send_event(
+                RioEvent::TriggerFired {
+                    route_id,
+                    action: event,
+                }
+                .into(),
+                window_id,
+            );
+        }
+    }
+
     pub(crate) fn render(&mut self) -> Option<crate::context::renderable::WindowUpdate> {
         let current_route = self.context_manager.current_route();
+        self.run_triggers();
         let (grid_cols, grid_rows) = {
             let terminal = self.context_manager.current().terminal.lock();
             (terminal.columns() as u32, terminal.screen_lines() as u32)
@@ -3681,6 +3741,9 @@ impl Screen<'_> {
                     rio_backend::crosswords::pos::Pos,
                     rio_backend::crosswords::pos::Pos,
                 )>,
+                /// Trigger highlight ranges with their per-rule bg color.
+                trigger_highlights:
+                    Option<Vec<(rio_backend::crosswords::search::Match, [u8; 4])>>,
             }
 
             let (active_key, scaled_margin) = {
@@ -3745,6 +3808,8 @@ impl Screen<'_> {
                     rio_backend::event::TerminalDamage::Noop,
                 );
                 let hint_matches = ctx.renderable_content.hint_matches.clone();
+                let trigger_highlights =
+                    ctx.renderable_content.trigger_highlights.clone();
                 let is_active = *key == active_key;
                 // `focused_match` lives on `Screen::search_state` — it's
                 // a per-window state tied to whichever panel has search
@@ -3807,6 +3872,7 @@ impl Screen<'_> {
                     hint_matches,
                     focused_match,
                     hovered_hyperlink,
+                    trigger_highlights,
                 });
             }
 
@@ -3909,6 +3975,7 @@ impl Screen<'_> {
                             p.hint_matches.as_deref(),
                             p.focused_match.as_ref(),
                             p.hovered_hyperlink,
+                            p.trigger_highlights.as_deref(),
                             y,
                             cols,
                             p.display_offset,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -70,6 +70,7 @@ pub struct Screen<'screen> {
     pub touchpurpose: TouchPurpose,
     pub search_state: SearchState,
     pub hint_state: HintState,
+    pub triggers: crate::triggers::Triggers,
     pub renderer: Renderer,
     pub sugarloaf: Sugarloaf<'screen>,
     pub context_manager: context::ContextManager<EventProxy>,
@@ -297,6 +298,7 @@ impl Screen<'_> {
         Ok(Screen {
             search_state: SearchState::default(),
             hint_state: HintState::new(config.hints.alphabet.clone()),
+            triggers: crate::triggers::Triggers::new(&config.triggers),
             hints_config: config
                 .hints
                 .rules
@@ -427,6 +429,8 @@ impl Screen<'_> {
             config.window.macos_use_unified_titlebar,
         );
         let padding_y_bottom = config.margin.bottom;
+
+        self.triggers.rebuild(&config.triggers);
 
         if should_update_font_library {
             self.sugarloaf.update_font(font_library);
@@ -1308,6 +1312,10 @@ impl Screen<'_> {
                             self.context_manager.current_mut().terminal.lock();
                         terminal.clear_saved_history();
                         drop(terminal);
+                        self.mark_dirty();
+                    }
+                    Act::ResetTriggers => {
+                        self.triggers.reset();
                         self.mark_dirty();
                     }
                     Act::ToggleFullscreen => self.context_manager.toggle_full_screen(),
@@ -3706,8 +3714,95 @@ impl Screen<'_> {
         }
     }
 
+    /// Scan the focused route's new output against the configured triggers
+    /// and dispatch their actions. No-op when no triggers are configured.
+    fn run_triggers(&mut self) {
+        if self.triggers.is_empty() {
+            // Rules were all removed: drop any highlights left on the
+            // focused pane so they don't drift as the text scrolls.
+            self.context_manager
+                .current_mut()
+                .renderable_content
+                .trigger_highlights = None;
+            return;
+        }
+
+        // The focused context's real route id (the value get_by_route_id
+        // matches), not the cached current_route which is unset until the
+        // first tab switch.
+        let route_id = self.context_manager.current().route_id;
+
+        let (actions, highlights) = {
+            let ctx = self.context_manager.current();
+            // Previous highlights let a Partial frame rescan only damaged
+            // rows and carry the rest over.
+            let prev = ctx.renderable_content.trigger_highlights.as_deref();
+            let terminal = ctx.terminal.lock();
+            let actions = self.triggers.scan(route_id, &terminal);
+            let highlights = self.triggers.highlights(&terminal, prev);
+            (actions, highlights)
+        };
+
+        // `None` means no terminal content changed this frame: keep the
+        // highlights already on the pane. `Some(empty)` means recompute
+        // produced nothing, so clear them.
+        if let Some(highlights) = highlights {
+            self.context_manager
+                .current_mut()
+                .renderable_content
+                .trigger_highlights = if highlights.is_empty() {
+                None
+            } else {
+                Some(highlights)
+            };
+        }
+
+        use crate::triggers::ResolvedAction as Action;
+        use rio_backend::event::{RioEvent, TriggerEventAction as Event};
+        let window_id = self.context_manager.window_id();
+        let tab_index = self.context_manager.current_index();
+        for action in actions {
+            let event = match action {
+                Action::Notify {
+                    title,
+                    body,
+                    urgency,
+                } => Event::Notify {
+                    title,
+                    body,
+                    urgency,
+                },
+                Action::Run { program, args } => Event::Run { program, args },
+                Action::SendText(text) => Event::SendText { text },
+                Action::Coprocess {
+                    program,
+                    args,
+                    stdin,
+                } => Event::Coprocess {
+                    program,
+                    args,
+                    stdin,
+                },
+                Action::TabColor(color) => {
+                    self.context_manager
+                        .set_custom_color(tab_index, Some(color));
+                    continue;
+                }
+            };
+            self.context_manager.event_proxy().send_event(
+                RioEvent::TriggerFired {
+                    route_id,
+                    action: event,
+                }
+                .into(),
+                window_id,
+            );
+        }
+    }
+
     pub(crate) fn render(&mut self) -> Option<crate::context::renderable::WindowUpdate> {
         self.update_close_button_hover(self.mouse.x, self.mouse.y);
+        self.run_triggers();
 
         let is_search_active = self.search_active();
         if is_search_active {
@@ -3894,6 +3989,9 @@ impl Screen<'_> {
                 )>,
                 hint_labels: Option<Vec<crate::context::renderable::HintLabel>>,
                 label_style_base: Option<u16>,
+                /// Trigger highlight ranges with their per-rule bg color.
+                trigger_highlights:
+                    Option<Vec<(rio_backend::crosswords::search::Match, [u8; 4])>>,
             }
 
             let (active_key, scaled_margin) = {
@@ -3959,6 +4057,8 @@ impl Screen<'_> {
                     rio_backend::event::TerminalDamage::Noop,
                 );
                 let hint_matches = ctx.renderable_content.hint_matches.clone();
+                let trigger_highlights =
+                    ctx.renderable_content.trigger_highlights.clone();
                 let is_active = *key == active_key;
                 // `focused_match` lives on `Screen::search_state` — it's
                 // a per-window state tied to whichever panel has search
@@ -4038,6 +4138,7 @@ impl Screen<'_> {
                     hovered_hyperlink,
                     hint_labels,
                     label_style_base,
+                    trigger_highlights,
                 });
             }
 
@@ -4140,6 +4241,7 @@ impl Screen<'_> {
                             p.hint_matches.as_deref(),
                             p.focused_match.as_ref(),
                             p.hovered_hyperlink,
+                            p.trigger_highlights.as_deref(),
                             y,
                             cols,
                             p.display_offset,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3526,7 +3526,15 @@ impl Screen<'_> {
         let tab_index = self.context_manager.current_index();
         for action in actions {
             let event = match action {
-                Action::Notify { title, body } => Event::Notify { title, body },
+                Action::Notify {
+                    title,
+                    body,
+                    urgency,
+                } => Event::Notify {
+                    title,
+                    body,
+                    urgency,
+                },
                 Action::Run { program, args } => Event::Run { program, args },
                 Action::SendText(text) => Event::SendText { text },
                 Action::Coprocess { program, args } => Event::Coprocess { program, args },

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1231,6 +1231,10 @@ impl Screen<'_> {
                         drop(terminal);
                         self.mark_dirty();
                     }
+                    Act::ResetTriggers => {
+                        self.triggers.reset();
+                        self.mark_dirty();
+                    }
                     Act::ToggleFullscreen => self.context_manager.toggle_full_screen(),
                     Act::ToggleAppearanceTheme => {
                         self.context_manager.toggle_appearance_theme();
@@ -3537,7 +3541,15 @@ impl Screen<'_> {
                 },
                 Action::Run { program, args } => Event::Run { program, args },
                 Action::SendText(text) => Event::SendText { text },
-                Action::Coprocess { program, args } => Event::Coprocess { program, args },
+                Action::Coprocess {
+                    program,
+                    args,
+                    stdin,
+                } => Event::Coprocess {
+                    program,
+                    args,
+                    stdin,
+                },
                 Action::TabColor(color) => {
                     self.context_manager
                         .set_custom_color(tab_index, Some(color));

--- a/frontends/rioterm/src/triggers.rs
+++ b/frontends/rioterm/src/triggers.rs
@@ -1,0 +1,753 @@
+use rio_backend::config::triggers::{TriggerAction, Triggers as TriggersConfig};
+use rio_backend::crosswords::grid::Dimensions;
+use rio_backend::crosswords::pos::{Column, Line, Pos};
+use rio_backend::crosswords::search::Match;
+use rio_backend::crosswords::square::Wide;
+use rio_backend::crosswords::{Crosswords, Mode};
+use rio_backend::event::{EventListener, TerminalDamage};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::hash::{Hash, Hasher};
+use std::time::{Duration, Instant};
+
+/// Longest line (chars) matched against trigger regexes.
+const LINE_SCAN_CAP: usize = 4096;
+
+/// Feedback-loop breaker for actions that write back into the pty
+/// (send_text / coprocess): the SAME rule may fire at most
+/// `WRITE_BURST_MAX` times within `WRITE_BURST_WINDOW`. A legitimate
+/// flow (login automation, a burst of [y/n] answers) stays far below the
+/// budget and pays zero latency; output produced by the action
+/// re-matching its own rule fires at render rate and hits the cap, so a
+/// loop is cut off instead of storming the pty. Read-only actions
+/// (notify/tab_color/run) are not budgeted.
+const WRITE_BURST_WINDOW: Duration = Duration::from_secs(1);
+const WRITE_BURST_MAX: u32 = 8;
+
+/// Scrollback lines (above the visible bottom) included when a feed_screen
+/// coprocess captures the screen, so a multi-line block that scrolled partly
+/// off the top is still captured whole.
+const FEED_HISTORY_LINES: i32 = 200;
+
+/// Upper bound (bytes) on a feed_screen payload. The consumer writes stdin
+/// before draining stdout, so a payload larger than the OS pipe buffer (~64KB
+/// on Linux) could deadlock; keep the capture comfortably under it. Truncated
+/// at a char boundary from the newest (bottom) end so the visible prompt is
+/// always kept.
+const FEED_PAYLOAD_CAP: usize = 48 * 1024;
+
+struct CompiledTrigger {
+    regex: onig::Regex,
+    instant: bool,
+    once: bool,
+    action: TriggerAction,
+    /// Stable identity (regex + action), independent of the rule's index in
+    /// the list, so `once` dedup survives a config reload that inserts or
+    /// reorders rules (an index would then point at a different rule).
+    id: u64,
+}
+
+/// The cursor (live prompt) line's fire state for one route: the row the
+/// cursor last sat on, and which (rule, match text) pairs already fired there.
+/// The set is cleared only when the cursor ROW NUMBER changes, so an action
+/// whose output echoes back into the same line (`send_text "y"` -> `[y/n]y`)
+/// does not re-fire the rule, yet a fresh prompt drawn at a new row does.
+#[derive(Default)]
+struct CursorFired {
+    /// The cursor's ABSOLUTE line (history + screen row) when these matches
+    /// fired — not the screen row, which stays constant on a scrolling
+    /// console and would suppress every re-drawn prompt as an echo.
+    row: i64,
+    fired: FxHashSet<(u64, u64)>,
+}
+
+/// Compiled trigger rules plus per-route dedup. Owned on the main thread
+/// (`onig::Regex` is `!Send`).
+#[derive(Default)]
+pub struct Triggers {
+    rules: Vec<CompiledTrigger>,
+    has_highlight: bool,
+    /// Any rule pipes the screen to a coprocess; gate the screen capture.
+    has_feed_screen: bool,
+    /// Per route, the set of (alt screen, absolute line, content hash,
+    /// finalized) we've already evaluated, so a given line+content fires
+    /// once. The absolute line is `scroll_epoch + row` (a never-clamped
+    /// physical-line identity; `history_size` stops at the scrollback
+    /// limit and is always 0 in the alt screen). The alt flag keeps the
+    /// two screens' keys apart so retention/purge on one never wipes the
+    /// other's, and swapping back doesn't mass re-fire.
+    seen: FxHashMap<usize, FxHashSet<(bool, i64, u64, bool)>>,
+    /// (route, stable rule id) of `once` rules that have already fired.
+    /// Retained across rebuild (config reload) — a stable id keeps the match
+    /// correct even when the rule list changes.
+    fired_once: FxHashSet<(usize, u64)>,
+    /// Per route, the cursor line's fire state (row + fired rule/match pairs).
+    /// A rule fires again on the cursor line only when a genuinely new match
+    /// appears; an echo of an action's own output, or the line merely growing
+    /// by a chunk, does not re-fire. See `CursorFired`.
+    cursor_fired: FxHashMap<usize, CursorFired>,
+    /// Per route, the last (screen_lines, columns) seen. A change means a
+    /// resize/font-zoom reflowed the grid, rewriting absolute line numbers and
+    /// wrapping, which invalidates `seen`'s (abs_line, content) keys; the next
+    /// scan then re-seeds `seen` without firing so reflow doesn't mass re-fire.
+    dims: FxHashMap<usize, (usize, usize)>,
+    /// Per (route, rule id): (window start, fires in window) for the
+    /// pty-writing burst budget. See WRITE_BURST_WINDOW's doc.
+    write_bursts: FxHashMap<(usize, u64), (Instant, u32)>,
+}
+
+/// A one-shot trigger action with captures already substituted.
+pub enum ResolvedAction {
+    Notify {
+        title: String,
+        body: String,
+        urgency: u8,
+    },
+    TabColor([f32; 4]),
+    Run {
+        program: String,
+        args: Vec<String>,
+    },
+    SendText(String),
+    Coprocess {
+        program: String,
+        args: Vec<String>,
+        stdin: Option<String>,
+    },
+}
+
+#[inline]
+fn rgba_u8(c: [f32; 4]) -> [u8; 4] {
+    [
+        (c[0] * 255.0).round() as u8,
+        (c[1] * 255.0).round() as u8,
+        (c[2] * 255.0).round() as u8,
+        (c[3] * 255.0).round() as u8,
+    ]
+}
+
+#[inline]
+fn hash_text(s: &str) -> u64 {
+    let mut h = rustc_hash::FxHasher::default();
+    s.hash(&mut h);
+    h.finish()
+}
+
+/// Stable identity for a rule: its regex plus a textual rendering of its
+/// action. Unlike the rule's list index, this survives inserting/reordering
+/// rules across a config reload, so `once` dedup stays attached to the same
+/// rule rather than being re-armed or leaking onto a different one.
+fn rule_id(regex: &str, action: &TriggerAction) -> u64 {
+    let mut h = rustc_hash::FxHasher::default();
+    regex.hash(&mut h);
+    format!("{action:?}").hash(&mut h);
+    h.finish()
+}
+
+/// Hash of the matched substring (whole match), used to dedup cursor-line
+/// fires by what matched rather than by the whole line's content, so an echo
+/// or a mid-line chunk append that reproduces an already-fired match is
+/// suppressed while a genuinely new match still fires.
+#[inline]
+fn match_hash(text: &str, caps: &onig::Captures) -> u64 {
+    match caps.pos(0) {
+        Some((s, e)) => hash_text(&text[s..e]),
+        None => 0,
+    }
+}
+
+impl Triggers {
+    pub fn new(config: &TriggersConfig) -> Self {
+        let mut rules = Vec::with_capacity(config.rules.len());
+        // Byte-identical duplicate rules would share an id (second `once`
+        // copy never fires, second instant copy swallowed by the shared
+        // cursor-line key); salt each repeat with its occurrence index —
+        // stable across reloads since file order is preserved.
+        let mut dups: FxHashMap<u64, u64> = FxHashMap::default();
+        for rule in &config.rules {
+            match onig::Regex::new(&rule.regex) {
+                Ok(regex) => {
+                    let base = rule_id(&rule.regex, &rule.action);
+                    let salt = dups.entry(base).or_insert(0);
+                    let id = base ^ salt.rotate_left(32).wrapping_add(*salt);
+                    *salt += 1;
+                    rules.push(CompiledTrigger {
+                        regex,
+                        instant: rule.instant,
+                        once: rule.once,
+                        id,
+                        action: rule.action.clone(),
+                    })
+                }
+                Err(err) => {
+                    tracing::warn!("invalid trigger regex {:?}: {}", rule.regex, err);
+                }
+            }
+        }
+        let has_highlight = rules
+            .iter()
+            .any(|r| matches!(r.action, TriggerAction::Highlight { .. }));
+        let has_feed_screen = rules.iter().any(|r| {
+            matches!(
+                r.action,
+                TriggerAction::Coprocess {
+                    feed_screen: true,
+                    ..
+                }
+            )
+        });
+        Self {
+            rules,
+            has_highlight,
+            has_feed_screen,
+            seen: FxHashMap::default(),
+            fired_once: FxHashSet::default(),
+            cursor_fired: FxHashMap::default(),
+            dims: FxHashMap::default(),
+            write_bursts: FxHashMap::default(),
+        }
+    }
+
+    /// Recompile rules from config (config hot-reload), PRESERVING the
+    /// per-route dedup state. `*self = Triggers::new(...)` would wipe
+    /// `seen`/`fired_once`, so the next scan would treat every line
+    /// already on screen as new — re-firing `once` rules and re-running
+    /// `send_text` (e.g. re-typing a saved credential) just because an
+    /// unrelated config file was edited. Only the rules change here.
+    pub fn rebuild(&mut self, config: &TriggersConfig) {
+        let fresh = Triggers::new(config);
+        self.rules = fresh.rules;
+        self.has_highlight = fresh.has_highlight;
+        self.has_feed_screen = fresh.has_feed_screen;
+        // seen / fired_once / cursor_fired / dims intentionally retained;
+        // fired_once is keyed on stable rule ids so retention stays correct
+        // even when the rule list is edited.
+    }
+
+    /// Forget a route's accumulated dedup state when its pane closes,
+    /// so `seen`/`fired_once`/`cursor_fired`/`dims` don't grow without bound
+    /// over a long session that opens and closes many tabs.
+    pub fn forget_route(&mut self, route_id: usize) {
+        self.seen.remove(&route_id);
+        self.cursor_fired.remove(&route_id);
+        self.dims.remove(&route_id);
+        self.fired_once.retain(|(r, _)| *r != route_id);
+        self.write_bursts.retain(|(r, _), _| *r != route_id);
+    }
+
+    /// Re-arm `once` rules so the automation can run again. Bound to
+    /// `ResetTriggers` (e.g. Alt+R). Drops only the cursor-line (non-finalized)
+    /// dedup, so instant rules (a `login:`/`Password:` prompt) re-fire on the
+    /// current live line even when it sits where one fired before. Finalized
+    /// (scrolled-past) content stays deduped, so a re-arm doesn't replay a
+    /// whole stale flow at once.
+    pub fn reset(&mut self) {
+        self.fired_once.clear();
+        for seen in self.seen.values_mut() {
+            seen.retain(|(_, _, _, finalized)| *finalized);
+        }
+        self.cursor_fired.clear();
+        self.write_bursts.clear();
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Match new output against the one-shot rules and return resolved
+    /// actions. Scans the live (non-scrolled) screen and dedups by
+    /// (line, content) so each line fires once: lines above the cursor are
+    /// "finalized" (non-instant rules); the cursor line fires instant rules.
+    pub fn scan<T: EventListener>(
+        &mut self,
+        route_id: usize,
+        term: &Crosswords<T>,
+    ) -> Vec<ResolvedAction> {
+        if self.rules.is_empty() {
+            return Vec::new();
+        }
+
+        let grid = &term.grid;
+        // Never-clamped physical-line identity base. `history_size` stops
+        // at the scrollback limit (and is 0 in the alt screen), which made
+        // `history + row` collapse once saturated: every scroll step gave
+        // each visible line a fresh key (mass re-fire) and pinned the
+        // cursor's key (prompts suppressed again). The epoch always
+        // advances with the rows.
+        let epoch = grid.scroll_epoch();
+        let cursor_row = grid.cursor.pos.row.0 as i64;
+        let screen_lines = grid.screen_lines();
+        let columns = term.columns();
+        let is_alt = term.mode().contains(Mode::ALT_SCREEN);
+
+        // A resize / font-zoom reflows the grid: absolute line numbers and
+        // wrapping are rewritten, so `seen`'s (abs_line, content) keys no
+        // longer identify the same output and every visible line would look
+        // new. Detect it by a dimension change and re-seed `seen` from the
+        // current screen WITHOUT firing, so already-visible finalized output
+        // is suppressed while genuinely new output still fires.
+        let reflowed = self.dims.insert(route_id, (screen_lines, columns))
+            != Some((screen_lines, columns));
+
+        // Skip when the terminal content did not change since the last render.
+        // scan() runs at the top of every render() — cursor blink, mouse hover
+        // and other UI-only repaints included — but only Full/Partial damage
+        // means cells actually changed. Noop/CursorOnly frames do no scan work
+        // (this walks and hashes visible lines under the terminal lock).
+        // A reflow always reports Full damage, so the re-seed above is reached.
+        let full_damage = match term.peek_damage_event() {
+            Some(TerminalDamage::Full) => true,
+            Some(TerminalDamage::Partial) => false,
+            _ => return Vec::new(),
+        };
+
+        // Captured lazily on the first feed_screen match (see below) so the
+        // common path — and every non-matching frame — pays nothing.
+        let mut screen_text: Option<String> = None;
+
+        let seen = self.seen.entry(route_id).or_default();
+        if reflowed {
+            seen.clear();
+        }
+        // Drop this screen's lines that scrolled out of the live view. The
+        // other screen's keys are kept for the swap back (leaving the alt
+        // screen must not make every restored primary line look new).
+        seen.retain(|(alt, abs, _, _)| *alt != is_alt || *abs >= epoch);
+        // A redrawing TUI (htop/watch) keeps producing new content hashes
+        // on the same rows, growing the set without bound. Cap it — but
+        // purge only this screen's keys, and re-seed silently below (like
+        // reflow) instead of letting the purge re-fire everything visible.
+        let mut purged = false;
+        if seen.len() > 8192 {
+            seen.retain(|(alt, _, _, _)| *alt != is_alt);
+            purged = true;
+        }
+        // Re-seed pass: record keys, fire nothing.
+        let reseed = reflowed || purged;
+
+        // Reset the cursor line's fire set when the cursor moved to a new
+        // absolute line, so a fresh prompt fires while an echo/growth on
+        // the same line cannot (a scrolling console keeps the cursor on
+        // the bottom SCREEN row forever, so the epoch-based line is the
+        // only identity that both advances with new prompts and stays put
+        // for an echo). A scrolled-back view (offset != 0) is not the live
+        // prompt, so leave the fire set untouched.
+        let live = grid.display_offset() == 0;
+        if live {
+            let cursor_abs = epoch + cursor_row;
+            let cf = self.cursor_fired.entry(route_id).or_default();
+            if cf.row != cursor_abs {
+                cf.row = cursor_abs;
+                cf.fired.clear();
+            }
+        }
+
+        let mut actions = Vec::new();
+        let mut text = String::new();
+        let mut cells: Vec<(u16, u16)> = Vec::new();
+        for i in 0..screen_lines {
+            // While scrolled back, the cursor row is still being written:
+            // matching it now would fire non-instant rules on a half-drawn
+            // line (truncated captures) and again once it finalizes. Skip
+            // it; it is evaluated when the view returns to the bottom.
+            if !live && (i as i64) == cursor_row {
+                continue;
+            }
+            // On a Partial frame only damaged rows can have changed; the
+            // rest keep both their content and their (epoch-based) keys.
+            // Re-seed passes must walk everything to rebuild the keys.
+            if !full_damage && !reseed && !term.peek_line_damaged(i) {
+                continue;
+            }
+            let abs = epoch + i as i64;
+            let is_cursor = live && (i as i64) == cursor_row;
+            let finalized = (i as i64) < cursor_row;
+            extract_match_line(term, Line(i as i32), &mut text, &mut cells);
+            if text.is_empty() {
+                continue;
+            }
+            let text: &str = if cells.len() > LINE_SCAN_CAP {
+                match text.char_indices().nth(LINE_SCAN_CAP) {
+                    Some((byte, _)) => &text[..byte],
+                    None => &text,
+                }
+            } else {
+                &text
+            };
+
+            // The cursor (live prompt) line is handled per-match below so an
+            // echo of an action's own output doesn't re-fire it (findings on
+            // send_text/coprocess feedback and growing instant matches). Other
+            // lines fire once each, keyed on (line, content, phase). When
+            // re-seeding (reflow / cap purge), record the key but don't fire.
+            if !is_cursor {
+                let fresh = seen.insert((is_alt, abs, hash_text(text), finalized));
+                if !fresh || reseed {
+                    continue;
+                }
+            }
+
+            for rule in &self.rules {
+                if matches!(rule.action, TriggerAction::Highlight { .. }) {
+                    continue;
+                }
+                // Finalized lines run non-instant rules; the cursor line
+                // runs instant rules (prompts with no trailing newline).
+                if rule.instant != is_cursor {
+                    continue;
+                }
+                if rule.once && self.fired_once.contains(&(route_id, rule.id)) {
+                    continue;
+                }
+                let mut matched = false;
+                for caps in rule.regex.captures_iter(text) {
+                    // On the cursor line, dedup by the matched substring so an
+                    // action's echo (or the line growing by a chunk) that
+                    // reproduces an already-fired match is suppressed, while a
+                    // new match on the same row still fires. On a re-seed
+                    // (reflow / purge) record the key silently — a resize
+                    // must not re-fire the still-visible prompt.
+                    if is_cursor {
+                        let key = (rule.id, match_hash(text, &caps));
+                        if !self
+                            .cursor_fired
+                            .get_mut(&route_id)
+                            .expect("cursor_fired seeded above")
+                            .fired
+                            .insert(key)
+                        {
+                            continue;
+                        }
+                        if reseed {
+                            continue;
+                        }
+                    }
+                    // Bound write-back feedback loops (see the const doc):
+                    // a fire inside the budget pays nothing; only a loop
+                    // exhausts it.
+                    if matches!(
+                        rule.action,
+                        TriggerAction::SendText { .. } | TriggerAction::Coprocess { .. }
+                    ) {
+                        let now = Instant::now();
+                        let burst = self
+                            .write_bursts
+                            .entry((route_id, rule.id))
+                            .or_insert((now, 0));
+                        if now - burst.0 > WRITE_BURST_WINDOW {
+                            *burst = (now, 0);
+                        }
+                        burst.1 += 1;
+                        if burst.1 > WRITE_BURST_MAX {
+                            tracing::warn!(
+                                "trigger write action exceeded {WRITE_BURST_MAX} fires/s; suppressing (feedback loop?)"
+                            );
+                            continue;
+                        }
+                    }
+                    if self.has_feed_screen
+                        && screen_text.is_none()
+                        && matches!(
+                            rule.action,
+                            TriggerAction::Coprocess {
+                                feed_screen: true,
+                                ..
+                            }
+                        )
+                    {
+                        screen_text = Some(capture_screen(term));
+                    }
+                    actions.push(resolve(&rule.action, &caps, screen_text.as_deref()));
+                    matched = true;
+                    // A `once` rule fires a single action per line even
+                    // when the pattern occurs several times — otherwise
+                    // it would emit N notifications/runs before
+                    // fired_once is set after the loop.
+                    if rule.once {
+                        break;
+                    }
+                }
+                if matched && rule.once {
+                    self.fired_once.insert((route_id, rule.id));
+                }
+            }
+        }
+        actions
+    }
+
+    /// Recompute highlight ranges over the visible region, or `None` when the
+    /// terminal content did not change since the last render so the caller
+    /// should keep the highlights it already has (passed as `prev`).
+    /// Highlights are a visual state, but re-running onig over every visible
+    /// line each frame — under the terminal lock, on cursor-blink and hover
+    /// repaints too — is wasted work when no cell changed. On a Partial frame
+    /// of the live view only damaged rows are rescanned; `prev`'s matches on
+    /// untouched rows are carried over. An empty `Vec` still means "clear",
+    /// e.g. when the last matching text scrolled off or the rules changed.
+    pub fn highlights<T: EventListener>(
+        &self,
+        term: &Crosswords<T>,
+        prev: Option<&[(Match, [u8; 4])]>,
+    ) -> Option<Vec<(Match, [u8; 4])>> {
+        if !self.has_highlight {
+            return Some(Vec::new());
+        }
+        let full_damage = match term.peek_damage_event() {
+            Some(TerminalDamage::Full) => true,
+            Some(TerminalDamage::Partial) => false,
+            _ => return None,
+        };
+        let grid = &term.grid;
+        let display_offset = grid.display_offset() as i32;
+        let topmost = grid.topmost_line().0;
+        let screen_lines = grid.screen_lines();
+        // Rescan damaged rows only when the view is live (line coords then
+        // equal screen rows, so prev's untouched entries stay valid); any
+        // scrolled view recomputes fully.
+        let incremental = !full_damage && display_offset == 0;
+        let mut out = Vec::new();
+        if incremental {
+            if let Some(prev) = prev {
+                out.extend(
+                    prev.iter()
+                        .filter(|(m, _)| {
+                            let row = m.start().row.0;
+                            row >= 0 && !term.peek_line_damaged(row as usize)
+                        })
+                        .cloned(),
+                );
+            }
+        }
+        let mut text = String::new();
+        let mut cells: Vec<(u16, u16)> = Vec::new();
+        for i in 0..screen_lines {
+            if incremental && !term.peek_line_damaged(i) {
+                continue;
+            }
+            let line = Line(i as i32 - display_offset);
+            if line.0 < topmost {
+                continue;
+            }
+            extract_match_line(term, line, &mut text, &mut cells);
+            if text.is_empty() {
+                continue;
+            }
+            for rule in &self.rules {
+                let TriggerAction::Highlight { color } = &rule.action else {
+                    continue;
+                };
+                let rgba = rgba_u8(*color);
+                // Cap matches per rule per line: a pathological pattern
+                // on adversarial output could otherwise push an unbounded
+                // number of ranges every frame (this runs under the
+                // terminal lock, on the render path).
+                for caps in rule.regex.captures_iter(&text).take(256) {
+                    if let Some((start, end)) = span(&text, &cells, &caps) {
+                        out.push((Pos::new(line, start)..=Pos::new(line, end), rgba));
+                    }
+                }
+            }
+        }
+        Some(out)
+    }
+}
+
+/// Fill `text` with one grid line's characters and `cells` with each
+/// character's (first, last) cell column. Wide-char spacer cells are
+/// skipped — with the padding spaces they'd otherwise inject, adjacent
+/// wide characters (CJK, emoji) could never match a regex — which is why
+/// the byte-offset -> column mapping needs the explicit `cells` table.
+/// Trailing NUL/whitespace is trimmed. Buffers are caller-owned so a
+/// screen walk reuses one allocation instead of two per line.
+fn extract_match_line<T: EventListener>(
+    term: &Crosswords<T>,
+    line: Line,
+    text: &mut String,
+    cells: &mut Vec<(u16, u16)>,
+) {
+    text.clear();
+    cells.clear();
+    let grid = &term.grid;
+    let mut keep_chars = 0;
+    let mut keep_bytes = 0;
+    for col in 0..grid.columns() {
+        let sq = &grid[line][Column(col)];
+        let wide = sq.wide();
+        if matches!(wide, Wide::Spacer | Wide::LeadingSpacer) {
+            continue;
+        }
+        let c = sq.c();
+        let end = if matches!(wide, Wide::Wide) {
+            col + 1
+        } else {
+            col
+        };
+        text.push(c);
+        cells.push((col as u16, end as u16));
+        if c != '\0' && !c.is_whitespace() {
+            keep_chars = cells.len();
+            keep_bytes = text.len();
+        }
+    }
+    cells.truncate(keep_chars);
+    text.truncate(keep_bytes);
+}
+
+/// Visible screen plus recent scrollback as one newline-joined string, for a
+/// feed_screen coprocess. Recent history is included so a multi-line block
+/// that has scrolled partly above the visible area is still captured whole.
+fn capture_screen<T: EventListener>(term: &Crosswords<T>) -> String {
+    let grid = &term.grid;
+    let screen_lines = grid.screen_lines() as i32;
+    let start = grid.topmost_line().0.max(-FEED_HISTORY_LINES);
+    let mut line = String::new();
+    let mut cells = Vec::new();
+    let mut text = String::new();
+    for i in start..screen_lines {
+        extract_match_line(term, Line(i), &mut line, &mut cells);
+        if i > start {
+            text.push('\n');
+        }
+        text.push_str(&line);
+    }
+    if text.len() <= FEED_PAYLOAD_CAP {
+        return text;
+    }
+    // Keep the newest end (visible prompt); drop the oldest scrollback.
+    let cut = text.len() - FEED_PAYLOAD_CAP;
+    match text.char_indices().find(|(i, _)| *i >= cut) {
+        Some((byte, _)) => text[byte..].to_string(),
+        None => text,
+    }
+}
+
+/// Match span as cell columns. onig reports byte offsets; `cells` maps
+/// each char index to its (first, last) cell column — wide characters
+/// cover two cells, so the mapping isn't 1:1.
+fn span(
+    text: &str,
+    cells: &[(u16, u16)],
+    caps: &onig::Captures,
+) -> Option<(Column, Column)> {
+    let (start_b, end_b) = caps.pos(0)?;
+    let start_char = text[..start_b].chars().count();
+    let end_char = text[..end_b].chars().count().saturating_sub(1);
+    let start = cells.get(start_char)?.0 as usize;
+    let end = cells.get(end_char.max(start_char))?.1 as usize;
+    Some((Column(start), Column(end.max(start))))
+}
+
+fn resolve(
+    action: &TriggerAction,
+    caps: &onig::Captures,
+    screen: Option<&str>,
+) -> ResolvedAction {
+    match action {
+        TriggerAction::Notify {
+            title,
+            body,
+            urgency,
+        } => ResolvedAction::Notify {
+            title: substitute(title, caps),
+            body: substitute(body, caps),
+            urgency: urgency.level(),
+        },
+        TriggerAction::TabColor { color } => ResolvedAction::TabColor(*color),
+        TriggerAction::Run { program, args } => ResolvedAction::Run {
+            program: program.clone(),
+            args: args.iter().map(|a| substitute(a, caps)).collect(),
+        },
+        TriggerAction::SendText { text } => {
+            ResolvedAction::SendText(substitute(text, caps))
+        }
+        TriggerAction::Coprocess {
+            program,
+            args,
+            feed_screen,
+        } => ResolvedAction::Coprocess {
+            program: program.clone(),
+            args: args.iter().map(|a| substitute(a, caps)).collect(),
+            stdin: if *feed_screen {
+                screen.map(str::to_owned)
+            } else {
+                None
+            },
+        },
+        // Handled by `highlights()`; `scan` skips it.
+        TriggerAction::Highlight { .. } => ResolvedAction::SendText(String::new()),
+    }
+}
+
+/// Expand `\0..\9` (whole match / capture groups) and `\\` in `template`.
+fn substitute(template: &str, caps: &onig::Captures) -> String {
+    if !template.contains('\\') {
+        return template.to_owned();
+    }
+    let mut out = String::with_capacity(template.len());
+    let mut chars = template.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            Some(d) if d.is_ascii_digit() => {
+                let n = (*d as u8 - b'0') as usize;
+                chars.next();
+                if let Some(group) = caps.at(n) {
+                    out.push_str(group);
+                }
+            }
+            Some('\\') => {
+                out.push('\\');
+                chars.next();
+            }
+            _ => out.push('\\'),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn caps<'a>(re: &str, text: &'a str) -> onig::Captures<'a> {
+        onig::Regex::new(re).unwrap().captures(text).unwrap()
+    }
+
+    #[test]
+    fn substitute_groups() {
+        let c = caps(r"error: (\w+) (\w+)", "error: disk full");
+        assert_eq!(substitute(r"\0", &c), "error: disk full");
+        assert_eq!(substitute(r"\1/\2", &c), "disk/full");
+        assert_eq!(substitute(r"\9", &c), "");
+        assert_eq!(substitute(r"a\\b", &c), r"a\b");
+        assert_eq!(substitute("plain", &c), "plain");
+    }
+
+    #[test]
+    fn rule_id_is_stable_and_distinct() {
+        let color = [0.0, 0.0, 0.0, 1.0];
+        let a = TriggerAction::TabColor { color };
+        let b = TriggerAction::SendText { text: "y\n".into() };
+        // Same regex + same action -> same id across calls (survives reload).
+        assert_eq!(rule_id("done", &a), rule_id("done", &a));
+        // A different regex or a different action -> different id.
+        assert_ne!(rule_id("done", &a), rule_id("finished", &a));
+        assert_ne!(rule_id("done", &a), rule_id("done", &b));
+    }
+
+    #[test]
+    fn match_hash_tracks_matched_substring() {
+        let re = onig::Regex::new(r"\[y/n\]").unwrap();
+        // The whole line grows as an echo appends, but the match text is the
+        // same, so the cursor-line dedup key is unchanged -> no re-fire.
+        let c1 = re.captures("Continue? [y/n]").unwrap();
+        let c2 = re.captures("Continue? [y/n]y").unwrap();
+        assert_eq!(
+            match_hash("Continue? [y/n]", &c1),
+            match_hash("Continue? [y/n]y", &c2)
+        );
+    }
+}

--- a/frontends/rioterm/src/triggers.rs
+++ b/frontends/rioterm/src/triggers.rs
@@ -32,11 +32,21 @@ pub struct Triggers {
 
 /// A one-shot trigger action with captures already substituted.
 pub enum ResolvedAction {
-    Notify { title: String, body: String },
+    Notify {
+        title: String,
+        body: String,
+        urgency: u8,
+    },
     TabColor([f32; 4]),
-    Run { program: String, args: Vec<String> },
+    Run {
+        program: String,
+        args: Vec<String>,
+    },
     SendText(String),
-    Coprocess { program: String, args: Vec<String> },
+    Coprocess {
+        program: String,
+        args: Vec<String>,
+    },
 }
 
 #[inline]
@@ -205,9 +215,14 @@ fn span(text: &str, caps: &onig::Captures) -> Option<(Column, Column)> {
 
 fn resolve(action: &TriggerAction, caps: &onig::Captures) -> ResolvedAction {
     match action {
-        TriggerAction::Notify { title, body } => ResolvedAction::Notify {
+        TriggerAction::Notify {
+            title,
+            body,
+            urgency,
+        } => ResolvedAction::Notify {
             title: substitute(title, caps),
             body: substitute(body, caps),
+            urgency: urgency.level(),
         },
         TriggerAction::TabColor { color } => ResolvedAction::TabColor(*color),
         TriggerAction::Run { program, args } => ResolvedAction::Run {

--- a/frontends/rioterm/src/triggers.rs
+++ b/frontends/rioterm/src/triggers.rs
@@ -11,9 +11,15 @@ use std::hash::{Hash, Hasher};
 /// Longest line (chars) matched against trigger regexes.
 const LINE_SCAN_CAP: usize = 4096;
 
+/// Scrollback lines (above the visible bottom) included when a feed_screen
+/// coprocess captures the screen, so a multi-line block that scrolled partly
+/// off the top is still captured whole.
+const FEED_HISTORY_LINES: i32 = 200;
+
 struct CompiledTrigger {
     regex: onig::Regex,
     instant: bool,
+    once: bool,
     action: TriggerAction,
 }
 
@@ -23,11 +29,21 @@ struct CompiledTrigger {
 pub struct Triggers {
     rules: Vec<CompiledTrigger>,
     has_highlight: bool,
+    /// Any rule pipes the screen to a coprocess; gate the screen capture.
+    has_feed_screen: bool,
     /// Per route, the set of (absolute line, content hash, finalized) we've
     /// already evaluated, so a given line+content fires once. Keyed on
     /// content rather than a cursor counter so prompt redraws and TUIs
     /// (which don't scroll) still register new output.
     seen: FxHashMap<usize, FxHashSet<(i64, u64, bool)>>,
+    /// (route, rule index) of `once` rules that have already fired. Reset on
+    /// rebuild (config reload).
+    fired_once: FxHashSet<(usize, usize)>,
+    /// Per route, the content hash of the cursor (live prompt) line last
+    /// evaluated. The cursor line re-fires whenever its content changes rather
+    /// than deduping forever, so a prompt that recurs at a redrawn position
+    /// (e.g. a second `login:` under tmux, which doesn't scroll) fires again.
+    last_cursor: FxHashMap<usize, u64>,
 }
 
 /// A one-shot trigger action with captures already substituted.
@@ -46,6 +62,7 @@ pub enum ResolvedAction {
     Coprocess {
         program: String,
         args: Vec<String>,
+        stdin: Option<String>,
     },
 }
 
@@ -74,6 +91,7 @@ impl Triggers {
                 Ok(regex) => rules.push(CompiledTrigger {
                     regex,
                     instant: rule.instant,
+                    once: rule.once,
                     action: rule.action.clone(),
                 }),
                 Err(err) => {
@@ -84,15 +102,41 @@ impl Triggers {
         let has_highlight = rules
             .iter()
             .any(|r| matches!(r.action, TriggerAction::Highlight { .. }));
+        let has_feed_screen = rules.iter().any(|r| {
+            matches!(
+                r.action,
+                TriggerAction::Coprocess {
+                    feed_screen: true,
+                    ..
+                }
+            )
+        });
         Self {
             rules,
             has_highlight,
+            has_feed_screen,
             seen: FxHashMap::default(),
+            fired_once: FxHashSet::default(),
+            last_cursor: FxHashMap::default(),
         }
     }
 
     pub fn rebuild(&mut self, config: &TriggersConfig) {
         *self = Triggers::new(config);
+    }
+
+    /// Re-arm `once` rules so the automation can run again. Bound to
+    /// `ResetTriggers` (e.g. Alt+R). Drops only the cursor-line (non-finalized)
+    /// dedup, so instant rules (a `login:`/`Password:` prompt) re-fire on the
+    /// current live line even when it sits where one fired before. Finalized
+    /// (scrolled-past) content stays deduped, so a re-arm doesn't replay a
+    /// whole stale flow at once.
+    pub fn reset(&mut self) {
+        self.fired_once.clear();
+        for seen in self.seen.values_mut() {
+            seen.retain(|(_, _, finalized)| *finalized);
+        }
+        self.last_cursor.clear();
     }
 
     #[inline]
@@ -122,6 +166,10 @@ impl Triggers {
         let cursor_row = grid.cursor.pos.row.0 as i64;
         let screen_lines = grid.screen_lines();
 
+        // Captured lazily on the first feed_screen match (see below) so the
+        // common path — and every non-matching frame — pays nothing.
+        let mut screen_text: Option<String> = None;
+
         let seen = self.seen.entry(route_id).or_default();
         // Drop lines that have scrolled out of the live view.
         seen.retain(|(abs, _, _)| *abs >= history);
@@ -143,13 +191,22 @@ impl Triggers {
                 &text
             };
 
-            // (line, content, phase) — re-evaluated only when the content
-            // changes, so unchanged lines cost just a hash lookup.
-            if !seen.insert((abs, hash_text(text), finalized)) {
+            let hash = hash_text(text);
+
+            // The live prompt (cursor line) re-fires when its content changes,
+            // so a prompt that recurs at a redrawn (non-scrolling) position —
+            // e.g. a second login: under tmux — isn't deduped forever. Other
+            // lines fire once each, keyed on (line, content, phase).
+            if (i as i64) == cursor_row {
+                if self.last_cursor.get(&route_id) == Some(&hash) {
+                    continue;
+                }
+                self.last_cursor.insert(route_id, hash);
+            } else if !seen.insert((abs, hash, finalized)) {
                 continue;
             }
 
-            for rule in &self.rules {
+            for (idx, rule) in self.rules.iter().enumerate() {
                 if matches!(rule.action, TriggerAction::Highlight { .. }) {
                     continue;
                 }
@@ -158,8 +215,28 @@ impl Triggers {
                 if rule.instant == finalized {
                     continue;
                 }
+                if rule.once && self.fired_once.contains(&(route_id, idx)) {
+                    continue;
+                }
+                let mut matched = false;
                 for caps in rule.regex.captures_iter(text) {
-                    actions.push(resolve(&rule.action, &caps));
+                    if self.has_feed_screen
+                        && screen_text.is_none()
+                        && matches!(
+                            rule.action,
+                            TriggerAction::Coprocess {
+                                feed_screen: true,
+                                ..
+                            }
+                        )
+                    {
+                        screen_text = Some(capture_screen(term));
+                    }
+                    actions.push(resolve(&rule.action, &caps, screen_text.as_deref()));
+                    matched = true;
+                }
+                if matched && rule.once {
+                    self.fired_once.insert((route_id, idx));
                 }
             }
         }
@@ -204,6 +281,19 @@ impl Triggers {
     }
 }
 
+/// Visible screen plus recent scrollback as one newline-joined string, for a
+/// feed_screen coprocess. Recent history is included so a multi-line block
+/// that has scrolled partly above the visible area is still captured whole.
+fn capture_screen<T: EventListener>(term: &Crosswords<T>) -> String {
+    let grid = &term.grid;
+    let screen_lines = grid.screen_lines() as i32;
+    let start = grid.topmost_line().0.max(-FEED_HISTORY_LINES);
+    (start..screen_lines)
+        .map(|i| extract_line_text(term, Line(i)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Match span as cell columns (onig reports byte offsets; columns are
 /// per-cell, one char each).
 fn span(text: &str, caps: &onig::Captures) -> Option<(Column, Column)> {
@@ -213,7 +303,11 @@ fn span(text: &str, caps: &onig::Captures) -> Option<(Column, Column)> {
     Some((Column(start), Column(end.max(start))))
 }
 
-fn resolve(action: &TriggerAction, caps: &onig::Captures) -> ResolvedAction {
+fn resolve(
+    action: &TriggerAction,
+    caps: &onig::Captures,
+    screen: Option<&str>,
+) -> ResolvedAction {
     match action {
         TriggerAction::Notify {
             title,
@@ -232,9 +326,18 @@ fn resolve(action: &TriggerAction, caps: &onig::Captures) -> ResolvedAction {
         TriggerAction::SendText { text } => {
             ResolvedAction::SendText(substitute(text, caps))
         }
-        TriggerAction::Coprocess { program, args } => ResolvedAction::Coprocess {
+        TriggerAction::Coprocess {
+            program,
+            args,
+            feed_screen,
+        } => ResolvedAction::Coprocess {
             program: program.clone(),
             args: args.iter().map(|a| substitute(a, caps)).collect(),
+            stdin: if *feed_screen {
+                screen.map(str::to_owned)
+            } else {
+                None
+            },
         },
         // Handled by `highlights()`; `scan` skips it.
         TriggerAction::Highlight { .. } => ResolvedAction::SendText(String::new()),

--- a/frontends/rioterm/src/triggers.rs
+++ b/frontends/rioterm/src/triggers.rs
@@ -1,0 +1,276 @@
+use crate::hints::extract_line_text;
+use rio_backend::config::triggers::{TriggerAction, Triggers as TriggersConfig};
+use rio_backend::crosswords::grid::Dimensions;
+use rio_backend::crosswords::pos::{Column, Line, Pos};
+use rio_backend::crosswords::search::Match;
+use rio_backend::crosswords::Crosswords;
+use rio_backend::event::EventListener;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::hash::{Hash, Hasher};
+
+/// Longest line (chars) matched against trigger regexes.
+const LINE_SCAN_CAP: usize = 4096;
+
+struct CompiledTrigger {
+    regex: onig::Regex,
+    instant: bool,
+    action: TriggerAction,
+}
+
+/// Compiled trigger rules plus per-route dedup. Owned on the main thread
+/// (`onig::Regex` is `!Send`).
+#[derive(Default)]
+pub struct Triggers {
+    rules: Vec<CompiledTrigger>,
+    has_highlight: bool,
+    /// Per route, the set of (absolute line, content hash, finalized) we've
+    /// already evaluated, so a given line+content fires once. Keyed on
+    /// content rather than a cursor counter so prompt redraws and TUIs
+    /// (which don't scroll) still register new output.
+    seen: FxHashMap<usize, FxHashSet<(i64, u64, bool)>>,
+}
+
+/// A one-shot trigger action with captures already substituted.
+pub enum ResolvedAction {
+    Notify { title: String, body: String },
+    TabColor([f32; 4]),
+    Run { program: String, args: Vec<String> },
+    SendText(String),
+    Coprocess { program: String, args: Vec<String> },
+}
+
+#[inline]
+fn rgba_u8(c: [f32; 4]) -> [u8; 4] {
+    [
+        (c[0] * 255.0).round() as u8,
+        (c[1] * 255.0).round() as u8,
+        (c[2] * 255.0).round() as u8,
+        (c[3] * 255.0).round() as u8,
+    ]
+}
+
+#[inline]
+fn hash_text(s: &str) -> u64 {
+    let mut h = rustc_hash::FxHasher::default();
+    s.hash(&mut h);
+    h.finish()
+}
+
+impl Triggers {
+    pub fn new(config: &TriggersConfig) -> Self {
+        let mut rules = Vec::with_capacity(config.rules.len());
+        for rule in &config.rules {
+            match onig::Regex::new(&rule.regex) {
+                Ok(regex) => rules.push(CompiledTrigger {
+                    regex,
+                    instant: rule.instant,
+                    action: rule.action.clone(),
+                }),
+                Err(err) => {
+                    tracing::warn!("invalid trigger regex {:?}: {}", rule.regex, err);
+                }
+            }
+        }
+        let has_highlight = rules
+            .iter()
+            .any(|r| matches!(r.action, TriggerAction::Highlight { .. }));
+        Self {
+            rules,
+            has_highlight,
+            seen: FxHashMap::default(),
+        }
+    }
+
+    pub fn rebuild(&mut self, config: &TriggersConfig) {
+        *self = Triggers::new(config);
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Match new output against the one-shot rules and return resolved
+    /// actions. Scans the live (non-scrolled) screen and dedups by
+    /// (line, content) so each line fires once: lines above the cursor are
+    /// "finalized" (non-instant rules); the cursor line fires instant rules.
+    pub fn scan<T: EventListener>(
+        &mut self,
+        route_id: usize,
+        term: &Crosswords<T>,
+    ) -> Vec<ResolvedAction> {
+        if self.rules.is_empty() {
+            return Vec::new();
+        }
+
+        let grid = &term.grid;
+        // Only the live bottom — don't re-fire history while scrolled back.
+        if grid.display_offset() != 0 {
+            return Vec::new();
+        }
+        let history = grid.history_size() as i64;
+        let cursor_row = grid.cursor.pos.row.0 as i64;
+        let screen_lines = grid.screen_lines();
+
+        let seen = self.seen.entry(route_id).or_default();
+        // Drop lines that have scrolled out of the live view.
+        seen.retain(|(abs, _, _)| *abs >= history);
+
+        let mut actions = Vec::new();
+        for i in 0..screen_lines {
+            let abs = history + i as i64;
+            let finalized = (i as i64) < cursor_row;
+            let text = extract_line_text(term, Line(i as i32));
+            if text.is_empty() {
+                continue;
+            }
+            let text: &str = if text.len() > LINE_SCAN_CAP {
+                match text.char_indices().nth(LINE_SCAN_CAP) {
+                    Some((byte, _)) => &text[..byte],
+                    None => &text,
+                }
+            } else {
+                &text
+            };
+
+            // (line, content, phase) — re-evaluated only when the content
+            // changes, so unchanged lines cost just a hash lookup.
+            if !seen.insert((abs, hash_text(text), finalized)) {
+                continue;
+            }
+
+            for rule in &self.rules {
+                if matches!(rule.action, TriggerAction::Highlight { .. }) {
+                    continue;
+                }
+                // Finalized lines run non-instant rules; the cursor line
+                // runs instant rules (prompts with no trailing newline).
+                if rule.instant == finalized {
+                    continue;
+                }
+                for caps in rule.regex.captures_iter(text) {
+                    actions.push(resolve(&rule.action, &caps));
+                }
+            }
+        }
+        actions
+    }
+
+    /// Recompute highlight ranges over the visible region. Highlights are a
+    /// visual state, re-evaluated each frame so they track the live text.
+    pub fn highlights<T: EventListener>(
+        &self,
+        term: &Crosswords<T>,
+    ) -> Vec<(Match, [u8; 4])> {
+        if !self.has_highlight {
+            return Vec::new();
+        }
+        let grid = &term.grid;
+        let display_offset = grid.display_offset() as i32;
+        let topmost = grid.topmost_line().0;
+        let mut out = Vec::new();
+        for i in 0..grid.screen_lines() {
+            let line = Line(i as i32 - display_offset);
+            if line.0 < topmost {
+                continue;
+            }
+            let text = extract_line_text(term, line);
+            if text.is_empty() {
+                continue;
+            }
+            for rule in &self.rules {
+                let TriggerAction::Highlight { color } = &rule.action else {
+                    continue;
+                };
+                let rgba = rgba_u8(*color);
+                for caps in rule.regex.captures_iter(&text) {
+                    if let Some((start, end)) = span(&text, &caps) {
+                        out.push((Pos::new(line, start)..=Pos::new(line, end), rgba));
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Match span as cell columns (onig reports byte offsets; columns are
+/// per-cell, one char each).
+fn span(text: &str, caps: &onig::Captures) -> Option<(Column, Column)> {
+    let (start_b, end_b) = caps.pos(0)?;
+    let start = text[..start_b].chars().count();
+    let end = text[..end_b].chars().count().saturating_sub(1);
+    Some((Column(start), Column(end.max(start))))
+}
+
+fn resolve(action: &TriggerAction, caps: &onig::Captures) -> ResolvedAction {
+    match action {
+        TriggerAction::Notify { title, body } => ResolvedAction::Notify {
+            title: substitute(title, caps),
+            body: substitute(body, caps),
+        },
+        TriggerAction::TabColor { color } => ResolvedAction::TabColor(*color),
+        TriggerAction::Run { program, args } => ResolvedAction::Run {
+            program: program.clone(),
+            args: args.iter().map(|a| substitute(a, caps)).collect(),
+        },
+        TriggerAction::SendText { text } => {
+            ResolvedAction::SendText(substitute(text, caps))
+        }
+        TriggerAction::Coprocess { program, args } => ResolvedAction::Coprocess {
+            program: program.clone(),
+            args: args.iter().map(|a| substitute(a, caps)).collect(),
+        },
+        // Handled by `highlights()`; `scan` skips it.
+        TriggerAction::Highlight { .. } => ResolvedAction::SendText(String::new()),
+    }
+}
+
+/// Expand `\0..\9` (whole match / capture groups) and `\\` in `template`.
+fn substitute(template: &str, caps: &onig::Captures) -> String {
+    if !template.contains('\\') {
+        return template.to_owned();
+    }
+    let mut out = String::with_capacity(template.len());
+    let mut chars = template.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            Some(d) if d.is_ascii_digit() => {
+                let n = (*d as u8 - b'0') as usize;
+                chars.next();
+                if let Some(group) = caps.at(n) {
+                    out.push_str(group);
+                }
+            }
+            Some('\\') => {
+                out.push('\\');
+                chars.next();
+            }
+            _ => out.push('\\'),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn caps<'a>(re: &str, text: &'a str) -> onig::Captures<'a> {
+        onig::Regex::new(re).unwrap().captures(text).unwrap()
+    }
+
+    #[test]
+    fn substitute_groups() {
+        let c = caps(r"error: (\w+) (\w+)", "error: disk full");
+        assert_eq!(substitute(r"\0", &c), "error: disk full");
+        assert_eq!(substitute(r"\1/\2", &c), "disk/full");
+        assert_eq!(substitute(r"\9", &c), "");
+        assert_eq!(substitute(r"a\\b", &c), r"a\b");
+        assert_eq!(substitute("plain", &c), "plain");
+    }
+}

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -11,6 +11,7 @@ pub mod platform;
 pub mod renderer;
 pub mod theme;
 pub mod title;
+pub mod triggers;
 pub mod window;
 
 use crate::ansi::CursorShape;
@@ -24,6 +25,7 @@ use crate::config::navigation::Navigation;
 use crate::config::platform::{Platform, PlatformConfig};
 use crate::config::renderer::Renderer;
 use crate::config::title::Title;
+use crate::config::triggers::Triggers;
 use crate::config::window::Window;
 use colors::Colors;
 use serde::{Deserialize, Serialize};
@@ -38,6 +40,7 @@ use tracing::warn;
 pub enum ConfigError {
     ErrLoadingConfig(String),
     ErrLoadingTheme(String),
+    ErrLoadingTriggers(String),
     PathNotFound,
 }
 
@@ -158,6 +161,9 @@ pub struct Config {
     pub draw_bold_text_with_light_colors: bool,
     #[serde(default = "Hints::default")]
     pub hints: Hints,
+    /// Loaded from the dedicated `triggers.toml`, never from `config.toml`.
+    #[serde(skip)]
+    pub triggers: Triggers,
     #[serde(default = "Bell::default")]
     pub bell: Bell,
     #[serde(default = "default_bool_true", rename = "enable-scroll-bar")]
@@ -219,6 +225,11 @@ pub fn config_dir_path() -> PathBuf {
 #[inline]
 pub fn config_file_path() -> PathBuf {
     config_dir_path().join("config.toml")
+}
+
+#[inline]
+pub fn triggers_file_path() -> PathBuf {
+    config_dir_path().join("triggers.toml")
 }
 
 #[inline]
@@ -353,6 +364,18 @@ impl Config {
         }
     }
 
+    fn load_triggers(path: &PathBuf) -> Result<Triggers, String> {
+        if path.exists() {
+            let content = std::fs::read_to_string(path).unwrap();
+            match toml::from_str::<Triggers>(&content) {
+                Ok(decoded) => Ok(decoded),
+                Err(err_message) => Err(format!("error parsing: {err_message:?}")),
+            }
+        } else {
+            Err(String::from("filepath does not exist"))
+        }
+    }
+
     pub fn to_string(&self) -> Result<String, toml::ser::Error> {
         toml::to_string(self)
     }
@@ -453,6 +476,18 @@ impl Config {
                                 && adaptive_colors.dark.is_some()
                             {
                                 decoded.adaptive_colors = Some(adaptive_colors);
+                            }
+                        }
+
+                        let triggers_path = triggers_file_path();
+                        if triggers_path.exists() {
+                            match Config::load_triggers(&triggers_path) {
+                                Ok(loaded) => decoded.triggers = loaded,
+                                Err(err_message) => {
+                                    return Err(ConfigError::ErrLoadingTriggers(
+                                        err_message,
+                                    ));
+                                }
                             }
                         }
 
@@ -660,6 +695,7 @@ impl Default for Config {
             hide_cursor_when_typing: false,
             draw_bold_text_with_light_colors: false,
             hints: Hints::default(),
+            triggers: Triggers::default(),
             bell: Bell::default(),
             enable_scroll_bar: true,
             scrollback_history_limit: default_scrollback_history_limit(),

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -11,6 +11,7 @@ pub mod platform;
 pub mod renderer;
 pub mod theme;
 pub mod title;
+pub mod triggers;
 pub mod window;
 
 use crate::ansi::CursorShape;
@@ -24,6 +25,7 @@ use crate::config::navigation::Navigation;
 use crate::config::platform::{Platform, PlatformConfig};
 use crate::config::renderer::Renderer;
 use crate::config::title::Title;
+use crate::config::triggers::Triggers;
 use crate::config::window::Window;
 use colors::Colors;
 use serde::{Deserialize, Serialize};
@@ -38,6 +40,7 @@ use tracing::warn;
 pub enum ConfigError {
     ErrLoadingConfig(String),
     ErrLoadingTheme(String),
+    ErrLoadingTriggers(String),
     PathNotFound,
 }
 
@@ -158,6 +161,15 @@ pub struct Config {
     pub draw_bold_text_with_light_colors: bool,
     #[serde(default = "Hints::default")]
     pub hints: Hints,
+    /// Loaded from the dedicated `triggers.toml`, never from `config.toml`.
+    #[serde(skip)]
+    pub triggers: Triggers,
+    /// Parse error when triggers.toml exists but failed to load, so a
+    /// hot-reload can keep the previously-live rules instead of silently
+    /// replacing them with this (empty) default, and the UI can surface
+    /// the message the same way a config.toml error is surfaced.
+    #[serde(skip)]
+    pub triggers_load_error: Option<String>,
     #[serde(default = "Bell::default")]
     pub bell: Bell,
     #[serde(default = "default_bool_true", rename = "enable-scroll-bar")]
@@ -219,6 +231,11 @@ pub fn config_dir_path() -> PathBuf {
 #[inline]
 pub fn config_file_path() -> PathBuf {
     config_dir_path().join("config.toml")
+}
+
+#[inline]
+pub fn triggers_file_path() -> PathBuf {
+    config_dir_path().join("triggers.toml")
 }
 
 #[inline]
@@ -353,6 +370,40 @@ impl Config {
         }
     }
 
+    fn load_triggers(path: &PathBuf) -> Result<Triggers, String> {
+        if path.exists() {
+            let content = std::fs::read_to_string(path)
+                .map_err(|err| format!("error reading: {err}"))?;
+            match toml::from_str::<Triggers>(&content) {
+                Ok(decoded) => Ok(decoded),
+                Err(err_message) => Err(format!("error parsing: {err_message:?}")),
+            }
+        } else {
+            Err(String::from("filepath does not exist"))
+        }
+    }
+
+    /// Load `triggers.toml` into `config`, if present. A parse error only
+    /// records the message and is logged: a triggers typo must not
+    /// discard the rest of a live config (fonts, colors, binds) by turning
+    /// into a whole-config load failure. The recorded error lets a
+    /// hot-reload keep the previously-live rules rather than silently
+    /// wiping them with this config's empty default, and gives the UI a
+    /// message to surface.
+    fn apply_triggers(config: &mut Config) {
+        let triggers_path = triggers_file_path();
+        if !triggers_path.exists() {
+            return;
+        }
+        match Config::load_triggers(&triggers_path) {
+            Ok(loaded) => config.triggers = loaded,
+            Err(err_message) => {
+                warn!("failed to load triggers.toml: {err_message}");
+                config.triggers_load_error = Some(err_message);
+            }
+        }
+    }
+
     pub fn to_string(&self) -> Result<String, toml::ser::Error> {
         toml::to_string(self)
     }
@@ -456,6 +507,8 @@ impl Config {
                             }
                         }
 
+                        Config::apply_triggers(&mut decoded);
+
                         Ok(decoded)
                     }
                     Err(err_message) => {
@@ -467,7 +520,11 @@ impl Config {
                 }
             }
         } else {
-            Err(ConfigError::PathNotFound)
+            // No config.toml, but triggers.toml is loaded independently so a
+            // triggers-only setup still works.
+            let mut decoded = Config::default();
+            Config::apply_triggers(&mut decoded);
+            Ok(decoded)
         }
     }
 
@@ -665,6 +722,8 @@ impl Default for Config {
             hide_cursor_when_typing: false,
             draw_bold_text_with_light_colors: false,
             hints: Hints::default(),
+            triggers: Triggers::default(),
+            triggers_load_error: None,
             bell: Bell::default(),
             enable_scroll_bar: true,
             scrollback_history_limit: default_scrollback_history_limit(),

--- a/rio-backend/src/config/triggers.rs
+++ b/rio-backend/src/config/triggers.rs
@@ -26,6 +26,30 @@ pub struct Trigger {
     pub action: TriggerAction,
 }
 
+/// Desktop-notification urgency. `critical` banners even while rio is the
+/// focused window — GNOME suppresses normal banners from the focused app and
+/// only files them in the notification list — at the cost of GNOME keeping
+/// critical notifications on screen until dismissed.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Urgency {
+    Low,
+    #[default]
+    Normal,
+    Critical,
+}
+
+impl Urgency {
+    /// freedesktop `urgency` hint level.
+    pub fn level(self) -> u8 {
+        match self {
+            Urgency::Low => 0,
+            Urgency::Normal => 1,
+            Urgency::Critical => 2,
+        }
+    }
+}
+
 /// `\0..\9` in textual parameters expand to the whole match and capture
 /// groups, respectively.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -36,6 +60,8 @@ pub enum TriggerAction {
         title: String,
         #[serde(default)]
         body: String,
+        #[serde(default)]
+        urgency: Urgency,
     },
 
     /// Set the tab color.
@@ -94,7 +120,7 @@ mod tests {
             [[triggers.rules]]
             regex = "error: (.*)"
             [triggers.rules.action]
-            notify = { title = "Error", body = "\\1" }
+            notify = { title = "Error", body = "\\1", urgency = "critical" }
 
             [[triggers.rules]]
             regex = "(?i)warn"
@@ -127,7 +153,10 @@ mod tests {
         assert_eq!(triggers.rules.len(), 6);
         assert!(matches!(
             triggers.rules[0].action,
-            TriggerAction::Notify { .. }
+            TriggerAction::Notify {
+                urgency: Urgency::Critical,
+                ..
+            }
         ));
         assert!(triggers.rules[1].instant);
         assert!(matches!(

--- a/rio-backend/src/config/triggers.rs
+++ b/rio-backend/src/config/triggers.rs
@@ -21,6 +21,12 @@ pub struct Trigger {
     #[serde(default)]
     pub instant: bool,
 
+    /// Fire at most once until the config is reloaded. Lets a rule drive one
+    /// step of a sequence (e.g. a login probe) without re-firing when the
+    /// same prompt reappears.
+    #[serde(default)]
+    pub once: bool,
+
     /// The action to perform. Externally tagged so the action's key names
     /// it, mirroring the `[hints]` config style.
     pub action: TriggerAction,
@@ -91,6 +97,11 @@ pub enum TriggerAction {
         program: String,
         #[serde(default)]
         args: Vec<String>,
+        /// Pipe the visible screen to the command's stdin. Lets the command
+        /// see multi-line context (e.g. a wrapped block) that a single
+        /// per-line capture group can't carry.
+        #[serde(default)]
+        feed_screen: bool,
     },
 }
 
@@ -140,6 +151,7 @@ mod tests {
 
             [[triggers.rules]]
             regex = "password:"
+            once = true
             [triggers.rules.action]
             send_text = { text = "hunter2\n" }
 
@@ -163,6 +175,7 @@ mod tests {
             triggers.rules[1].action,
             TriggerAction::Highlight { .. }
         ));
+        assert!(triggers.rules[4].once);
         assert!(matches!(
             triggers.rules[5].action,
             TriggerAction::Coprocess { .. }

--- a/rio-backend/src/config/triggers.rs
+++ b/rio-backend/src/config/triggers.rs
@@ -1,0 +1,158 @@
+use crate::config::colors::{deserialize_to_arr, ColorArray};
+use serde::{Deserialize, Serialize};
+
+/// Triggers configuration, loaded from a dedicated `triggers.toml` so the
+/// file's top level is the rule list (`[[rules]]`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct Triggers {
+    #[serde(default)]
+    pub rules: Vec<Trigger>,
+}
+
+/// A single trigger rule: a regex matched against terminal output and the
+/// action to perform on a match.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Trigger {
+    /// Oniguruma regex matched against a line of terminal output.
+    pub regex: String,
+
+    /// Fire mid-line on every output batch instead of only when the line is
+    /// finalized by a newline / cursor move.
+    #[serde(default)]
+    pub instant: bool,
+
+    /// The action to perform. Externally tagged so the action's key names
+    /// it, mirroring the `[hints]` config style.
+    pub action: TriggerAction,
+}
+
+/// `\0..\9` in textual parameters expand to the whole match and capture
+/// groups, respectively.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerAction {
+    /// Post a desktop notification.
+    Notify {
+        title: String,
+        #[serde(default)]
+        body: String,
+    },
+
+    /// Set the tab color.
+    TabColor {
+        #[serde(deserialize_with = "deserialize_to_arr")]
+        color: ColorArray,
+    },
+
+    /// Spawn a detached command (output discarded).
+    Run {
+        program: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+
+    /// Highlight the matched text.
+    Highlight {
+        #[serde(deserialize_with = "deserialize_to_arr")]
+        color: ColorArray,
+    },
+
+    /// Write text into the matched session's PTY.
+    SendText { text: String },
+
+    /// Run a command and write its stdout into the matched session's PTY.
+    Coprocess {
+        program: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct Root {
+        #[serde(default)]
+        triggers: Triggers,
+    }
+
+    fn parse(content: &str) -> Triggers {
+        toml::from_str::<Root>(content).unwrap().triggers
+    }
+
+    #[test]
+    fn empty_is_default() {
+        assert_eq!(parse("").rules.len(), 0);
+    }
+
+    #[test]
+    fn parses_each_action() {
+        let triggers = parse(
+            r##"
+            [[triggers.rules]]
+            regex = "error: (.*)"
+            [triggers.rules.action]
+            notify = { title = "Error", body = "\\1" }
+
+            [[triggers.rules]]
+            regex = "(?i)warn"
+            instant = true
+            [triggers.rules.action]
+            highlight = { color = "#FFAA00" }
+
+            [[triggers.rules]]
+            regex = "done"
+            [triggers.rules.action]
+            tab_color = { color = "#00FF00" }
+
+            [[triggers.rules]]
+            regex = "deploy"
+            [triggers.rules.action]
+            run = { program = "notify-send", args = ["deploy"] }
+
+            [[triggers.rules]]
+            regex = "password:"
+            [triggers.rules.action]
+            send_text = { text = "hunter2\n" }
+
+            [[triggers.rules]]
+            regex = "now"
+            [triggers.rules.action]
+            coprocess = { program = "date" }
+        "##,
+        );
+
+        assert_eq!(triggers.rules.len(), 6);
+        assert!(matches!(
+            triggers.rules[0].action,
+            TriggerAction::Notify { .. }
+        ));
+        assert!(triggers.rules[1].instant);
+        assert!(matches!(
+            triggers.rules[1].action,
+            TriggerAction::Highlight { .. }
+        ));
+        assert!(matches!(
+            triggers.rules[5].action,
+            TriggerAction::Coprocess { .. }
+        ));
+    }
+
+    #[test]
+    fn regex_compiles() {
+        for rule in parse(
+            r#"
+            [[triggers.rules]]
+            regex = "error: (.*)"
+            [triggers.rules.action]
+            notify = { title = "e", body = "\\1" }
+        "#,
+        )
+        .rules
+        {
+            onig::Regex::new(&rule.regex).expect("regex compiles");
+        }
+    }
+}

--- a/rio-backend/src/config/triggers.rs
+++ b/rio-backend/src/config/triggers.rs
@@ -1,0 +1,208 @@
+use crate::config::colors::{deserialize_to_arr, ColorArray};
+use serde::{Deserialize, Serialize};
+
+/// Triggers configuration, loaded from a dedicated `triggers.toml` so the
+/// file's top level is the rule list (`[[rules]]`).
+///
+/// Scanning scope: rules run against the FOCUSED pane's output as it
+/// renders. A pane in a background tab is not scanned until it is
+/// focused again, so a notify rule fires when you switch to that tab,
+/// not at the moment the text appeared.
+///
+/// Substituted captures (`\1`...) in `run`/`coprocess` args come from
+/// untrusted terminal output; no shell is involved and words are never
+/// re-split, but a capture can begin with `-`. Put `--` before capture
+/// arguments when the program supports it, e.g.
+/// `run = { program = "notify-send", args = ["--", "\1"] }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct Triggers {
+    #[serde(default)]
+    pub rules: Vec<Trigger>,
+}
+
+/// A single trigger rule: a regex matched against terminal output and the
+/// action to perform on a match.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Trigger {
+    /// Oniguruma regex matched against a line of terminal output.
+    pub regex: String,
+
+    /// Fire mid-line on every output batch instead of only when the line is
+    /// finalized by a newline / cursor move.
+    #[serde(default)]
+    pub instant: bool,
+
+    /// Fire at most once until the config is reloaded. Lets a rule drive one
+    /// step of a sequence (e.g. a login probe) without re-firing when the
+    /// same prompt reappears.
+    #[serde(default)]
+    pub once: bool,
+
+    /// The action to perform. Externally tagged so the action's key names
+    /// it, mirroring the `[hints]` config style.
+    pub action: TriggerAction,
+}
+
+/// Desktop-notification urgency. `critical` banners even while rio is the
+/// focused window — GNOME suppresses normal banners from the focused app and
+/// only files them in the notification list — at the cost of GNOME keeping
+/// critical notifications on screen until dismissed.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Urgency {
+    Low,
+    #[default]
+    Normal,
+    Critical,
+}
+
+impl Urgency {
+    /// freedesktop `urgency` hint level.
+    pub fn level(self) -> u8 {
+        match self {
+            Urgency::Low => 0,
+            Urgency::Normal => 1,
+            Urgency::Critical => 2,
+        }
+    }
+}
+
+/// `\0..\9` in textual parameters expand to the whole match and capture
+/// groups, respectively.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerAction {
+    /// Post a desktop notification.
+    Notify {
+        title: String,
+        #[serde(default)]
+        body: String,
+        #[serde(default)]
+        urgency: Urgency,
+    },
+
+    /// Set the tab color.
+    TabColor {
+        #[serde(deserialize_with = "deserialize_to_arr")]
+        color: ColorArray,
+    },
+
+    /// Spawn a detached command (output discarded).
+    Run {
+        program: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+
+    /// Highlight the matched text.
+    Highlight {
+        #[serde(deserialize_with = "deserialize_to_arr")]
+        color: ColorArray,
+    },
+
+    /// Write text into the matched session's PTY.
+    SendText { text: String },
+
+    /// Run a command and write its stdout into the matched session's PTY.
+    Coprocess {
+        program: String,
+        #[serde(default)]
+        args: Vec<String>,
+        /// Pipe the visible screen to the command's stdin. Lets the command
+        /// see multi-line context (e.g. a wrapped block) that a single
+        /// per-line capture group can't carry.
+        #[serde(default)]
+        feed_screen: bool,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `triggers.toml` puts the rule list at the file's top level (`[[rules]]`,
+    /// loaded as `Triggers` directly), so the tests parse the same shape rather
+    /// than a `[[triggers.rules]]` wrapper that never appears in the real file.
+    fn parse(content: &str) -> Triggers {
+        toml::from_str::<Triggers>(content).unwrap()
+    }
+
+    #[test]
+    fn empty_is_default() {
+        assert_eq!(parse("").rules.len(), 0);
+    }
+
+    #[test]
+    fn parses_each_action() {
+        let triggers = parse(
+            r##"
+            [[rules]]
+            regex = "error: (.*)"
+            [rules.action]
+            notify = { title = "Error", body = "\\1", urgency = "critical" }
+
+            [[rules]]
+            regex = "(?i)warn"
+            instant = true
+            [rules.action]
+            highlight = { color = "#FFAA00" }
+
+            [[rules]]
+            regex = "done"
+            [rules.action]
+            tab_color = { color = "#00FF00" }
+
+            [[rules]]
+            regex = "deploy"
+            [rules.action]
+            run = { program = "notify-send", args = ["deploy"] }
+
+            [[rules]]
+            regex = "password:"
+            once = true
+            [rules.action]
+            send_text = { text = "hunter2\n" }
+
+            [[rules]]
+            regex = "now"
+            [rules.action]
+            coprocess = { program = "date" }
+        "##,
+        );
+
+        assert_eq!(triggers.rules.len(), 6);
+        assert!(matches!(
+            triggers.rules[0].action,
+            TriggerAction::Notify {
+                urgency: Urgency::Critical,
+                ..
+            }
+        ));
+        assert!(triggers.rules[1].instant);
+        assert!(matches!(
+            triggers.rules[1].action,
+            TriggerAction::Highlight { .. }
+        ));
+        assert!(triggers.rules[4].once);
+        assert!(matches!(
+            triggers.rules[5].action,
+            TriggerAction::Coprocess { .. }
+        ));
+    }
+
+    #[test]
+    fn regex_compiles() {
+        for rule in parse(
+            r#"
+            [[rules]]
+            regex = "error: (.*)"
+            [rules.action]
+            notify = { title = "e", body = "\\1" }
+        "#,
+        )
+        .rules
+        {
+            onig::Regex::new(&rule.regex).expect("regex compiles");
+        }
+    }
+}

--- a/rio-backend/src/crosswords/grid/mod.rs
+++ b/rio-backend/src/crosswords/grid/mod.rs
@@ -59,6 +59,14 @@ pub struct Grid<T> {
     /// Maximum number of lines in history.
     max_scroll_limit: usize,
 
+    /// Net lines the whole screen has scrolled over the grid's lifetime
+    /// (up minus down), NEVER clamped — unlike `history_size`, which stops
+    /// growing at `max_scroll_limit` (and is always 0 for the alt grid).
+    /// `scroll_epoch + screen_row` therefore stays a stable identity for a
+    /// physical line across scrolling even after the scrollback saturates,
+    /// which per-line dedup (terminal triggers) relies on.
+    scroll_epoch: i64,
+
     /// Total lines ever evicted off the scrollback ring (dropped from
     /// history at the cap, shrunk by a config change, or purged by
     /// `clear_history`). Together with `history_size` this defines a
@@ -235,6 +243,7 @@ impl<T: GridSquare + Default + PartialEq + Clone> Grid<T> {
         Grid {
             raw: Storage::with_capacity(lines, columns),
             max_scroll_limit,
+            scroll_epoch: 0,
             total_lines_scrolled: 0,
             track_reflow_remap: false,
             reflow_remap: None,
@@ -246,6 +255,13 @@ impl<T: GridSquare + Default + PartialEq + Clone> Grid<T> {
             style_set: crate::crosswords::style::StyleSet::new(),
             extras_table: ExtrasTable::new(),
         }
+    }
+
+    /// Net lines the screen has scrolled (up minus down), never clamped by
+    /// the history limit. See the field doc.
+    #[inline]
+    pub fn scroll_epoch(&self) -> i64 {
+        self.scroll_epoch
     }
 
     /// Update the size of the scrollback history.
@@ -300,6 +316,13 @@ impl<T: GridSquare + Default + PartialEq + Clone> Grid<T> {
             }
 
             return;
+        }
+
+        // Screen rows shift down when the region starts at the top: move
+        // the epoch back so `scroll_epoch + row` still names the same
+        // physical line (mirror of the scroll_up advance).
+        if region.start == 0 {
+            self.scroll_epoch -= positions as i64;
         }
 
         // Which implementation we can use depends on the existence of a scrollback history.
@@ -385,6 +408,11 @@ impl<T: GridSquare + Default + PartialEq + Clone> Grid<T> {
 
         // Only rotate the entire history if the active region starts at the top.
         if region.start == 0 {
+            // Every screen row's content moves up: advance the epoch so
+            // `scroll_epoch + row` keeps identifying the same physical
+            // line even when the history below is already saturated.
+            self.scroll_epoch += positions as i64;
+
             // Create scrollback for the new lines. Whatever the cap
             // refuses to grow is evicted off the ring instead.
             let grown = min(positions, self.max_scroll_limit - self.history_size());

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -604,6 +604,15 @@ impl<U: EventListener> Crosswords<U> {
         }
     }
 
+    /// Non-destructive per-line damage probe for `Partial` frames, so a
+    /// screen-walking consumer (terminal triggers) can skip lines whose
+    /// cells did not change. Unknown lines report damaged (safe side);
+    /// full damage marks every line damaged.
+    #[inline]
+    pub fn peek_line_damaged(&self, line: usize) -> bool {
+        self.damage.full || self.damage.lines.get(line).is_none_or(|l| l.is_damaged())
+    }
+
     #[inline]
     pub fn reset_damage(&mut self) {
         self.damage.reset();

--- a/rio-backend/src/error/mod.rs
+++ b/rio-backend/src/error/mod.rs
@@ -33,6 +33,10 @@ impl From<ConfigError> for RioError {
                 report: RioErrorType::InvalidConfigurationTheme(message),
                 level: RioErrorLevel::Warning,
             },
+            ConfigError::ErrLoadingTriggers(message) => RioError {
+                report: RioErrorType::InvalidConfigurationFormat(message),
+                level: RioErrorLevel::Warning,
+            },
             ConfigError::PathNotFound => RioError {
                 report: RioErrorType::ConfigurationNotFound,
                 level: RioErrorLevel::Warning,

--- a/rio-backend/src/error/mod.rs
+++ b/rio-backend/src/error/mod.rs
@@ -33,6 +33,10 @@ impl From<ConfigError> for RioError {
                 report: RioErrorType::InvalidConfigurationTheme(message),
                 level: RioErrorLevel::Warning,
             },
+            ConfigError::ErrLoadingTriggers(message) => RioError {
+                report: RioErrorType::InvalidTriggersFormat(message),
+                level: RioErrorLevel::Warning,
+            },
             ConfigError::PathNotFound => RioError {
                 report: RioErrorType::ConfigurationNotFound,
                 level: RioErrorLevel::Warning,
@@ -54,6 +58,8 @@ pub enum RioErrorType {
     ConfigurationNotFound,
     // configuration file have an invalid format
     InvalidConfigurationFormat(String),
+    // triggers.toml has an invalid format
+    InvalidTriggersFormat(String),
     // configuration invalid theme
     InvalidConfigurationTheme(String),
 
@@ -87,6 +93,9 @@ impl std::fmt::Display for RioErrorType {
             RioErrorType::IgnoredReport => write!(f, ""),
             RioErrorType::InvalidConfigurationFormat(message) => {
                 write!(f, "Found an issue loading the configuration file:\n\n{message}\n\nRio will proceed with the default configuration")
+            }
+            RioErrorType::InvalidTriggersFormat(message) => {
+                write!(f, "Found an issue loading triggers.toml:\n\n{message}\n\nExisting trigger rules stay in effect until the file parses")
             }
             RioErrorType::InvalidConfigurationTheme(message) => {
                 write!(f, "Found an issue in the configured theme:\n\n{message}")

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -68,6 +68,16 @@ pub enum TerminalDamage {
     CursorOnly,
 }
 
+/// Trigger actions that are dispatched through the event loop (the in-grid
+/// actions — tab color and highlight — are applied directly by the scanner).
+#[derive(Debug, Clone)]
+pub enum TriggerEventAction {
+    Notify { title: String, body: String },
+    Run { program: String, args: Vec<String> },
+    SendText { text: String },
+    Coprocess { program: String, args: Vec<String> },
+}
+
 #[derive(Clone)]
 pub enum RioEvent {
     PrepareRender(u64),
@@ -197,6 +207,13 @@ pub enum RioEvent {
         body: String,
     },
 
+    /// A trigger rule matched output on `route_id`; the action is already
+    /// capture-substituted, ready to dispatch.
+    TriggerFired {
+        route_id: usize,
+        action: TriggerEventAction,
+    },
+
     /// Shutdown request.
     Exit,
 
@@ -276,6 +293,9 @@ impl Debug for RioEvent {
             }
             RioEvent::Scroll(scroll) => write!(f, "Scroll {scroll:?}"),
             RioEvent::Bell => write!(f, "Bell"),
+            RioEvent::TriggerFired { route_id, .. } => {
+                write!(f, "TriggerFired(route {route_id})")
+            }
             RioEvent::DesktopNotification { title, body } => {
                 write!(f, "DesktopNotification({title}, {body})")
             }

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -72,10 +72,23 @@ pub enum TerminalDamage {
 /// actions — tab color and highlight — are applied directly by the scanner).
 #[derive(Debug, Clone)]
 pub enum TriggerEventAction {
-    Notify { title: String, body: String },
-    Run { program: String, args: Vec<String> },
-    SendText { text: String },
-    Coprocess { program: String, args: Vec<String> },
+    Notify {
+        title: String,
+        body: String,
+        /// freedesktop urgency level (0 low, 1 normal, 2 critical).
+        urgency: u8,
+    },
+    Run {
+        program: String,
+        args: Vec<String>,
+    },
+    SendText {
+        text: String,
+    },
+    Coprocess {
+        program: String,
+        args: Vec<String>,
+    },
 }
 
 #[derive(Clone)]

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -88,6 +88,8 @@ pub enum TriggerEventAction {
     Coprocess {
         program: String,
         args: Vec<String>,
+        /// Visible screen to pipe to the command's stdin, if requested.
+        stdin: Option<String>,
     },
 }
 

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -68,6 +68,31 @@ pub enum TerminalDamage {
     CursorOnly,
 }
 
+/// Trigger actions that are dispatched through the event loop (the in-grid
+/// actions — tab color and highlight — are applied directly by the scanner).
+#[derive(Debug, Clone)]
+pub enum TriggerEventAction {
+    Notify {
+        title: String,
+        body: String,
+        /// freedesktop urgency level (0 low, 1 normal, 2 critical).
+        urgency: u8,
+    },
+    Run {
+        program: String,
+        args: Vec<String>,
+    },
+    SendText {
+        text: String,
+    },
+    Coprocess {
+        program: String,
+        args: Vec<String>,
+        /// Visible screen to pipe to the command's stdin, if requested.
+        stdin: Option<String>,
+    },
+}
+
 #[derive(Clone)]
 pub enum RioEvent {
     PrepareRender(u64),
@@ -221,6 +246,13 @@ pub enum RioEvent {
     /// Color index: 0 for foreground, 1 for background, 2 for cursor color.
     ColorChange(usize, usize, Option<ColorRgb>),
 
+    /// A trigger rule matched output on `route_id`; the action is already
+    /// capture-substituted, ready to dispatch.
+    TriggerFired {
+        route_id: usize,
+        action: TriggerEventAction,
+    },
+
     // No operation
     Noop,
 }
@@ -314,6 +346,9 @@ impl Debug for RioEvent {
             }
             RioEvent::ColorChange(route_id, color, rgb) => {
                 write!(f, "ColorChange({route_id}, {color:?}, {rgb:?})")
+            }
+            RioEvent::TriggerFired { route_id, .. } => {
+                write!(f, "TriggerFired(route {route_id})")
             }
         }
     }

--- a/rio-notifier/src/lib.rs
+++ b/rio-notifier/src/lib.rs
@@ -12,8 +12,11 @@ pub fn request_authorization() {
 /// - **Linux**: D-Bus `org.freedesktop.Notifications`.
 /// - **Windows**: Toast notifications via `windows` crate.
 ///
+/// `urgency` is the freedesktop level (0 low, 1 normal, 2 critical); it only
+/// affects the Linux backend.
+///
 /// Spawns a background thread so the caller is never blocked.
-pub fn send_notification(title: &str, body: &str) {
+pub fn send_notification(title: &str, body: &str, urgency: u8) {
     let title = if title.is_empty() {
         "Rio".to_string()
     } else {
@@ -22,7 +25,7 @@ pub fn send_notification(title: &str, body: &str) {
     let body = body.to_string();
 
     std::thread::spawn(move || {
-        platform::notify(&title, &body);
+        platform::notify(&title, &body, urgency);
     });
 }
 
@@ -60,7 +63,7 @@ mod platform {
         });
     }
 
-    pub fn notify(title: &str, body: &str) {
+    pub fn notify(title: &str, body: &str, _urgency: u8) {
         unsafe {
             // UNUserNotificationCenter crashes if the app has no bundle
             // identifier (e.g. cargo run). Guard like Kitty does.
@@ -95,7 +98,24 @@ mod platform {
 mod platform {
     use std::collections::HashMap;
 
-    pub fn notify(title: &str, body: &str) {
+    pub fn notify(title: &str, body: &str, urgency: u8) {
+        let level = match urgency {
+            0 => "low",
+            2 => "critical",
+            _ => "normal",
+        };
+        // GNOME won't banner a notification it attributes to the focused
+        // window's own process (rio), so a direct D-Bus call from rio is
+        // filed silently while rio is focused. notify-send runs as a
+        // separate process and banners regardless. Fall back to D-Bus when
+        // notify-send isn't installed.
+        if std::process::Command::new("notify-send")
+            .args(["-a", "Rio", "-u", level, "--", title, body])
+            .status()
+            .is_ok()
+        {
+            return;
+        }
         let Ok(connection) = zbus::blocking::Connection::session() else {
             return;
         };
@@ -107,7 +127,8 @@ mod platform {
         ) else {
             return;
         };
-        let hints: HashMap<&str, zbus::zvariant::Value<'_>> = HashMap::new();
+        let mut hints: HashMap<&str, zbus::zvariant::Value<'_>> = HashMap::new();
+        hints.insert("urgency", zbus::zvariant::Value::U8(urgency));
         let _: Result<u32, _> = proxy.call(
             "Notify",
             &(
@@ -126,7 +147,7 @@ mod platform {
 
 #[cfg(target_os = "windows")]
 mod platform {
-    pub fn notify(title: &str, body: &str) {
+    pub fn notify(title: &str, body: &str, _urgency: u8) {
         use windows::core::HSTRING;
         use windows::Data::Xml::Dom::XmlDocument;
         use windows::UI::Notifications::{ToastNotification, ToastNotificationManager};

--- a/rio-notifier/src/lib.rs
+++ b/rio-notifier/src/lib.rs
@@ -12,8 +12,11 @@ pub fn request_authorization() {
 /// - **Linux**: D-Bus `org.freedesktop.Notifications`.
 /// - **Windows**: Toast notifications via `windows` crate.
 ///
+/// `urgency` is the freedesktop level (0 low, 1 normal, 2 critical); it only
+/// affects the Linux backend.
+///
 /// Spawns a background thread so the caller is never blocked.
-pub fn send_notification(title: &str, body: &str) {
+pub fn send_notification(title: &str, body: &str, urgency: u8) {
     let title = if title.is_empty() {
         "Rio".to_string()
     } else {
@@ -22,7 +25,7 @@ pub fn send_notification(title: &str, body: &str) {
     let body = body.to_string();
 
     std::thread::spawn(move || {
-        platform::notify(&title, &body);
+        platform::notify(&title, &body, urgency);
     });
 }
 
@@ -60,7 +63,7 @@ mod platform {
         });
     }
 
-    pub fn notify(title: &str, body: &str) {
+    pub fn notify(title: &str, body: &str, _urgency: u8) {
         unsafe {
             // UNUserNotificationCenter crashes if the app has no bundle
             // identifier (e.g. cargo run). Guard like Kitty does.
@@ -95,7 +98,24 @@ mod platform {
 mod platform {
     use std::collections::HashMap;
 
-    pub fn notify(title: &str, body: &str) {
+    pub fn notify(title: &str, body: &str, urgency: u8) {
+        let level = match urgency {
+            0 => "low",
+            2 => "critical",
+            _ => "normal",
+        };
+        // GNOME won't banner a notification it attributes to the focused
+        // window's own process (rio), so a direct D-Bus call from rio is
+        // filed silently while rio is focused. notify-send runs as a
+        // separate process and banners regardless. Fall back to D-Bus when
+        // notify-send isn't installed.
+        if std::process::Command::new("notify-send")
+            .args(["-a", "Rio", "-u", level, "--", title, body])
+            .status()
+            .is_ok()
+        {
+            return;
+        }
         let Ok(connection) = zbus::blocking::Connection::session() else {
             return;
         };
@@ -107,7 +127,8 @@ mod platform {
         ) else {
             return;
         };
-        let hints: HashMap<&str, zbus::zvariant::Value<'_>> = HashMap::new();
+        let mut hints: HashMap<&str, zbus::zvariant::Value<'_>> = HashMap::new();
+        hints.insert("urgency", zbus::zvariant::Value::U8(urgency));
         let _: Result<u32, _> = proxy.call(
             "Notify",
             &(
@@ -126,7 +147,7 @@ mod platform {
 
 #[cfg(target_os = "windows")]
 mod platform {
-    pub fn notify(title: &str, body: &str) {
+    pub fn notify(title: &str, body: &str, _urgency: u8) {
         use windows::core::HSTRING;
         use windows::Data::Xml::Dom::XmlDocument;
         use windows::UI::Notifications::{ToastNotification, ToastNotificationManager};
@@ -134,9 +155,28 @@ mod platform {
         let Ok(xml) = XmlDocument::new() else {
             return;
         };
+        // Escape XML metacharacters: title/body carry trigger capture
+        // substitutions, i.e. attacker-controlled terminal output. Raw
+        // `<`/`>`/`&`/quotes would at best break the toast and at worst
+        // inject markup (e.g. a clickable protocol-launch action).
+        fn xml_escape(s: &str) -> String {
+            let mut out = String::with_capacity(s.len());
+            for c in s.chars() {
+                match c {
+                    '&' => out.push_str("&amp;"),
+                    '<' => out.push_str("&lt;"),
+                    '>' => out.push_str("&gt;"),
+                    '"' => out.push_str("&quot;"),
+                    '\'' => out.push_str("&apos;"),
+                    _ => out.push(c),
+                }
+            }
+            out
+        }
         let toast_xml = format!(
             r#"<toast><visual><binding template="ToastGeneric"><text>{}</text><text>{}</text></binding></visual></toast>"#,
-            title, body,
+            xml_escape(title),
+            xml_escape(body),
         );
         if xml.LoadXml(&HSTRING::from(&toast_xml)).is_err() {
             return;


### PR DESCRIPTION
## Terminal triggers

Adds iTerm2-style **triggers**: user-defined regex rules matched against
terminal output that fire an action. Rules live in a dedicated
`~/.config/rio/triggers.toml` (loaded independently of `config.toml`, so
a triggers-only setup needs no `config.toml`) — mirroring how themes load
from a separate file. The file's top level is the rule list (`[[rules]]`).

### Actions (`snake_case` in TOML)
- **notify** — desktop notification; optional `urgency = "low" | "normal" | "critical"`
- **tab_color** — recolor the tab that matched
- **run** — spawn a detached command (output discarded)
- **send_text** — type text into the matched session's PTY
- **coprocess** — run a command and write its stdout back into the PTY
- **highlight** — colorize the matched text in the grid

`run` / `send_text` / `coprocess` / `notify` support `\0..\9`
capture-group substitution.

### `feed_screen` (coprocess option)

By default a coprocess only receives the regex capture groups as args.
Set `feed_screen = true` to also pipe the **visible screen plus up to
200 lines of scrollback above it** to the command's **stdin** — so the
command can act on multi-line context (e.g. a wrapped block, a whole
error trace) that a single per-line capture can't carry. The command
reads that on stdin; whatever it writes to stdout is typed back into the
PTY as usual.

Details: the payload is captured lazily (only on the first `feed_screen`
match in a frame — non-matching frames pay nothing) and byte-capped
comfortably under the OS pipe buffer (~64KB on Linux), truncated from
the top so the newest lines / visible prompt are always kept, avoiding a
stdin/stdout deadlock.

```toml
# Send the whole visible block to a summarizer, type its reply back
[[rules]]
regex = "^SUMMARIZE$"
action = { coprocess = { program = "my-summarizer", feed_screen = true } }
```

### Matching
- Scans the **focused pane's** output as it renders; a background tab is
  not scanned until focused (so a notify fires when you switch to it, not
  when the text first appeared).
- **Damage-gated**: only lines the terminal marked dirty are re-scanned,
  keyed by a scroll epoch so a line's identity is stable across scrollback
  movement. Each rule fires once per fresh occurrence, not every frame —
  prompt redraws and alternate-screen TUIs still register new output, but
  a static match on screen isn't re-fired.
- Per-rule **`instant`** fires on the live cursor line (prompts with no
  trailing newline).
- Per-rule **`once`** fires at most once until re-armed; the bindable
  **`resettriggers`** action re-arms them (keeping the per-line dedup so
  stale on-screen content isn't re-fired). Together these enable
  multi-step automations.

### Robustness
- A malformed `triggers.toml` surfaces the parse error in the UI and keeps
  the previously-loaded rules live instead of silently dropping them.
- `coprocess` has a bounded deadline so a hung command can't wedge the
  scan.

### Design
- `onig` (Oniguruma) regexes — the same engine `[hints]` already uses.
  `onig::Regex` is `!Send`, so matching runs on the main thread against
  the terminal already locked for rendering; the backend stays
  `Send`-safe (config structs + a `TriggerFired` event payload only).
- Per-line text extraction is factored out of `hints.rs` into a shared
  `extract_line_text` helper (no duplication).
- Zero cost when unused: with no `triggers.toml` / no rules, nothing is
  locked or scanned.

### Example `triggers.toml`
```toml
# Turn the tab red on any "error"
[[rules]]
regex = "(?i)\\berror\\b"
action = { tab_color = { color = "#FF0000" } }

# Desktop notification with a capture group
[[rules]]
regex = "error: (.*)"
action = { notify = { title = "Error", body = "\\1", urgency = "critical" } }

# Highlight WARN mid-line (before Enter)
[[rules]]
regex = "WARN"
instant = true
action = { highlight = { color = "#FFAA00" } }

# Run a command and type its output back
[[rules]]
regex = "^run date"
action = { coprocess = { program = "date" } }
```

### Notes
- **Security**: `run` / `coprocess` (spawn processes) and `send_text`
  (types into the shell) act on text that may be attacker-controlled
  terminal output — the same command-injection surface iTerm2 documents.
  No shell is involved and words are never re-split, but a capture can
  begin with `-`, so put `--` before capture arguments where the program
  supports it. Entirely opt-in: off until `triggers.toml` exists.

CI: `cargo fmt --check`, `cargo clippy`, and `cargo test` all green.