### PR TITLE
feat(navigation): show tab index in titles (display-tab-number)

### DIFF
--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -146,6 +146,12 @@ pub fn tab_strip_layout(
 
 pub struct Island {
     pub hide_if_single: bool,
+    /// Prefix each tab title with its 1-based visual position (`1 vim`).
+    /// The number is derived from the render position, so reordering tabs
+    /// renumbers them automatically.
+    pub display_tab_number: bool,
+    /// String inserted between the number and the title (default a space).
+    pub tab_number_separator: String,
     pub inactive_text_color: [f32; 4],
     pub active_text_color: [f32; 4],
     pub border_color: [f32; 4],
@@ -186,9 +192,13 @@ impl Island {
         active_text_color: [f32; 4],
         border_color: [f32; 4],
         hide_if_single: bool,
+        display_tab_number: bool,
+        tab_number_separator: String,
     ) -> Self {
         Self {
             hide_if_single,
+            display_tab_number,
+            tab_number_separator,
             inactive_text_color,
             active_text_color,
             border_color,
@@ -1182,8 +1192,24 @@ impl Island {
         self.color_picker_tab.is_some()
     }
 
-    /// Get the title text for a specific tab index
+    /// Get the title text for a specific tab index, with the 1-based
+    /// position prefix applied when `display_tab_number` is enabled.
     fn get_title_for_tab(
+        &self,
+        context_manager: &ContextManager<EventProxy>,
+        tab_index: usize,
+    ) -> String {
+        let title = self.raw_title_for_tab(context_manager, tab_index);
+        Self::format_tab_label(
+            self.display_tab_number,
+            tab_index,
+            &self.tab_number_separator,
+            title,
+        )
+    }
+
+    /// The displayed title for a tab before any index prefix is applied.
+    fn raw_title_for_tab(
         &self,
         context_manager: &ContextManager<EventProxy>,
         tab_index: usize,
@@ -1206,8 +1232,25 @@ impl Island {
             }
         }
 
-        // Default fallback - show tab number
+        // Default fallback when nothing is known yet
         String::from("~")
+    }
+
+    /// Prefix `title` with its 1-based visual position when enabled, joined
+    /// by `separator`. `position` is the render-time tab index (0 = leftmost),
+    /// so a tab dragged from slot 2 to slot 0 renumbers `3 - x` → `1 - x` for
+    /// free.
+    fn format_tab_label(
+        display_tab_number: bool,
+        position: usize,
+        separator: &str,
+        title: String,
+    ) -> String {
+        if display_tab_number {
+            format!("{}{}{}", position + 1, separator, title)
+        } else {
+            title
+        }
     }
 }
 
@@ -1242,12 +1285,20 @@ mod tests {
         let active_color = [0.9, 0.9, 0.9, 1.0];
         let border_color = [0.7, 0.7, 0.7, 1.0];
 
-        let island = Island::new(inactive_color, active_color, border_color, true);
+        let island = Island::new(
+            inactive_color,
+            active_color,
+            border_color,
+            true,
+            false,
+            " - ".to_string(),
+        );
 
         assert_eq!(island.inactive_text_color, inactive_color);
         assert_eq!(island.active_text_color, active_color);
         assert_eq!(island.border_color, border_color);
         assert!(island.hide_if_single);
+        assert!(!island.display_tab_number);
     }
 
     #[test]
@@ -1257,6 +1308,8 @@ mod tests {
             [1.0, 1.0, 1.0, 1.0],
             [0.8, 0.8, 0.8, 1.0],
             false,
+            false,
+            " - ".to_string(),
         );
         assert_eq!(island.height(), ISLAND_HEIGHT);
     }
@@ -1267,7 +1320,51 @@ mod tests {
             [0.9, 0.9, 0.9, 1.0],
             [0.7, 0.7, 0.7, 1.0],
             false,
+            false,
+            " - ".to_string(),
         )
+    }
+
+    #[test]
+    fn format_tab_label_prefixes_one_based_position() {
+        // Disabled: the title is returned untouched.
+        assert_eq!(
+            Island::format_tab_label(false, 0, " - ", "vim".to_string()),
+            "vim"
+        );
+        // Enabled: 1-based position prefix with the default separator.
+        assert_eq!(
+            Island::format_tab_label(true, 0, " - ", "vim".to_string()),
+            "1 - vim"
+        );
+        assert_eq!(
+            Island::format_tab_label(true, 2, " - ", "htop".to_string()),
+            "3 - htop"
+        );
+        // Custom separator.
+        assert_eq!(
+            Island::format_tab_label(true, 0, ": ", "vim".to_string()),
+            "1: vim"
+        );
+    }
+
+    #[test]
+    fn tab_numbers_follow_visual_position_after_reorder() {
+        // The number is derived from the render position (`tab_index`), which
+        // is the live slot in ContextManager's reordered `contexts` vector.
+        // Simulate a reorder by moving the last tab to the front: its number
+        // must drop from 3 to 1 and the others shift up, matching ghostty.
+        let labels = |titles: &[&str]| -> Vec<String> {
+            titles
+                .iter()
+                .enumerate()
+                .map(|(i, t)| Island::format_tab_label(true, i, " - ", t.to_string()))
+                .collect()
+        };
+
+        assert_eq!(labels(&["a", "b", "c"]), ["1 - a", "2 - b", "3 - c"]);
+        // "c" dragged from slot 2 to slot 0 renumbers 3 → 1.
+        assert_eq!(labels(&["c", "a", "b"]), ["1 - c", "2 - a", "3 - b"]);
     }
 
     #[test]

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -307,6 +307,12 @@ pub struct Island {
     pub hide_if_single: bool,
     /// Cap on tab width in logical px (`navigation.max-tab-width`).
     pub max_tab_width: f32,
+    /// Prefix each tab title with its 1-based visual position (`1 vim`).
+    /// The number is derived from the render position, so reordering tabs
+    /// renumbers them automatically.
+    pub display_tab_number: bool,
+    /// String inserted between the number and the title (default a space).
+    pub tab_number_separator: String,
     pub inactive_text_color: [f32; 4],
     pub active_text_color: [f32; 4],
     /// Current progress bar state
@@ -349,10 +355,14 @@ impl Island {
         active_text_color: [f32; 4],
         hide_if_single: bool,
         max_tab_width: f32,
+        display_tab_number: bool,
+        tab_number_separator: String,
     ) -> Self {
         Self {
             hide_if_single,
             max_tab_width,
+            display_tab_number,
+            tab_number_separator,
             inactive_text_color,
             active_text_color,
             progress_state: None,
@@ -1354,8 +1364,24 @@ impl Island {
         self.color_picker_tab.is_some()
     }
 
-    /// Get the title text for a specific tab index
+    /// Get the title text for a specific tab index, with the 1-based
+    /// position prefix applied when `display_tab_number` is enabled.
     fn get_title_for_tab(
+        &self,
+        context_manager: &ContextManager<EventProxy>,
+        tab_index: usize,
+    ) -> String {
+        let title = self.raw_title_for_tab(context_manager, tab_index);
+        Self::format_tab_label(
+            self.display_tab_number,
+            tab_index,
+            &self.tab_number_separator,
+            title,
+        )
+    }
+
+    /// The displayed title for a tab before any index prefix is applied.
+    fn raw_title_for_tab(
         &self,
         context_manager: &ContextManager<EventProxy>,
         tab_index: usize,
@@ -1378,8 +1404,25 @@ impl Island {
             }
         }
 
-        // Default fallback - show tab number
+        // Default fallback when nothing is known yet
         String::from("~")
+    }
+
+    /// Prefix `title` with its 1-based visual position when enabled, joined
+    /// by `separator`. `position` is the render-time tab index (0 = leftmost),
+    /// so a tab dragged from slot 2 to slot 0 renumbers `3 - x` → `1 - x` for
+    /// free.
+    fn format_tab_label(
+        display_tab_number: bool,
+        position: usize,
+        separator: &str,
+        title: String,
+    ) -> String {
+        if display_tab_number {
+            format!("{}{}{}", position + 1, separator, title)
+        } else {
+            title
+        }
     }
 }
 
@@ -1465,22 +1508,85 @@ mod tests {
         let inactive_color = [0.5, 0.5, 0.5, 1.0];
         let active_color = [0.9, 0.9, 0.9, 1.0];
 
-        let island = Island::new(inactive_color, active_color, true, 240.0);
+        let island = Island::new(
+            inactive_color,
+            active_color,
+            true,
+            240.0,
+            false,
+            " - ".to_string(),
+        );
 
         assert_eq!(island.inactive_text_color, inactive_color);
         assert_eq!(island.active_text_color, active_color);
         assert!(island.hide_if_single);
+        assert!(!island.display_tab_number);
     }
 
     #[test]
     fn test_island_height() {
-        let island =
-            Island::new([0.8, 0.8, 0.8, 1.0], [1.0, 1.0, 1.0, 1.0], false, 240.0);
+        let island = Island::new(
+            [0.8, 0.8, 0.8, 1.0],
+            [1.0, 1.0, 1.0, 1.0],
+            false,
+            240.0,
+            false,
+            " - ".to_string(),
+        );
         assert_eq!(island.height(), ISLAND_HEIGHT);
     }
 
     fn test_island() -> Island {
-        Island::new([0.5, 0.5, 0.5, 1.0], [0.9, 0.9, 0.9, 1.0], false, 240.0)
+        Island::new(
+            [0.5, 0.5, 0.5, 1.0],
+            [0.9, 0.9, 0.9, 1.0],
+            false,
+            240.0,
+            false,
+            " - ".to_string(),
+        )
+    }
+
+    #[test]
+    fn format_tab_label_prefixes_one_based_position() {
+        // Disabled: the title is returned untouched.
+        assert_eq!(
+            Island::format_tab_label(false, 0, " - ", "vim".to_string()),
+            "vim"
+        );
+        // Enabled: 1-based position prefix with the default separator.
+        assert_eq!(
+            Island::format_tab_label(true, 0, " - ", "vim".to_string()),
+            "1 - vim"
+        );
+        assert_eq!(
+            Island::format_tab_label(true, 2, " - ", "htop".to_string()),
+            "3 - htop"
+        );
+        // Custom separator.
+        assert_eq!(
+            Island::format_tab_label(true, 0, ": ", "vim".to_string()),
+            "1: vim"
+        );
+    }
+
+    #[test]
+    fn tab_numbers_follow_visual_position_after_reorder() {
+        // The number is derived from the render position (`tab_index`), which
+        // is the live slot in ContextManager's reordered `contexts` vector.
+        // Simulate a reorder by moving the last tab to the front: its number
+        // must drop from 3 to 1 and the others shift up, matching ghostty.
+        let labels = |titles: &[&str]| -> Vec<String> {
+            titles
+                .iter()
+                .enumerate()
+                .map(|(i, t)| Island::format_tab_label(true, i, " - ", t.to_string()))
+                .collect()
+        };
+
+        assert_eq!(labels(&["a", "b", "c"]), ["1 - a", "2 - b", "3 - c"]);
+        // "c" dragged from slot 2 to slot 0 renumbers 3 → 1.
+        assert_eq!(labels(&["c", "a", "b"]), ["1 - c", "2 - a", "3 - b"]);
     }
 
     #[test]

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -121,6 +121,8 @@ impl Renderer {
                 named_colors.tabs_active,
                 named_colors.tab_border,
                 config.navigation.hide_if_single,
+                config.navigation.display_tab_number,
+                config.navigation.tab_number_separator.clone(),
             ))
         } else {
             None

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -127,6 +127,8 @@ impl Renderer {
                 named_colors.tabs_active,
                 config.navigation.hide_if_single,
                 config.navigation.max_tab_width,
+                config.navigation.display_tab_number,
+                config.navigation.tab_number_separator.clone(),
             ))
         } else {
             None

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -422,6 +422,10 @@ impl Screen<'_> {
                 config.colors.tabs_active,
                 config.colors.tab_border,
             );
