### PR TITLE
fix: render sixel and iTerm2 inline images (imgcat) again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,6 +1493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2150,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -4768,6 +4775,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ image_rs = { package = "image", version = "0.25.10", default-features = false, f
     "pnm",
     "webp",
     "bmp",
+    # chafa's iTerm2 renderer emits TIFF payloads (OSC 1337)
+    "tiff",
 ] }
 regex = "1.12.3"
 onig = { version = "6.5.1", default-features = false }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -319,17 +319,22 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
             }
-            RioEventType::Rio(RioEvent::UpdateGraphics {
-                route_id: _,
-                queues,
-            }) => {
+            RioEventType::Rio(RioEvent::UpdateGraphics { route_id, queues }) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     // Process graphics directly in sugarloaf
                     let sugarloaf = &mut route.window.screen.sugarloaf;
 
-                    // Atlas graphics (sixel/iTerm2)
+                    // Atlas graphics (sixel/iTerm2) → the same per-image
+                    // texture store the overlay pipeline draws from, under
+                    // a namespaced key.
                     for graphic_data in queues.pending {
-                        sugarloaf.graphics.insert(graphic_data);
+                        let key = crate::renderer::atlas_image_key(graphic_data.id.get());
+                        sugarloaf.image_data.insert(
+                            key,
+                            rio_backend::sugarloaf::GraphicDataEntry::from_graphic_data(
+                                graphic_data,
+                            ),
+                        );
                     }
 
                     // Image textures (kitty) → separate store, no clone
@@ -342,8 +347,20 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         );
                     }
 
-                    for graphic_data in queues.remove_queue {
-                        sugarloaf.graphics.remove(&graphic_data);
+                    for graphic_id in queues.remove_queue {
+                        sugarloaf
+                            .image_data
+                            .remove(&crate::renderer::atlas_image_key(graphic_id.get()));
+                    }
+
+                    // Mark the panel dirty — the renderer skips non-dirty
+                    // panels, so a bare redraw after the pixels arrive
+                    // would no-op and leave the image blank until the
+                    // next unrelated damage.
+                    if let Some(ctx_item) =
+                        route.window.screen.ctx_mut().get_by_route_id(route_id)
+                    {
+                        ctx_item.val.renderable_content.pending_update.set_dirty();
                     }
 
                     // Request a redraw to display the updated graphics

--- a/frontends/rioterm/src/context/renderable.rs
+++ b/frontends/rioterm/src/context/renderable.rs
@@ -97,6 +97,9 @@ pub struct RenderableContent {
     pub kitty_images: FxHashMap<u32, StoredImage>,
     pub kitty_placements: Vec<KittyPlacement>,
     pub kitty_graphics_dirty: bool,
+    /// `true` while any atlas graphic (sixel/iTerm2) is alive on the
+    /// grid. Gates the per-frame cell scan that builds their overlays.
+    pub has_atlas_graphics: bool,
 }
 
 impl RenderableContent {
@@ -128,6 +131,7 @@ impl RenderableContent {
             kitty_images: FxHashMap::default(),
             kitty_placements: Vec::new(),
             kitty_graphics_dirty: false,
+            has_atlas_graphics: false,
         }
     }
 

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -43,6 +43,17 @@ fn window_bg_alpha(config: &Config) -> f32 {
     }
 }
 
+/// `image_data` (u32) key for an atlas graphic (sixel/iTerm2).
+/// `GraphicId`s are small sequential u64s; the high bit keeps them out
+/// of the kitty protocol id space (see the `KittyPlacement` doc comment
+/// in rio-backend), so both kinds share the per-image texture store.
+pub const ATLAS_IMAGE_ID_FLAG: u32 = 0x8000_0000;
+
+#[inline]
+pub fn atlas_image_key(id: u64) -> u32 {
+    ATLAS_IMAGE_ID_FLAG | (id as u32 & 0x7FFF_FFFF)
+}
+
 pub struct Renderer {
     is_vi_mode_enabled: bool,
     is_game_mode_enabled: bool,
@@ -387,6 +398,8 @@ impl Renderer {
                 } else {
                     context.renderable_content.kitty_graphics_dirty = false;
                 }
+                context.renderable_content.has_atlas_graphics =
+                    !terminal.graphics.placed_textures.is_empty();
                 context.renderable_content.frame_damage = damage;
                 drop(terminal);
             }
