### PR TITLE
fix: reporting of support for sixel and iterm2 graphics

### DIFF
--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -2872,7 +2872,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
         match intermediate {
             None => {
                 trace!("Reporting primary device attributes");
-                let text = String::from("\x1b[?62;4;6;22c");
+                let text = String::from("\x1b[?62;6;22c");
                 self.event_proxy
                     .send_event(RioEvent::PtyWrite(self.route_id, text), self.window_id);
             }

--- a/rio-backend/src/performer/handler.rs
+++ b/rio-backend/src/performer/handler.rs
@@ -1748,9 +1748,12 @@ fn get_termcap_capability(name: &str) -> Option<String> {
 
         // Image protocol support
         //
-        // Sixel and iTerm2 graphics protocols were previously supported in v0.3 but they have not
-        // yet been ported to atlas graphics in the v0.4 atlast graphics rewrite, until their
+        // NOTE: Sixel and iTerm2 graphics protocols were previously supported in v0.3 but they have
+        // not yet been ported to atlas graphics in the v0.4 atlast graphics rewrite, until their
         // integration is completed, they are commented out to correctly report "no support"
+        //
+        // When re-enabling Sixel, also restore the `4` parameter in the DA1 primary device
+        // attributes response (crosswords/mod.rs: identify_terminal) and delete these comments!
         //
         // "sixel" => Some("".to_string()),
         // "iterm2" => Some("".to_string()),

--- a/rio-backend/src/performer/handler.rs
+++ b/rio-backend/src/performer/handler.rs
@@ -1747,8 +1747,13 @@ fn get_termcap_capability(name: &str) -> Option<String> {
         "npc" => Some("".to_string()),   // No pad character
 
         // Image protocol support
-        "sixel" => Some("".to_string()), // Sixel graphics support
-        "iterm2" => Some("".to_string()), // iTerm2 image protocol support
+        //
+        // Sixel and iTerm2 graphics protocols were previously supported in v0.3 but they have not
+        // yet been ported to atlas graphics in the v0.4 atlast graphics rewrite, until their
+        // integration is completed, they are commented out to correctly report "no support"
+        //
+        // "sixel" => Some("".to_string()),
+        // "iterm2" => Some("".to_string()),
         "TK" | "kitty" => Some("yes".to_string()), // Kitty graphics protocol support
 
         // Cursor movement - from terminfo
@@ -2240,8 +2245,8 @@ mod tests {
         );
 
         // Test image protocol capabilities
-        assert_eq!(get_termcap_capability("sixel"), Some("".to_string()));
-        assert_eq!(get_termcap_capability("iterm2"), Some("".to_string()));
+        assert_eq!(get_termcap_capability("sixel"), None);
+        assert_eq!(get_termcap_capability("iterm2"), None);
     }
 
     // APC accumulation tests


### PR DESCRIPTION
Since these have been unsupported since 0.4, it is good not to report support of them, so downstream applications do not use them until they are re-integrated, favor kitty when supporting.