+            // Pick up live-reloaded tab-number settings (the preserved
+            // island keeps its old constructor values otherwise).
+            island.display_tab_number = config.navigation.display_tab_number;
+            island.tab_number_separator = config.navigation.tab_number_separator.clone();
             self.renderer.island = Some(island);
         }
 

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -456,6 +456,10 @@ impl Screen<'_> {
         if let Some(mut island) = old_island {
             island.update_colors(config.colors.tabs, config.colors.tabs_active);
             island.max_tab_width = config.navigation.max_tab_width;
+            // Pick up live-reloaded tab-number settings (the preserved
+            // island keeps its old constructor values otherwise).
+            island.display_tab_number = config.navigation.display_tab_number;
+            island.tab_number_separator = config.navigation.tab_number_separator.clone();
             self.renderer.island = Some(island);
         }
 

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -7,6 +7,11 @@ pub fn default_unfocused_split_opacity() -> f32 {
     0.7
 }
 
+#[inline]
+pub fn default_tab_number_separator() -> String {
+    String::from(" ")
+}
+
 /// Clamp `unfocused_split_opacity` to `[0.15, 1.0]`.
 ///
 /// A value of `0.0` makes the inactive pane invisible, which is never what
@@ -127,6 +132,21 @@ pub struct Navigation {
     pub current_working_directory: bool,
     #[serde(default = "bool::default", rename = "use-terminal-title")]
     pub use_terminal_title: bool,
+    /// Prefix each tab title with its 1-based visual position, e.g.
+    /// `1 vim`. The number tracks the position, so reordering tabs
+    /// renumbers them. The number/title separator is configurable via
+    /// `tab_number_separator`. Only applies to the rio-rendered tab strip
+    /// (`Tab` mode); `NativeTab` uses the OS tab bar.
+    #[serde(default = "bool::default", rename = "display-tab-number")]
+    pub display_tab_number: bool,
+    /// String inserted between the tab number and the title when
+    /// `display_tab_number` is enabled. Defaults to a single space
+    /// (`1 vim`); set e.g. `" - "` for `1 - vim` or `": "` for `1: vim`.
+    #[serde(
+        default = "default_tab_number_separator",
+        rename = "tab-number-separator"
+    )]
+    pub tab_number_separator: String,
     #[serde(default = "default_bool_true", rename = "hide-if-single")]
     pub hide_if_single: bool,
     #[serde(default = "default_bool_true", rename = "use-split")]
