### PR TITLE
fix: drop unused SurfaceCapabilitiesKHR import (sugarloaf vulkan)

### DIFF
--- a/sugarloaf/src/context/vulkan.rs
+++ b/sugarloaf/src/context/vulkan.rs
@@ -18,7 +18,7 @@
 use crate::sugarloaf::{Colorspace, SugarloafWindow, SugarloafWindowSize};
 use ash::khr;
 use ash::vk;
-use ash::vk::{CompositeAlphaFlagsKHR, SurfaceCapabilitiesKHR};
+use ash::vk::CompositeAlphaFlagsKHR;
 use ash::{Device, Entry, Instance};
 use raw_window_handle::{
     HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,


### PR DESCRIPTION
`SurfaceCapabilitiesKHR` is imported in `sugarloaf/src/context/vulkan.rs` but never used — left over from #1667 (the composite-alpha change). It emits an `unused_imports` warning on a `--no-default-features --features=wayland` build. This drops it; `CompositeAlphaFlagsKHR` (the one actually used) stays.