@@ -397,7 +410,8 @@ impl Renderer {
             let rc = &context.renderable_content;
             let has_overlays = !rc.kitty_placements.is_empty();
             let has_virtual = !rc.kitty_virtual_placements.is_empty();
-            if has_overlays || has_virtual {
+            let has_atlas = rc.has_atlas_graphics;
+            if has_overlays || has_virtual || has_atlas {
                 let layout = context.dimension;
                 // Canonical integer cell stride — line_height already
                 // baked into `cell.cell_height`. Same value the GPU
@@ -453,8 +467,20 @@ impl Renderer {
                         cell_height,
                     );
                 }
-            } else if rc.kitty_graphics_dirty {
-                // Placements were removed — clear overlays
+
+                if has_atlas {
+                    Self::push_atlas_graphic_overlays(
+                        overlays,
+                        rc,
+                        origin_x,
+                        origin_y,
+                        cell_width,
+                        cell_height,
+                    );
+                }
+            } else {
+                // No placements of any kind — drop stale overlays (kitty
+                // deletes, or the last atlas graphic scrolled out).
                 sugarloaf.clear_image_overlays_for(context.rich_text_id);
             }
 
@@ -875,6 +901,160 @@ impl Renderer {
                 z_index,
                 source_rect: geom.source_rect,
             });