@@ -160,6 +180,8 @@ impl Default for Navigation {
             clickable: false,
             current_working_directory: true,
             use_terminal_title: false,
+            display_tab_number: false,
+            tab_number_separator: default_tab_number_separator(),
             hide_if_single: true,
             use_split: true,
             unfocused_split_opacity: default_unfocused_split_opacity(),
@@ -239,6 +261,24 @@ mod tests {
         assert_eq!(decoded.navigation.mode, NavigationMode::Tab);
         assert!(!decoded.navigation.clickable);
         assert!(decoded.navigation.color_automation.is_empty());
+    }
+
+    #[test]
+    fn test_display_tab_number() {
+        // Defaults: disabled, separator is a single space.
+        let decoded = toml::from_str::<Root>("[navigation]\nmode = 'Tab'\n").unwrap();
+        assert!(!decoded.navigation.display_tab_number);
+        assert_eq!(decoded.navigation.tab_number_separator, " ");
+
+        let content = r#"
+            [navigation]
+            mode = 'Tab'
+            display-tab-number = true
+            tab-number-separator = ": "
+        "#;
+        let decoded = toml::from_str::<Root>(content).unwrap();
+        assert!(decoded.navigation.display_tab_number);
+        assert_eq!(decoded.navigation.tab_number_separator, ": ");
     }
 
     #[test]

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -23,6 +23,11 @@ pub fn clamp_max_tab_width(v: f32) -> f32 {
     v.clamp(80.0, 280.0)
 }
 
+#[inline]
+pub fn default_tab_number_separator() -> String {
+    String::from(" ")
+}
+
 /// Clamp `unfocused_split_opacity` to `[0.15, 1.0]`.
 ///
 /// A value of `0.0` makes the inactive pane invisible, which is never what
@@ -143,6 +148,21 @@ pub struct Navigation {
     pub current_working_directory: bool,
     #[serde(default = "bool::default", rename = "use-terminal-title")]
     pub use_terminal_title: bool,
+    /// Prefix each tab title with its 1-based visual position, e.g.
+    /// `1 vim`. The number tracks the position, so reordering tabs
+    /// renumbers them. The number/title separator is configurable via
+    /// `tab_number_separator`. Only applies to the rio-rendered tab strip
+    /// (`Tab` mode); `NativeTab` uses the OS tab bar.
+    #[serde(default = "bool::default", rename = "display-tab-number")]
+    pub display_tab_number: bool,
+    /// String inserted between the tab number and the title when
+    /// `display_tab_number` is enabled. Defaults to a single space
+    /// (`1 vim`); set e.g. `" - "` for `1 - vim` or `": "` for `1: vim`.
+    #[serde(
+        default = "default_tab_number_separator",
+        rename = "tab-number-separator"
+    )]
+    pub tab_number_separator: String,
     #[serde(default = "default_bool_true", rename = "hide-if-single")]
     pub hide_if_single: bool,
     #[serde(default = "default_bool_true", rename = "use-split")]
