### PR TITLE
fix(tabs): recompute grid rows when the tab strip toggles

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1557,7 +1557,15 @@ impl Screen<'_> {
                     padding_y_bottom * scale,
                     d.scaled_margin.left,
                 ));
-                self.resize_all_contexts();
+                // Re-run the full grid resize so the Taffy root shrinks by the
+                // new margin and the row count (PTY lines) is recomputed.
+                // update_scaled_margin alone only moves the render offset:
+                // content shifts down by the tab-bar height without losing any
+                // rows, so the bottom overflows off-window until the next window
+                // resize. resize() runs try_update_size + apply_taffy_layout,
+                // which is exactly what the window-resize path does per grid.
+                let (width, height) = (d.width, d.height);
+                d.resize(width, height, &mut self.sugarloaf);
             }
         }
     }


### PR DESCRIPTION
## Summary

Opening a second tab (or closing back to a single tab) shows/hides the tab strip, which changes the terminal's top margin. The grid's row count was not recomputed, so the bottom rows overflowed off-window until the next window resize.

## Reproduction

1. Launch Rio in the default `Tab` navigation (tab strip hidden while there is a single tab).
2. Fill the terminal to the bottom (e.g. `seq 1 200`, or open `vim`).
3. Open a second tab — the strip appears.
4. The content shifts down by the strip height, but the grid keeps the same number of rows, so the bottom row (shell prompt / bottom of vim) is now clipped below the window edge. The window itself did not resize.
5. Manually resizing the window corrects it.

Reproduced on `main` (2bb89d2c5c); the report was cross-platform.

## Root cause

`ContextGrid` represents the margin twice, and both must stay in sync:

- `scaled_margin` — the **render offset** (`origin_y = panel_rect.y + scaled_margin.top`).
- the **Taffy root-node size** — from which the panel height, and therefore the row count (`lines`, the PTY winsize), is derived. It is set by `try_update_size`, which subtracts `scaled_margin`.

`ContextGrid::resize()` (the window-resize path) updates both. But `resize_top_or_bottom_line` — the tab-strip toggle path — called `update_scaled_margin()` (which sets only the field) followed by `resize_all_contexts()` (which resends the existing, now-stale `dimension`). The Taffy root was never resized, so `lines` stayed at the full-height value: the content shifted down without dropping any rows, and only the next window resize (the one path that runs `try_update_size`) corrected it.

## Fix

After updating the margin, re-run the same per-grid resize the window-resize path already uses (`try_update_size` + `apply_taffy_layout`), so the root shrinks by the new margin and the row count is recomputed and pushed to the PTY. This covers both directions: the strip appearing (1 → 2 tabs) and disappearing (2 → 1).

## Testing

- `cargo test -p rioterm` — 147/147 pass.
- Verified manually on Linux (WSLg) with before/after builds: opening a tab no longer clips the bottom, and closing back to a single tab refills the grid instead of leaving a gap at the bottom.