+        }
+    }
+
+    /// Scan visible rows for cells carrying atlas graphics (sixel/iTerm2)
+    /// and push one `GraphicOverlay` per row-run. The backend writes a
+    /// `GraphicCell { texture, offset_x, offset_y }` into every covered
+    /// cell, so contiguous cells continuing the same texture at the
+    /// expected pixel offset coalesce into one overlay; erased or
+    /// overwritten cells break the run and that slice is not drawn.
+    fn push_atlas_graphic_overlays(
+        overlays: &mut Vec<rio_backend::sugarloaf::GraphicOverlay>,
+        rc: &RenderableContent,
+        origin_x: f32,
+        origin_y: f32,
+        cell_width: f32,
+        cell_height: f32,
+    ) {
+        // Below text, like virtual placements.
+        const ATLAS_Z_INDEX: i32 = -1;
+
+        struct Run {
+            id: u64,
+            tex_w: f32,
+            tex_h: f32,
+            /// Cell size when the graphic was inserted — the pixel stride
+            /// between covered cells. Differs from the live cell size
+            /// after a font resize (the image then scales with the font).
+            insert_cw: f32,
+            insert_ch: f32,
+            src_x0: f32,
+            src_y: f32,
+            start_col: usize,
+            cells: usize,
+        }
+
+        /// Push the run as one overlay: a `source_rect` slice of the
+        /// texture (normalized, resolution-independent) covering the
+        /// run's cells. Edge cells draw only the pixels the image
+        /// actually has.
+        fn flush(
+            overlays: &mut Vec<rio_backend::sugarloaf::GraphicOverlay>,
+            r: Run,
+            line: usize,
+            origin_x: f32,
+            origin_y: f32,
+            cell_width: f32,
+            cell_height: f32,
+        ) {
+            let src_w = (r.cells as f32 * r.insert_cw).min(r.tex_w - r.src_x0);
+            let src_h = r.insert_ch.min(r.tex_h - r.src_y);
+            if src_w <= 0.0 || src_h <= 0.0 {
+                return;
+            }
+            overlays.push(rio_backend::sugarloaf::GraphicOverlay {
+                image_id: atlas_image_key(r.id),
+                x: origin_x + r.start_col as f32 * cell_width,
+                y: origin_y + line as f32 * cell_height,
+                width: src_w * (cell_width / r.insert_cw),
+                height: src_h * (cell_height / r.insert_ch),
+                z_index: ATLAS_Z_INDEX,
+                source_rect: [
+                    r.src_x0 / r.tex_w,
+                    r.src_y / r.tex_h,
+                    (r.src_x0 + src_w) / r.tex_w,
+                    (r.src_y + src_h) / r.tex_h,
+                ],
+            });
+        }
+
+        for (line_idx, row) in rc.visible_rows.iter().enumerate() {
+            if !row.has_extras {
+                continue;
+            }
+
+            let mut run: Option<Run> = None;
+
+            for (col_idx, square) in row.inner.iter().enumerate() {
+                let graphic = if square.has_graphics() {
+                    square
+                        .extras_id()
+                        .and_then(|eid| rc.extras.get(&eid))
+                        .and_then(|e| e.graphic.as_ref())
+                        .and_then(|g| g.first())
+                } else {
+                    None
+                };
+
+                let Some(cell) = graphic else {
+                    if let Some(r) = run.take() {
+                        flush(
+                            overlays,
+                            r,
+                            line_idx,
+                            origin_x,
+                            origin_y,
+                            cell_width,
+                            cell_height,
+                        );
+                    }
+                    continue;
+                };
+
+                // Covered cells of one image row share a single
+                // `GraphicCell`; the per-cell x offset is positional:
+                // offset_x + (col - anchor_col) * insert-time cell width.
+                match &mut run {
+                    Some(r)
+                        if r.id == cell.texture.id.get()
+                            && r.src_y == cell.offset_y as f32
+                            && col_idx == r.start_col + r.cells =>
+                    {
+                        r.cells += 1;
+                    }
+                    _ => {
+                        if let Some(r) = run.take() {
+                            flush(
+                                overlays,
+                                r,
+                                line_idx,
+                                origin_x,
+                                origin_y,
+                                cell_width,
+                                cell_height,
+                            );
+                        }
+                        let insert_cw = cell.texture.cell_width.max(1) as f32;
+                        let src_x0 = cell.offset_x as f32
+                            + (col_idx as f32 - cell.anchor_col as f32) * insert_cw;
+                        run = Some(Run {
+                            id: cell.texture.id.get(),
+                            tex_w: cell.texture.width as f32,
+                            tex_h: cell.texture.height as f32,
+                            insert_cw,
+                            insert_ch: cell.texture.cell_height.max(1) as f32,
+                            src_x0,
+                            src_y: cell.offset_y as f32,
+                            start_col: col_idx,
+                            cells: 1,
+                        });
+                    }
+                }
+            }
+
+            if let Some(r) = run {
+                flush(
+                    overlays,
+                    r,
+                    line_idx,
+                    origin_x,
+                    origin_y,
+                    cell_width,
+                    cell_height,
+                );
+            }
         }
     }
 }

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -36,6 +36,9 @@ pub struct TextureRef {
     /// Height, in pixels, of the graphic.
     pub height: u16,
 
+    /// Width, in pixels, of the cell when the graphic was inserted.
+    pub cell_width: usize,
+
     /// Height, in pixels, of the cell when the graphic was inserted.
     pub cell_height: usize,
 
@@ -63,17 +66,25 @@ impl Drop for TextureRef {
 /// A list of graphics in a single cell.
 pub type GraphicsCell = SmallVec<[GraphicCell; 1]>;
 
-/// Graphic data stored in a single cell.
+/// Graphic data stored in a cell's extras slot.
+///
+/// One `GraphicCell` (one extras slot) is shared by every covered cell of
+/// an image row — a slot per cell would exhaust the u16 extras id space in
+/// a dozen large images. A cell's actual x offset is derived positionally:
+/// `offset_x + (col - anchor_col) * texture.cell_width`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GraphicCell {
     /// Texture to draw the graphic in this cell.
     pub texture: Arc<TextureRef>,
 
-    /// Offset in the x direction.
+    /// Offset in the x direction, at `anchor_col`.
     pub offset_x: u16,
 
     /// Offset in the y direction.
     pub offset_y: u16,
+
+    /// Grid column `offset_x` is measured at.
+    pub anchor_col: u16,
 }
 
 /// Kitty graphics Unicode placeholder character

--- a/rio-backend/src/crosswords/grid/mod.rs
+++ b/rio-backend/src/crosswords/grid/mod.rs
@@ -121,6 +121,22 @@ impl ExtrasTable {
         id
     }
 
+    /// Nearly out of slot ids — time for `Grid::gc_extras`.
+    pub fn under_pressure(&self) -> bool {
+        self.slots.len() >= u16::MAX as usize && self.free.len() < 256
+    }
+
+    /// Free every allocated slot whose bit is not set in `live`.
+    pub fn sweep_unmarked(&mut self, live: &[u64]) {
+        for id in 1..self.slots.len() {
+            let marked = live[id / 64] & (1 << (id % 64)) != 0;
+            if !marked && self.slots[id].is_some() {
+                self.slots[id] = None;
+                self.free.push(id as u16);
+            }
+        }
+    }
+
     /// Free a previously-allocated slot. No-op if `id == 0`.
     pub fn free(&mut self, id: crate::crosswords::square::ExtrasId) {
         if id == 0 {
@@ -471,6 +487,42 @@ use crate::crosswords::square::Square;
 use crate::crosswords::style::{Style, StyleId};
 
 impl Grid<Square> {
+    /// Free extras slots no longer referenced by any cell.
+    ///
+    /// Cells are overwritten and rows drop off the scrollback ring without
+    /// freeing their extras slot, so a session heavy on per-cell extras —
+    /// inline graphics above all — eventually exhausts the u16 id space.
+    /// Mark every slot referenced by a live row (visible + history) or a
+    /// cursor template, then free the rest. Swept graphic slots drop their
+    /// `TextureRef`, which queues the image removal downstream.
+    pub fn gc_extras(&mut self) {
+        #[inline]
+        fn mark(live: &mut [u64], sq: &Square) {
+            if matches!(
+                sq.content_tag(),
+                crate::crosswords::square::ContentTag::Codepoint
+            ) {
+                if let Some(eid) = sq.extras_id() {
+                    live[eid as usize / 64] |= 1 << (eid % 64);
+                }
+            }
+        }
+
+        let mut live = vec![0u64; (u16::MAX as usize).div_ceil(64)];
+        for l in self.topmost_line().0..=self.bottommost_line().0 {
+            let row = &self.raw[Line(l)];
+            if !row.has_extras {
+                continue;
+            }
+            for sq in &row.inner {
+                mark(&mut live, sq);
+            }
+        }
+        mark(&mut live, &self.cursor.template);
+        mark(&mut live, &self.saved_cursor.template);
+        self.extras_table.sweep_unmarked(&live);
+    }
+
     /// Read the style associated with the cell's style id.
     #[inline]
     pub fn style_of(&self, square: &Square) -> Style {

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -1369,8 +1369,15 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
 
+        // A Noop/CursorOnly frame normally has nothing to copy — but rows
+        // written after the damage event was consumed (e.g. a graphics
+        // insert racing a redraw) still carry their dirty bit. Fall
+        // through when any row is dirty so the snapshot can't go stale.
         if matches!(damage, TerminalDamage::Noop | TerminalDamage::CursorOnly) {
-            return;
+            let any_dirty = (0..count as i32).any(|y| self.grid[Line(start + y)].dirty);
+            if !any_dirty {
+                return;
+            }
         }
 
         #[allow(clippy::needless_range_loop)]
@@ -1405,6 +1412,11 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
         for sq in &row.inner {
+            // Bg-only cells reuse the extras_id bits for the bg color;
+            // reading them would insert junk map entries.
+            if sq.is_bg_only() {
+                continue;
+            }
             if let Some(id) = sq.extras_id() {
                 if let Some(live) = self.grid.extras_table.get(id) {
                     extras.insert(id, live.clone());
@@ -1791,12 +1803,18 @@ impl<U: EventListener> Crosswords<U> {
     #[inline]
     fn clear_cell_graphic(extras_table: &mut grid::ExtrasTable, cell: &mut Square) {
         if let Some(eid) = cell.extras_id() {
-            if let Some(extras) = extras_table.get_mut(eid) {
-                extras.graphic = None;
-                if extras.is_empty() {
-                    extras_table.free(eid);
-                    cell.set_extras_id(None);
+            match extras_table.get_mut(eid) {
+                Some(extras) => {
+                    extras.graphic = None;
+                    if extras.is_empty() {
+                        extras_table.free(eid);
+                        cell.set_extras_id(None);
+                    }
                 }
+                // Covered cells share one slot per image row; another cell
+                // already freed it. Drop the stale id so a reused slot
+                // isn't aliased.
+                None => cell.set_extras_id(None),
             }
         }
         cell.remove_cell_flag(CellFlags::GRAPHICS);
@@ -3675,12 +3693,19 @@ impl<U: EventListener> Handler for Crosswords<U> {
             id: graphic_id,
             width,
             height,
+            cell_width,
             cell_height,
             texture_operations: Arc::downgrade(&self.graphics.texture_operations),
         });
 
         self.graphics
             .register_placed_texture(graphic_id, Arc::downgrade(&texture));
+
+        // Reclaim slots dropped off the scrollback ring before allocating
+        // this image's rows against a nearly-full table.
+        if self.grid.extras_table.under_pressure() {
+            self.grid.gc_extras();
+        }
 
         for (top, offset_y) in (0..).zip((0..height).step_by(cell_height)) {
             let line = if scrolling {
@@ -3694,19 +3719,21 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 Line(top)
             };
 
-            // Store a reference to the graphic in the first column.
+            // One shared extras slot per image row: every covered cell
+            // points at the same `GraphicCell` and derives its own x
+            // offset from `anchor_col`. A slot per cell would exhaust
+            // the u16 extras id space in a dozen screen-sized images.
+            let graphic_cell = GraphicCell {
+                texture: texture.clone(),
+                offset_x: 0,
+                offset_y,
+                anchor_col: leftmost as u16,
+            };
+            let mut shared_eid: Option<square::ExtrasId> = None;
+
             let row_len = self.grid[line].len();
-            for (left, offset_x) in (leftmost..).zip((0..width).step_by(cell_width)) {
-                if left >= row_len {
-                    break;
-                }
-
-                let graphic_cell = GraphicCell {
-                    texture: texture.clone(),
-                    offset_x,
-                    offset_y,
-                };
-
+            let cols = (width as usize).div_ceil(cell_width);
+            for left in leftmost..(leftmost + cols).min(row_len) {
                 let cell_ref = &mut self.grid.raw[line][Column(left)];
 
                 // Bg-only cells (BgPalette/BgRgb) reuse the upper 32
@@ -3718,17 +3745,26 @@ impl<U: EventListener> Handler for Crosswords<U> {
                     cell_ref.clear();
                 }
 
-                // If the cell already has an extras slot (e.g. hyperlink),
-                // merge the graphic into it; otherwise allocate a new one.
+                // A cell that already has an extras slot (e.g. hyperlink)
+                // gets the graphic merged into its own slot — never into
+                // the shared one, which other cells read. Bare cells all
+                // point at the single shared slot.
                 if let Some(eid) = cell_ref.extras_id() {
                     if let Some(extras) = self.grid.extras_table.get_mut(eid) {
-                        extras.graphic = Some(smallvec::smallvec![graphic_cell]);
+                        extras.graphic = Some(smallvec::smallvec![graphic_cell.clone()]);
                     }
                 } else {
-                    let eid = self.grid.extras_table.alloc(square::Extras {
-                        graphic: Some(smallvec::smallvec![graphic_cell]),
-                        ..Default::default()
-                    });
+                    let eid = match shared_eid {
+                        Some(eid) => eid,
+                        None => {
+                            let eid = self.grid.extras_table.alloc(square::Extras {
+                                graphic: Some(smallvec::smallvec![graphic_cell.clone()]),
+                                ..Default::default()
+                            });
+                            shared_eid = Some(eid);
+                            eid
+                        }
+                    };
                     cell_ref.set_extras_id(Some(eid));
                 }
                 cell_ref.insert_cell_flag(CellFlags::GRAPHICS);
@@ -6150,8 +6186,11 @@ mod tests {
 
         cw.insert_graphic(graphic, None, None);
 
-        // The image spans rows 0..2, cols 0..2.
+        // The image spans rows 0..2, cols 0..2. Covered cells of one image
+        // row share a single GraphicCell (one extras slot per row); each
+        // cell's x offset derives from anchor_col.
         for row in 0..2 {
+            let mut row_eid = None;
             for col in 0..2 {
                 let cell = &cw.grid[Line(row)][Column(col)];
                 assert!(
@@ -6159,6 +6198,10 @@ mod tests {
                     "cell ({row},{col}) should have GRAPHICS flag"
                 );
                 let eid = cell.extras_id().expect("cell should have extras_id");
+                if let Some(prev) = row_eid {
+                    assert_eq!(eid, prev, "row {row} cells should share one slot");
+                }
+                row_eid = Some(eid);
                 let extras = cw
                     .grid
                     .extras_table
@@ -6171,8 +6214,10 @@ mod tests {
                     .first()
                     .expect("graphic SmallVec should have one entry");
 
-                // Verify offsets match the cell position.
-                assert_eq!(gc.offset_x, (col * 10) as u16);
+                // Derived offsets match the cell position.
+                let derived_x = gc.offset_x as usize
+                    + (col - gc.anchor_col as usize) * gc.texture.cell_width;
+                assert_eq!(derived_x, col * 10);
                 assert_eq!(gc.offset_y, (row * 10) as u16);
             }
         }

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -1110,6 +1110,7 @@ fn test_no_double_push_on_graphic_cell_drop() {
         id: GraphicId::new(99),
         width: 10,
         height: 20,
+        cell_width: 10,
         cell_height: 20,
         texture_operations: Arc::downgrade(&texture_ops),
     });
@@ -1119,11 +1120,13 @@ fn test_no_double_push_on_graphic_cell_drop() {
         texture: texture.clone(),
         offset_x: 0,
         offset_y: 0,
+        anchor_col: 0,
     };
     let cell2 = GraphicCell {
         texture: texture.clone(),
         offset_x: 10,
         offset_y: 0,
+        anchor_col: 0,
     };
 
     // Drop both cells — should NOT push to texture_operations (GraphicCell has no Drop impl)
@@ -1204,6 +1207,7 @@ fn test_collect_active_ids_uses_weak_refs() {
         id: GraphicId::new(1),
         width: 10,
         height: 20,
+        cell_width: 10,
         cell_height: 20,
         texture_operations: Arc::downgrade(&texture_ops),
     });


### PR DESCRIPTION
Fixes #1591 — `imgcat`, `icat`, `viu`, `chafa -f iterm` and sixel tools parsed fine but nothing ever rendered.

## Root cause

Since the kitty overlay rewrite, atlas graphics (sixel / iTerm2 OSC 1337) are parsed and uploaded into `sugarloaf.graphics` — a store **no draw path reads** (`Renderer::prepare` receives it as `_graphics`), and the per-cell `GraphicCell` references aren't consumed anywhere either. Only kitty images render, via `image_data` + `GraphicOverlay`s.

## Fix (3 commits)

1. **crosswords: make per-cell graphics state survive large inline images** — every covered cell used to allocate its own slot in the u16-indexed extras table, so ~a dozen screen-sized images exhausted the id space (images then rendered partially or not at all until restart). One shared slot per image row + a mark-and-sweep of unreferenced slots (which also reclaims images dropped off scrollback), plus two snapshot-freshness fixes.
2. **deps: enable TIFF decode** — chafa's iTerm2 renderer transmits TIFF; same change as #1428.
3. **rioterm: render sixel and iTerm2 graphics through the image overlay pipeline** — upload atlas pixels into the per-image texture store under a namespaced key (high bit keeps sequential `GraphicId`s out of the kitty protocol id space) and build overlays per frame by scanning visible rows for graphic cells, mirroring the kitty Unicode-placeholder pass. Row-runs coalesce into one overlay with a normalized source-rect slice, so partial overwrites hide exactly the erased region and images scroll with the grid. Also marks the panel dirty when `UpdateGraphics` arrives so the pixels aren't invisible until the next unrelated repaint.

## Tested (Linux/Wayland, Vulkan)

- `imgcat` (PNG), `chafa -f iterm` (TIFF), `chafa -f sixels`, `viu` — all render; `chafa -f kitty` unaffected.
- Repeated large (1600×900) images well past the old ~14-image exhaustion point; scrollback, `clear`, and partial overwrite behave.
- `cargo fmt`, `clippy`, and the full test suite pass; new behavior covered by updated graphics tests.