@@ -181,6 +201,8 @@ impl Default for Navigation {
             clickable: false,
             current_working_directory: true,
             use_terminal_title: false,
+            display_tab_number: false,
+            tab_number_separator: default_tab_number_separator(),
             hide_if_single: true,
             use_split: true,
             unfocused_split_opacity: default_unfocused_split_opacity(),
@@ -261,6 +283,24 @@ mod tests {
         assert_eq!(decoded.navigation.mode, NavigationMode::Tab);
         assert!(!decoded.navigation.clickable);
         assert!(decoded.navigation.color_automation.is_empty());
+    }
+
+    #[test]
+    fn test_display_tab_number() {
+        // Defaults: disabled, separator is a single space.
+        let decoded = toml::from_str::<Root>("[navigation]\nmode = 'Tab'\n").unwrap();
+        assert!(!decoded.navigation.display_tab_number);
+        assert_eq!(decoded.navigation.tab_number_separator, " ");
+
+        let content = r#"
+            [navigation]
+            mode = 'Tab'
+            display-tab-number = true
+            tab-number-separator = ": "
+        "#;
+        let decoded = toml::from_str::<Root>(content).unwrap();
+        assert!(decoded.navigation.display_tab_number);
+        assert_eq!(decoded.navigation.tab_number_separator, ": ");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an opt-in `[navigation] display-tab-number` setting. When enabled, each tab in the rio-rendered strip is prefixed with its **1-based visual position**:

```
1 vim
2 ~/src/rio
3 htop
```

```toml
[navigation]
display-tab-number = true
# Optional separator between the number and the title (default: a single space)
tab-number-separator = " - "   # -> "1 - vim"
```

Default is `false` — no change for existing users.

Closes #1537.

## Why

- Requested in #1537 (show a number on the tab, like WezTerm).
- @raphamorim already endorsed this exact API in #593: *"is possible to add this feature behind a configuration property? … `[navigation] display-tab-number = true`"*. That PR was closed only because *"this will change a lot on v0.3 as the tab system is being rewritten"* — the rewrite has since landed, so this reimplements it on the current `Island` strip.

## Behavior

- **Reordering renumbers automatically.** The number is the render position (`tab_index`), i.e. the live slot in `ContextManager`'s `contexts` vector. Keyboard moves (`move_current_to_*`) and drag-reorder physically reorder that vector, so a tab dragged from slot 3 to the front becomes `1` and the rest shift up (ghostty-style), live during the drag.
- **Configurable separator.** `tab-number-separator` is the string inserted between the number and the title. Default is a single space (`1 vim`); set `" - "` for `1 - vim`, `": "` for `1: vim`, or `""` for `1vim`.
- **Applied uniformly**, including user-renamed tabs.
- **Scope:** `Tab` mode only. `Plain` has no strip; `NativeTab` (macOS) uses the OS tab bar, which rio doesn't render.
- **Live config reload** is honored — the preserved island picks up both settings.

## Implementation

- `rio-backend`: two `Navigation` fields — `display-tab-number: bool` and `tab-number-separator: String` (default `" "`).
- `frontends/rioterm`: `Island` carries both; `get_title_for_tab` applies the prefix via a small pure `format_tab_label(display, position, separator, title)` helper, so both the strip and the drag preview share one code path.

## Tests

- `rio-backend`: parses `display-tab-number` / `tab-number-separator` and checks defaults.
- `rioterm`: `format_tab_label` prefix + separator logic, and a reorder test asserting the moved tab renumbers (`["a","b","c"]` → move `c` to front → `["1 - c","2 - a","3 - b"]`).

`cargo fmt --check`, `cargo clippy --all-targets --features wgpu`, and the touched test suites pass locally.

## Docs

Companion docs PR (config reference for both options): raphamorim/rioterm.com#2
