### PR TITLE
feat: session save/restore — tabs, splits, working dirs, scrollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,6 +4049,7 @@ dependencies = [
  "rio-window",
  "rustc-hash 2.1.2",
  "serde",
+ "serde_json",
  "smallvec",
  "sugarloaf",
  "taffy",

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -42,6 +42,7 @@ image_rs = { workspace = true }
 libc = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
+serde_json = "1.0"
 taffy = { version = "0.10.1", features = ["flexbox","grid"] }
 teletypewriter = { workspace = true }
 unicode-width = { workspace = true }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -36,6 +36,7 @@ pub struct Application<'a> {
     router: Router<'a>,
     scheduler: Scheduler,
     app_id: Option<String>,
+    session_name: Option<String>,
 }
 
 impl Application<'_> {
@@ -44,6 +45,7 @@ impl Application<'_> {
         config_error: Option<rio_backend::config::ConfigError>,
         event_loop: &EventLoop<EventPayload>,
         app_id: Option<String>,
+        session_name: Option<String>,
     ) -> Application<'app> {
         // SAFETY: Since this takes a pointer to the winit event loop, it MUST be dropped first,
         // which is done in `exiting`.
@@ -75,6 +77,7 @@ impl Application<'_> {
             router,
             scheduler,
             app_id,
+            session_name,
         }
     }
 
@@ -192,6 +195,40 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             None,
             self.app_id.as_deref(),
         );
+
+        if let Some(name) = self.session_name.clone() {
+            // `rio --session <name>`: explicit binding restores the
+            // named session (when it exists) regardless of the
+            // configured restore mode, and saves write back to it.
+            let name = crate::session::sanitize_name(&name);
+            if let Some(route) = self.router.routes.values_mut().next() {
+                route.session_name = Some(name.clone());
+                if let Some(state) = crate::session::SessionState::load(
+                    &rio_backend::config::session_named_path(&name),
+                ) {
+                    route.restore_session(state);
+                }
+            }
+        } else {
+            match self.config.session.restore {
+                rio_backend::config::session::SessionRestore::Never => {}
+                mode => {
+                    if let Some(state) = crate::session::SessionState::load(
+                        &rio_backend::config::session_file_path(),
+                    ) {
+                        if let Some(route) = self.router.routes.values_mut().next() {
+                            if mode
+                                == rio_backend::config::session::SessionRestore::Always
+                            {
+                                route.restore_session(state);
+                            } else {
+                                route.prompt_session_resume(state);
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         // Schedule title updates every 2s
         let timer_id = TimerId::new(Topic::UpdateTitles, 0);
@@ -430,6 +467,64 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     } else {
                         route.clear_errors();
                     }
+                }
+            }
+            RioEventType::Rio(RioEvent::SaveSession) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    route.save_session();
+                    route
+                        .window
+                        .screen
+                        .renderer
+                        .session_prompt
+                        .set_saved_notice(true);
+                    route.request_redraw();
+                    self.scheduler.schedule(
+                        EventPayload::new(
+                            RioEventType::Rio(RioEvent::ClearSessionNotice),
+                            window_id,
+                        ),
+                        Duration::from_millis(1500),
+                        false,
+                        TimerId::new(Topic::ClearSessionNotice, 0),
+                    );
+                }
+            }
+            RioEventType::Rio(RioEvent::SaveSessionAs(name)) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    route.save_session_as(&name);
+                    route
+                        .window
+                        .screen
+                        .renderer
+                        .session_prompt
+                        .set_saved_notice(true);
+                    route.request_redraw();
+                    self.scheduler.schedule(
+                        EventPayload::new(
+                            RioEventType::Rio(RioEvent::ClearSessionNotice),
+                            window_id,
+                        ),
+                        Duration::from_millis(1500),
+                        false,
+                        TimerId::new(Topic::ClearSessionNotice, 0),
+                    );
+                }
+            }
+            RioEventType::Rio(RioEvent::RestoreSessionByName(name)) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    route.restore_session_named(&name);
+                }
+            }
+            RioEventType::Rio(RioEvent::ClearSessionNotice) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    route
+                        .window
+                        .screen
+                        .renderer
+                        .session_prompt
+                        .set_saved_notice(false);
+                    route.request_redraw();
                 }
             }
             RioEventType::Rio(RioEvent::Exit | RioEvent::Quit) => {
@@ -1002,6 +1097,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             WindowEvent::MouseInput { state, button, .. } => {
                 if route.path != RoutePath::Terminal
                     || route.window.screen.renderer.confirm_quit.is_active()
+                    || route.window.screen.renderer.session_prompt.is_active()
                 {
                     #[cfg(target_os = "macos")]
                     if state == ElementState::Pressed
@@ -1310,6 +1406,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                 if route.path != RoutePath::Terminal
                     || route.window.screen.renderer.confirm_quit.is_active()
+                    || route.window.screen.renderer.session_prompt.is_active()
                 {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
@@ -1620,6 +1717,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             WindowEvent::MouseWheel { delta, phase, .. } => {
                 if route.path != RoutePath::Terminal
                     || route.window.screen.renderer.confirm_quit.is_active()
+                    || route.window.screen.renderer.session_prompt.is_active()
                 {
                     return;
                 }
@@ -1970,6 +2068,31 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
     // This is irreversible - if this event is emitted, it is guaranteed to be the last event that gets emitted.
     // You generally want to treat this as an “do on quit” event.
     fn exiting(&mut self, _event_loop: &ActiveEventLoop) {
+        if self.config.session.restore
+            == rio_backend::config::session::SessionRestore::Always
+        {
+            let max = self.config.session.max_scrollback_lines;
+            let windows: Vec<crate::session::WindowState> = self
+                .router
+                .routes
+                .values()
+                .map(|route| {
+                    crate::session::capture_window(
+                        route.window.screen.ctx(),
+                        max,
+                        &route.window.winit_window,
+                    )
+                })
+                .collect();
+            if !windows.is_empty() {
+                let state = crate::session::SessionState {
+                    version: crate::session::SESSION_VERSION,
+                    windows,
+                };
+                let _ = state.save(&rio_backend::config::session_file_path());
+            }
+        }
+
         // Ensure that all the windows are dropped, so the destructors for
         // Renderer and contexts ran.
         self.router.routes.clear();

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -215,6 +215,7 @@ impl From<String> for Action {
         let action_from_string = match action.as_str() {
             "paste" => Some(Action::Paste),
             "quit" => Some(Action::Quit),
+            "savesession" => Some(Action::SaveSession),
             "copy" => Some(Action::Copy),
             "searchforward" => Some(Action::SearchForward),
             "searchbackward" => Some(Action::SearchBackward),
@@ -401,6 +402,9 @@ pub enum Action {
 
     /// Quit Rio.
     Quit,
+
+    /// Save the current session (tabs/splits/CWDs/scrollback) to disk.
+    SaveSession,
 
     /// Clear warning and error notices.
     ClearLogNotice,
@@ -1007,6 +1011,7 @@ pub fn platform_key_bindings(
         "h", ModifiersState::SUPER | ModifiersState::ALT; Action::HideOtherApplications;
         "m", ModifiersState::SUPER; Action::Minimize;
         "q", ModifiersState::SUPER; Action::Quit;
+        "s", ModifiersState::SUPER | ModifiersState::SHIFT; Action::SaveSession;
         "n", ModifiersState::SUPER; Action::WindowCreateNew;
         ",", ModifiersState::SUPER; Action::ConfigEditor;
         "p", ModifiersState::SUPER | ModifiersState::SHIFT; Action::OpenCommandPalette;
@@ -1092,6 +1097,7 @@ pub fn platform_key_bindings(
         "-", ModifiersState::CONTROL;  Action::DecreaseFontSize;
         "-", ModifiersState::CONTROL;  Action::DecreaseFontSize;
         "n", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::WindowCreateNew;
+        "s", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::SaveSession;
         ",", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::ConfigEditor;
         "p", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::OpenCommandPalette;
 

--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -46,6 +46,11 @@ pub struct TerminalOptions {
     /// Set the Wayland app_id or X11 WM_CLASS (Linux/BSD only)
     #[clap(long)]
     pub app_id: Option<String>,
+
+    /// Bind this instance to a named session: restores
+    /// sessions/<NAME>.json on launch and saves back to it.
+    #[clap(long, value_name = "NAME")]
+    pub session: Option<String>,
 }
 
 impl TerminalOptions {

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -676,6 +676,24 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         self.event_proxy.send_event(RioEvent::Quit, self.window_id);
     }
 
+    #[inline]
+    pub fn request_save_session(&mut self) {
+        self.event_proxy
+            .send_event(RioEvent::SaveSession, self.window_id);
+    }
+
+    #[inline]
+    pub fn request_save_session_as(&mut self, name: String) {
+        self.event_proxy
+            .send_event(RioEvent::SaveSessionAs(name), self.window_id);
+    }
+
+    #[inline]
+    pub fn request_restore_session_named(&mut self, name: String) {
+        self.event_proxy
+            .send_event(RioEvent::RestoreSessionByName(name), self.window_id);
+    }
+
     #[cfg(target_os = "macos")]
     #[inline]
     pub fn hide_other_apps(&mut self) {
@@ -812,6 +830,117 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     #[inline]
     pub fn current_grid(&self) -> &ContextGrid<T> {
         &self.contexts[self.current_index]
+    }
+
+    /// All tabs, for session capture.
+    #[inline]
+    pub fn grids(&self) -> &[ContextGrid<T>] {
+        &self.contexts
+    }
+
+    /// Select the current grid's pane by visual order index. Used by
+    /// session restore to reselect the saved active pane.
+    pub fn select_pane_by_order(&mut self, index: usize) {
+        let grid = &mut self.contexts[self.current_index];
+        if let Some(&node) = grid.get_ordered_keys().get(index) {
+            grid.set_current(node);
+            self.current_route = grid.current().route_id;
+        }
+    }
+
+    /// Split the current pane, spawning the new pane's shell at `dir`.
+    /// Forces the spawn (non-fork) pty path — the fork path has no
+    /// working-directory support.
+    pub fn split_with_dir(
+        &mut self,
+        rich_text_id: usize,
+        split_down: bool,
+        sugarloaf: &mut Sugarloaf,
+        dir: Option<String>,
+    ) {
+        let mut cloned_config = self.config.clone();
+        if dir.is_some() {
+            cloned_config.working_dir = dir;
+            #[cfg(not(target_os = "windows"))]
+            {
+                cloned_config.use_fork = false;
+            }
+        }
+
+        let current = self.current();
+        let cursor = current.cursor_from_ref();
+
+        match ContextManager::create_context(
+            (&cursor, current.renderable_content.has_blinking_enabled),
+            self.event_proxy.clone(),
+            self.window_id,
+            rich_text_id,
+            self.current().dimension,
+            &cloned_config,
+        ) {
+            Ok(new_context) => {
+                let new_route_id = new_context.route_id;
+                if split_down {
+                    self.contexts[self.current_index].split_down(new_context, sugarloaf);
+                } else {
+                    self.contexts[self.current_index].split_right(new_context, sugarloaf);
+                }
+                self.current_route = new_route_id;
+            }
+            Err(..) => {
+                tracing::error!("session restore: not able to create a split context");
+            }
+        }
+    }
+
+    /// Add a tab whose shell spawns at `dir` (session restore). Same
+    /// spawn-path requirement as `split_with_dir`.
+    pub fn add_context_with_dir(&mut self, rich_text_id: usize, dir: Option<String>) {
+        let mut cloned_config = self.config.clone();
+        if dir.is_some() {
+            cloned_config.working_dir = dir;
+            #[cfg(not(target_os = "windows"))]
+            {
+                cloned_config.use_fork = false;
+            }
+        }
+
+        if self.contexts.len() >= self.capacity {
+            return;
+        }
+        let last_index = self.contexts.len();
+        let current = self.current();
+        let cursor = current.cursor_from_ref();
+        let mut dimension = current.dimension;
+        if self.current_grid().len() > 1 {
+            dimension = self.current_grid().grid_dimension();
+        }
+
+        match ContextManager::create_context(
+            (&cursor, current.renderable_content.has_blinking_enabled),
+            self.event_proxy.clone(),
+            self.window_id,
+            rich_text_id,
+            dimension,
+            &cloned_config,
+        ) {
+            Ok(new_context) => {
+                let previous_scaled_margin =
+                    self.contexts[self.current_index].scaled_margin;
+                self.contexts.push(ContextGrid::new(
+                    new_context,
+                    previous_scaled_margin,
+                    self.config.split_color,
+                    self.config.split_active_color,
+                    self.config.panel,
+                ));
+                self.current_index = last_index;
+                self.current_route = self.current().route_id;
+            }
+            Err(..) => {
+                tracing::error!("session restore: not able to create a tab context");
+            }
+        }
     }
 
     #[inline]

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -946,6 +946,122 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
         &self.inner
     }
 
+    /// Serialize the split tree for session save. Panes are the nodes
+    /// present in `inner`; anything else is a flex container. Containers
+    /// with a single child (e.g. the root wrapper) are collapsed.
+    pub fn to_layout_node(
+        &self,
+        capture_pane: &mut dyn FnMut(&Context<T>, bool) -> crate::session::PaneState,
+    ) -> crate::session::LayoutNode {
+        use crate::session::{LayoutNode, SplitDir};
+
+        fn walk<T: rio_backend::event::EventListener>(
+            grid: &ContextGrid<T>,
+            node: NodeId,
+            capture_pane: &mut dyn FnMut(&Context<T>, bool) -> crate::session::PaneState,
+        ) -> Option<LayoutNode> {
+            if let Some(item) = grid.inner.get(&node) {
+                return Some(LayoutNode::Leaf(capture_pane(
+                    &item.val,
+                    node == grid.current,
+                )));
+            }
+            let children = grid.tree.children(node).ok()?;
+            let direction = grid
+                .tree
+                .style(node)
+                .map(|s| match s.flex_direction {
+                    taffy::FlexDirection::Column
+                    | taffy::FlexDirection::ColumnReverse => SplitDir::Vertical,
+                    _ => SplitDir::Horizontal,
+                })
+                .unwrap_or(SplitDir::Horizontal);
+
+            let mut nodes = Vec::new();
+            for child in children {
+                let weight = grid
+                    .tree
+                    .style(child)
+                    .map(|s| s.flex_grow)
+                    .unwrap_or(1.0)
+                    .max(0.01);
+                if let Some(n) = walk(grid, child, capture_pane) {
+                    nodes.push((weight, n));
+                }
+            }
+            match nodes.len() {
+                0 => None,
+                1 => Some(nodes.pop().unwrap().1),
+                _ => Some(LayoutNode::Split {
+                    direction,
+                    children: nodes,
+                }),
+            }
+        }
+
+        walk(self, self.root_node, capture_pane).unwrap_or_else(|| {
+            // Degenerate fallback: a grid always has at least one pane.
+            let item = self.inner.get(&self.current).expect("grid has a pane");
+            crate::session::LayoutNode::Leaf(capture_pane(&item.val, true))
+        })
+    }
+
+    /// Point `current` at a specific pane. Used by session restore to
+    /// choose which leaf the next split acts on.
+    pub fn set_current(&mut self, node: NodeId) -> bool {
+        if self.inner.contains_key(&node) {
+            self.current = node;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Re-apply saved split ratios after a session rebuild: walk the
+    /// live tree parallel to the saved layout and copy each child's
+    /// weight into its `flex_grow`. Shape mismatches stop silently —
+    /// content correctness never depends on ratios.
+    pub fn apply_layout_weights(&mut self, layout: &crate::session::LayoutNode) {
+        use crate::session::LayoutNode;
+
+        fn walk<T: rio_backend::event::EventListener>(
+            grid: &mut ContextGrid<T>,
+            node: NodeId,
+            layout: &LayoutNode,
+        ) {
+            // Collapse single-child containers the same way capture does.
+            let mut node = node;
+            while !grid.inner.contains_key(&node) {
+                match grid.tree.children(node) {
+                    Ok(children) if children.len() == 1 => node = children[0],
+                    _ => break,
+                }
+            }
+            let LayoutNode::Split { children, .. } = layout else {
+                return;
+            };
+            let Ok(live_children) = grid.tree.children(node) else {
+                return;
+            };
+            if live_children.len() != children.len() {
+                return;
+            }
+            for (child_node, (weight, child_layout)) in
+                live_children.into_iter().zip(children)
+            {
+                if let Ok(mut style) = grid.tree.style(child_node).cloned() {
+                    style.flex_basis = length(0.0);
+                    style.flex_grow = *weight;
+                    style.flex_shrink = 1.0;
+                    let _ = grid.tree.set_style(child_node, style);
+                }
+                walk(grid, child_node, child_layout);
+            }
+        }
+
+        walk(self, self.root_node, layout);
+    }
+
     /// Get contexts ordered by visual position (top-to-bottom, left-to-right)
     pub fn get_ordered_keys(&self) -> Vec<NodeId> {
         let mut panels: Vec<(NodeId, f32, f32)> = self

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -22,6 +22,7 @@ mod renderer;
 mod router;
 mod scheduler;
 mod screen;
+mod session;
 mod watcher;
 
 use clap::Parser;
@@ -237,12 +238,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rio_window::event_loop::EventLoop::<EventPayload>::with_user_event().build()?;
 
     let app_id = args.window_options.terminal_options.app_id;
+    let session_name = args.window_options.terminal_options.session;
 
     let mut application = crate::application::Application::new(
         config,
         config_error,
         &window_event_loop,
         app_id,
+        session_name,
     );
     let _ = application.run(window_event_loop);
 

--- a/frontends/rioterm/src/renderer/command_palette.rs
+++ b/frontends/rioterm/src/renderer/command_palette.rs
@@ -69,6 +69,8 @@ const ORDER: u8 = 20;
 /// Actions that can be triggered from the command palette.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PaletteAction {
+    SaveSessionAs,
+    RestoreSessionPicker,
     TabCreate,
     TabClose,
     TabCloseUnfocused,
@@ -232,6 +234,16 @@ const COMMANDS: &[Command] = &[
         shortcut: "Cmd+Q",
         action: PaletteAction::Quit,
     },
+    Command {
+        title: "Save Session As...",
+        shortcut: "",
+        action: PaletteAction::SaveSessionAs,
+    },
+    Command {
+        title: "Restore Session...",
+        shortcut: "",
+        action: PaletteAction::RestoreSessionPicker,
+    },
 ];
 
 /// What the palette is currently browsing and filtering over.
@@ -247,6 +259,12 @@ const COMMANDS: &[Command] = &[
 enum PaletteMode {
     Commands,
     Fonts(Vec<String>),
+    /// Saved-session picker. `saving` chooses what Enter means:
+    /// save-as (the query itself is a valid new name) vs restore.
+    Sessions {
+        names: Vec<String>,
+        saving: bool,
+    },
 }
 
 /// One row in the filtered result list. Variants carry exactly the
@@ -258,16 +276,20 @@ enum PaletteRow<'a> {
         shortcut: &'a str,
         action: PaletteAction,
     },
+    Session {
+        name: std::borrow::Cow<'a, str>,
+    },
     Font {
         family: &'a str,
     },
 }
 
 impl<'a> PaletteRow<'a> {
-    fn title(&self) -> &'a str {
-        match *self {
+    fn title(&self) -> &str {
+        match self {
             PaletteRow::Command { title, .. } => title,
             PaletteRow::Font { family } => family,
+            PaletteRow::Session { name } => name,
         }
     }
 
@@ -275,6 +297,7 @@ impl<'a> PaletteRow<'a> {
         match *self {
             PaletteRow::Command { shortcut, .. } => shortcut,
             PaletteRow::Font { .. } => "",
+            PaletteRow::Session { .. } => "",
         }
     }
 
@@ -282,6 +305,7 @@ impl<'a> PaletteRow<'a> {
         match *self {
             PaletteRow::Command { action, .. } => Some(action),
             PaletteRow::Font { .. } => None,
+            PaletteRow::Session { .. } => None,
         }
     }
 }
@@ -497,6 +521,31 @@ impl CommandPalette {
     /// list. Clears the query so the full list is visible, keeps the
     /// palette open. Called by the router after the user picks the
     /// `List Fonts` command.
+    /// Swap into the saved-session picker. `saving` selects the Enter
+    /// semantics (save-as vs restore).
+    pub fn enter_sessions_mode(&mut self, names: Vec<String>, saving: bool) {
+        self.mode = PaletteMode::Sessions { names, saving };
+        self.query.clear();
+        self.selected_index = 0;
+        self.scroll_offset = 0;
+        self.caret_blink_start = Instant::now();
+        self.last_scroll_time = None;
+    }
+
+    /// Selected (or typed, in save-as mode) session name plus the
+    /// `saving` flag. Owned so the caller can mutate palette state.
+    pub fn get_selected_session(&self) -> Option<(String, bool)> {
+        let PaletteMode::Sessions { saving, .. } = self.mode else {
+            return None;
+        };
+        self.filtered_rows()
+            .get(self.selected_index)
+            .and_then(|(_, row)| match row {
+                PaletteRow::Session { name } => Some((name.to_string(), saving)),
+                _ => None,
+            })
+    }
+
     pub fn enter_fonts_mode(&mut self, fonts: Vec<String>) {
         self.mode = PaletteMode::Fonts(fonts);
         self.query.clear();
@@ -552,7 +601,7 @@ impl CommandPalette {
             .get(self.selected_index)
             .and_then(|(_, row)| match row {
                 PaletteRow::Font { family } => Some((*family).to_owned()),
-                PaletteRow::Command { .. } => None,
+                _ => None,
             })
     }
 
@@ -591,6 +640,35 @@ impl CommandPalette {
                     Some((score, PaletteRow::Font { family }))
                 })
                 .collect(),
+            PaletteMode::Sessions { names, saving } => {
+                let mut rows: Vec<(i32, PaletteRow<'_>)> = names
+                    .iter()
+                    .filter_map(|name| {
+                        let score = fuzzy_score(&self.query, name)?;
+                        Some((
+                            score,
+                            PaletteRow::Session {
+                                name: std::borrow::Cow::Borrowed(name.as_str()),
+                            },
+                        ))
+                    })
+                    .collect();
+                // Save-as: the typed query is itself a valid new name.
+                // Offer it as the top row unless it exactly matches an
+                // existing session (that row already covers overwrite).
+                if *saving && !self.query.trim().is_empty() {
+                    let typed = crate::session::sanitize_name(&self.query);
+                    if !typed.is_empty() && !names.contains(&typed) {
+                        rows.push((
+                            i32::MAX,
+                            PaletteRow::Session {
+                                name: std::borrow::Cow::Owned(typed),
+                            },
+                        ));
+                    }
+                }
+                rows
+            }
         };
 
         results.sort_by_key(|r| std::cmp::Reverse(r.0));
@@ -708,6 +786,8 @@ impl CommandPalette {
         let placeholder = match self.mode {
             PaletteMode::Commands => "Type a command...",
             PaletteMode::Fonts(_) => "Type a font name...",
+            PaletteMode::Sessions { saving: true, .. } => "Type a session name...",
+            PaletteMode::Sessions { saving: false, .. } => "Pick a session to restore...",
         };
         let display_text = if self.query.is_empty() {
             placeholder

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -6,6 +6,7 @@ pub mod helpers;
 pub mod island;
 pub mod scrollbar;
 pub mod search;
+pub mod session_prompt;
 pub mod trail_cursor;
 pub mod utils;
 
@@ -68,6 +69,11 @@ pub struct Renderer {
     pub search: search::SearchOverlay,
     pub assistant: assistant::AssistantOverlay,
     pub confirm_quit: confirm_quit::ConfirmQuit,
+    pub session_prompt: session_prompt::SessionPrompt,
+    /// `[session]` config snapshot the prompt/save flows read — the
+    /// renderer is rebuilt on config reload so this stays current.
+    pub session_restore: rio_backend::config::session::SessionRestore,
+    pub session_max_scrollback: usize,
     pub scrollbar: scrollbar::Scrollbar,
     #[allow(unused)]
     pub option_as_alt: String,
@@ -156,6 +162,9 @@ impl Renderer {
             search: search::SearchOverlay::default(),
             assistant: assistant::AssistantOverlay::default(),
             confirm_quit: confirm_quit::ConfirmQuit::default(),
+            session_prompt: session_prompt::SessionPrompt::default(),
+            session_restore: config.session.restore,
+            session_max_scrollback: config.session.max_scrollback_lines,
             scrollbar: scrollbar::Scrollbar::new(config.enable_scroll_bar),
             is_game_mode_enabled: config.renderer.strategy.is_game(),
             custom_mouse_cursor: config.effects.custom_mouse_cursor,
@@ -601,6 +610,11 @@ impl Renderer {
         );
 
         self.confirm_quit.render(
+            sugarloaf,
+            (window_size.width, window_size.height, scale_factor),
+        );
+
+        self.session_prompt.render(
             sugarloaf,
             (window_size.width, window_size.height, scale_factor),
         );

--- a/frontends/rioterm/src/renderer/session_prompt.rs
+++ b/frontends/rioterm/src/renderer/session_prompt.rs
@@ -1,0 +1,143 @@
+use rio_backend::sugarloaf::text::DrawOpts;
+use rio_backend::sugarloaf::Sugarloaf;
+
+const CONFIRM: &str = "yes (y)";
+const DISMISS: &str = "no (n)";
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum SessionPromptKind {
+    SaveOnExit,
+    ResumeOnLaunch,
+}
+
+/// Session save/resume overlay; same shape as `ConfirmQuit`, but which
+/// action the keys gate depends on the active kind.
+#[derive(Default)]
+pub struct SessionPrompt {
+    active: Option<SessionPromptKind>,
+    /// Transient "session saved" flash; cleared by a scheduler event.
+    saved_notice: bool,
+}
+
+impl SessionPrompt {
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        self.active.is_some()
+    }
+
+    #[inline]
+    pub fn kind(&self) -> Option<SessionPromptKind> {
+        self.active
+    }
+
+    #[inline]
+    pub fn set_active(&mut self, kind: Option<SessionPromptKind>) {
+        self.active = kind;
+    }
+
+    #[inline]
+    pub fn set_saved_notice(&mut self, on: bool) {
+        self.saved_notice = on;
+    }
+
+    /// `dimensions` is `(window_width, window_height, scale_factor)`,
+    /// matching the other overlays' `render` signature.
+    pub fn render(&self, sugarloaf: &mut Sugarloaf, dimensions: (f32, f32, f32)) {
+        if self.saved_notice {
+            self.render_saved_notice(sugarloaf, dimensions);
+        }
+        let Some(kind) = self.active else {
+            return;
+        };
+        let heading = match kind {
+            SessionPromptKind::SaveOnExit => "save session?",
+            SessionPromptKind::ResumeOnLaunch => "resume last session?",
+        };
+
+        let (width, height, scale) = dimensions;
+        let win_w = width / scale;
+        let win_h = height / scale;
+
+        let full_text = format!("{}  {}  /  {}", heading, CONFIRM, DISMISS);
+        let padding_x = 12.0;
+        let padding_y = 6.0;
+        let text_h = 16.0;
+        let box_w = full_text.len() as f32 * 7.5 + padding_x * 2.0;
+        let box_h = text_h + padding_y * 2.0;
+        let box_x = (win_w - box_w) / 2.0;
+        let box_y = (win_h - box_h) / 2.0;
+
+        sugarloaf.rect(
+            None,
+            box_x,
+            box_y,
+            box_w,
+            box_h,
+            [0.0, 0.0, 0.0, 1.0],
+            0.0,
+            20,
+        );
+
+        let heading_opts = DrawOpts {
+            font_size: 13.0,
+            color: [255, 255, 255, 255],
+            ..DrawOpts::default()
+        };
+        let gray_opts = DrawOpts {
+            font_size: 13.0,
+            color: [166, 166, 166, 255],
+            ..DrawOpts::default()
+        };
+
+        let text_x = box_x + padding_x;
+        let text_y = box_y + padding_y + 2.0;
+
+        let ui = sugarloaf.text_mut();
+        let heading_w = ui.draw(text_x, text_y, heading, &heading_opts);
+        ui.draw(
+            text_x + heading_w,
+            text_y,
+            &format!("  {CONFIRM}  /  {DISMISS}"),
+            &gray_opts,
+        );
+    }
+
+    fn render_saved_notice(
+        &self,
+        sugarloaf: &mut Sugarloaf,
+        dimensions: (f32, f32, f32),
+    ) {
+        const NOTICE: &str = "session saved";
+        let (width, _, scale) = dimensions;
+        let win_w = width / scale;
+
+        let padding_x = 10.0;
+        let padding_y = 5.0;
+        let box_w = NOTICE.len() as f32 * 7.5 + padding_x * 2.0;
+        let box_h = 16.0 + padding_y * 2.0;
+        let box_x = win_w - box_w - 12.0;
+        let box_y = 40.0;
+
+        sugarloaf.rect(
+            None,
+            box_x,
+            box_y,
+            box_w,
+            box_h,
+            [0.0, 0.0, 0.0, 0.9],
+            0.0,
+            20,
+        );
+        let opts = DrawOpts {
+            font_size: 13.0,
+            color: [140, 220, 140, 255],
+            ..DrawOpts::default()
+        };
+        sugarloaf.text_mut().draw(
+            box_x + padding_x,
+            box_y + padding_y + 2.0,
+            NOTICE,
+            &opts,
+        );
+    }
+}

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -1,6 +1,7 @@
 pub mod routes;
 mod window;
 use crate::event::EventProxy;
+use crate::renderer::session_prompt::SessionPromptKind;
 use crate::router::window::{
     configure_window, create_window_builder, DEFAULT_MINIMUM_WINDOW_HEIGHT,
     DEFAULT_MINIMUM_WINDOW_WIDTH,
@@ -35,6 +36,12 @@ pub struct Route<'a> {
     pub assistant: assistant::Assistant,
     pub path: RoutePath,
     pub window: RouteWindow<'a>,
+    /// Parsed session waiting on the launch "resume?" answer.
+    pub pending_session: Option<crate::session::SessionState>,
+    /// Named-session binding (`rio --session <name>`): saves and
+    /// quit-prompts target `sessions/<name>.json` instead of the
+    /// implicit last-session slot.
+    pub session_name: Option<String>,
 }
 
 impl Route<'_> {
@@ -49,6 +56,8 @@ impl Route<'_> {
             assistant,
             path,
             window,
+            pending_session: None,
+            session_name: None,
         }
     }
 }
@@ -137,7 +146,175 @@ impl Route<'_> {
 
     #[inline]
     pub fn quit(&mut self) {
+        use rio_backend::config::session::SessionRestore;
+        match self.window.screen.renderer.session_restore {
+            SessionRestore::Prompt => {
+                self.window.screen.renderer.confirm_quit.set_active(false);
+                self.window
+                    .screen
+                    .renderer
+                    .session_prompt
+                    .set_active(Some(SessionPromptKind::SaveOnExit));
+                self.request_overlay_redraw();
+                return;
+            }
+            SessionRestore::Always => self.save_session(),
+            SessionRestore::Never => {}
+        }
         std::process::exit(0);
+    }
+
+    /// Target file for this window's session saves: the bound name
+    /// (CLI/save-as) or the implicit last-session slot.
+    fn session_path(&self) -> std::path::PathBuf {
+        match &self.session_name {
+            Some(name) => {
+                let _ = std::fs::create_dir_all(rio_backend::config::sessions_dir_path());
+                rio_backend::config::session_named_path(name)
+            }
+            None => rio_backend::config::session_file_path(),
+        }
+    }
+
+    /// Persist this window's tabs/splits/CWDs/scrollback to disk.
+    pub fn save_session(&mut self) {
+        let max = self.window.screen.renderer.session_max_scrollback;
+        let state = crate::session::SessionState {
+            version: crate::session::SESSION_VERSION,
+            windows: vec![crate::session::capture_window(
+                self.window.screen.ctx(),
+                max,
+                &self.window.winit_window,
+            )],
+        };
+        if let Err(err) = state.save(&self.session_path()) {
+            tracing::warn!("session save failed: {err}");
+        }
+    }
+
+    /// Palette "Save Session As": bind this window to `name` and save.
+    pub fn save_session_as(&mut self, name: &str) {
+        let name = crate::session::sanitize_name(name);
+        if name.is_empty() {
+            return;
+        }
+        self.session_name = Some(name);
+        self.save_session();
+    }
+
+    /// Palette "Restore Session": append a named session's tabs to
+    /// this window. Named sessions are workspaces — never consumed.
+    pub fn restore_session_named(&mut self, name: &str) {
+        let path = rio_backend::config::session_named_path(name);
+        if let Some(state) = crate::session::SessionState::load(&path) {
+            self.session_name = Some(name.to_string());
+            self.restore_session_inner(state, false);
+        }
+    }
+
+    /// Offer to resume `state` (activates the launch prompt).
+    pub fn prompt_session_resume(&mut self, state: crate::session::SessionState) {
+        self.pending_session = Some(state);
+        self.window
+            .screen
+            .renderer
+            .session_prompt
+            .set_active(Some(SessionPromptKind::ResumeOnLaunch));
+        self.request_overlay_redraw();
+    }
+
+    /// Rebuild tabs/splits/scrollback from a saved session, replacing
+    /// the window's default tab (launch-time restore).
+    pub fn restore_session(&mut self, state: crate::session::SessionState) {
+        self.restore_session_inner(state, true);
+    }
+
+    fn restore_session_inner(
+        &mut self,
+        state: crate::session::SessionState,
+        replace: bool,
+    ) {
+        let Some(win) = state.windows.into_iter().next() else {
+            return;
+        };
+        if win.tabs.is_empty() {
+            return;
+        }
+        if replace && win.size.0 > 0 && win.size.1 > 0 {
+            // When the platform applies the size immediately (Wayland),
+            // no Resized event follows — run the resize pipeline here so
+            // the layout and the tabs built below use the final size.
+            if let Some(applied) = self
+                .window
+                .winit_window
+                .request_inner_size(PhysicalSize::new(win.size.0, win.size.1))
+            {
+                if applied.width > 0 && applied.height > 0 {
+                    self.window.screen.resize(applied);
+                }
+            }
+        }
+        // No-op on Wayland: the compositor owns placement.
+        if let (true, Some((x, y))) = (replace, win.position) {
+            self.window
+                .winit_window
+                .set_outer_position(PhysicalPosition::new(x, y));
+        }
+        let screen = &mut self.window.screen;
+        for tab in &win.tabs {
+            let first = tab.layout.first_leaf();
+
+            // Mirror Screen::create_tab: grow the top margin before the
+            // tab exists (hide_if_single -> visible transition) and
+            // reposition the previous tab's rich texts.
+            let num_tabs = screen.ctx().len();
+            let old_index = screen.context_manager.current_index();
+            screen.resize_top_or_bottom_line(num_tabs + 1);
+            #[cfg(not(target_os = "macos"))]
+            screen.context_manager.contexts_mut()[old_index]
+                .update_dimensions(&mut screen.sugarloaf);
+
+            screen.ctx_mut().add_context_with_dir(
+                crate::context::next_rich_text_id(),
+                first.cwd.clone(),
+            );
+            let new_index = screen.context_manager.current_index();
+            screen.context_manager.switch_context_visibility(
+                &mut screen.sugarloaf,
+                old_index,
+                new_index,
+            );
+            screen.ctx_mut().current_grid_mut().custom_title = tab.custom_title.clone();
+            crate::session::restore_tab_layout(
+                &mut screen.context_manager,
+                &tab.layout,
+                &mut screen.sugarloaf,
+            );
+        }
+        if replace {
+            // Drop the default tab the window opened with; the restored
+            // tabs then sit at their saved indices.
+            screen.ctx_mut().select_tab(0);
+            screen
+                .context_manager
+                .close_current_context(&mut screen.sugarloaf);
+            let num_tabs = screen.ctx().len();
+            screen.resize_top_or_bottom_line(num_tabs);
+            screen
+                .ctx_mut()
+                .select_tab(win.active_tab.min(win.tabs.len().saturating_sub(1)));
+        }
+        screen.resize_all_contexts();
+
+        // The implicit last-session slot is consumed once restored;
+        // quitting offers a fresh save, so a stale copy must not
+        // re-prompt next launch. Named sessions persist.
+        if replace && self.session_name.is_none() {
+            crate::session::SessionState::discard(
+                &rio_backend::config::session_file_path(),
+            );
+        }
+        self.request_redraw();
     }
 
     #[inline]
@@ -218,6 +395,35 @@ impl Route<'_> {
                             .get_selected_action();
                         use crate::renderer::command_palette::PaletteAction;
 
+                        // Sessions-mode Enter: save-as or restore the
+                        // picked name, then close the palette.
+                        if let Some((name, saving)) = self
+                            .window
+                            .screen
+                            .renderer
+                            .command_palette
+                            .get_selected_session()
+                        {
+                            self.window
+                                .screen
+                                .renderer
+                                .command_palette
+                                .set_enabled(false);
+                            if saving {
+                                self.window
+                                    .screen
+                                    .context_manager
+                                    .request_save_session_as(name);
+                            } else {
+                                self.window
+                                    .screen
+                                    .context_manager
+                                    .request_restore_session_named(name);
+                            }
+                            self.request_overlay_redraw();
+                            return true;
+                        }
+
                         // Fonts-mode Enter: copy the family name to
                         // the system clipboard and close. The copy
                         // icon on each row advertises this.
@@ -248,6 +454,22 @@ impl Route<'_> {
                                     .renderer
                                     .command_palette
                                     .enter_fonts_mode(fonts);
+                            }
+                            // Sessions pickers stay inside the palette,
+                            // swapping to the saved-session list.
+                            Some(
+                                action @ (PaletteAction::SaveSessionAs
+                                | PaletteAction::RestoreSessionPicker),
+                            ) => {
+                                let names = crate::session::list_sessions();
+                                self.window
+                                    .screen
+                                    .renderer
+                                    .command_palette
+                                    .enter_sessions_mode(
+                                        names,
+                                        action == PaletteAction::SaveSessionAs,
+                                    );
                             }
                             // Any other command is a one-shot: close
                             // the palette first, then dispatch.
@@ -326,8 +548,55 @@ impl Route<'_> {
                         self.request_overlay_redraw();
                     }
                     Key::Character(c) if c.as_str() == "y" || c.as_str() == "Y" => {
+                        self.window.screen.renderer.confirm_quit.set_active(false);
                         self.quit();
                         return true;
+                    }
+                    _ => {}
+                }
+            }
+            return true;
+        }
+
+        if let Some(kind) = self.window.screen.renderer.session_prompt.kind() {
+            if key_event.state == rio_window::event::ElementState::Pressed {
+                match (&key_event.logical_key, kind) {
+                    (Key::Character(c), SessionPromptKind::SaveOnExit)
+                        if c.as_str() == "y" || c.as_str() == "Y" =>
+                    {
+                        self.save_session();
+                        std::process::exit(0);
+                    }
+                    (Key::Character(c), SessionPromptKind::SaveOnExit)
+                        if c.as_str() == "n" || c.as_str() == "N" =>
+                    {
+                        std::process::exit(0);
+                    }
+                    (Key::Character(c), SessionPromptKind::ResumeOnLaunch)
+                        if c.as_str() == "y" || c.as_str() == "Y" =>
+                    {
+                        self.window.screen.renderer.session_prompt.set_active(None);
+                        if let Some(state) = self.pending_session.take() {
+                            self.restore_session(state);
+                        }
+                        self.request_overlay_redraw();
+                    }
+                    (Key::Character(c), SessionPromptKind::ResumeOnLaunch)
+                        if c.as_str() == "n" || c.as_str() == "N" =>
+                    {
+                        self.window.screen.renderer.session_prompt.set_active(None);
+                        self.pending_session = None;
+                        crate::session::SessionState::discard(
+                            &rio_backend::config::session_file_path(),
+                        );
+                        self.request_overlay_redraw();
+                    }
+                    // Esc cancels: on exit it aborts the quit, on
+                    // launch it keeps the file for next time.
+                    (Key::Named(NamedKey::Escape), _) => {
+                        self.window.screen.renderer.session_prompt.set_active(None);
+                        self.pending_session = None;
+                        self.request_overlay_redraw();
                     }
                     _ => {}
                 }
@@ -533,6 +802,8 @@ impl Router<'_> {
             window,
             path: RoutePath::Terminal,
             assistant: Assistant::new(),
+            pending_session: None,
+            session_name: None,
         };
 
         if let Some(err) = &self.propagated_report {
@@ -569,6 +840,8 @@ impl Router<'_> {
                 window,
                 path: RoutePath::Terminal,
                 assistant: Assistant::new(),
+                pending_session: None,
+                session_name: None,
             },
         );
     }

--- a/frontends/rioterm/src/scheduler.rs
+++ b/frontends/rioterm/src/scheduler.rs
@@ -29,6 +29,7 @@ pub enum Topic {
     CursorBlinking,
     UpdateTitles,
     SelectionScrolling,
+    ClearSessionNotice,
 }
 
 /// Event scheduled to be emitted at a specific time.

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1115,6 +1115,9 @@ impl Screen<'_> {
                     Act::Quit => {
                         self.context_manager.quit();
                     }
+                    Act::SaveSession => {
+                        self.context_manager.request_save_session();
+                    }
                     Act::IncreaseFontSize => {
                         self.change_font_size(FontSizeAction::Increase);
                     }
@@ -3482,6 +3485,9 @@ impl Screen<'_> {
                 // caller firing the action directly — do nothing so the
                 // palette just closes without side effects.
             }
+            // Handled in the router before dispatch (they swap the
+            // palette into sessions mode and keep it open).
+            PaletteAction::SaveSessionAs | PaletteAction::RestoreSessionPicker => {}
             PaletteAction::Quit => {
                 self.context_manager.quit();
             }

--- a/frontends/rioterm/src/session/mod.rs
+++ b/frontends/rioterm/src/session/mod.rs
@@ -1,0 +1,266 @@
+//! Session save/restore: tabs, split layout, per-pane working directory
+//! and styled scrollback, persisted across runs (`[session]` config).
+
+use crate::context::{self, ContextManager};
+use rio_backend::event::EventListener;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Bumped whenever the on-disk shape changes; mismatched files are
+/// discarded rather than migrated.
+pub const SESSION_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize)]
+pub struct SessionState {
+    pub version: u32,
+    pub windows: Vec<WindowState>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WindowState {
+    pub tabs: Vec<TabState>,
+    pub active_tab: usize,
+    /// Physical inner size; (0, 0) when unknown.
+    #[serde(default)]
+    pub size: (u32, u32),
+    /// Physical outer position. Absent on Wayland (compositor-placed).
+    #[serde(default)]
+    pub position: Option<(i32, i32)>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TabState {
+    pub layout: LayoutNode,
+    pub custom_title: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum LayoutNode {
+    Leaf(PaneState),
+    /// Weight is the child's taffy `flex_grow` — proportional share of
+    /// the container, not an absolute size.
+    Split {
+        direction: SplitDir,
+        children: Vec<(f32, LayoutNode)>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq)]
+pub enum SplitDir {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PaneState {
+    pub cwd: Option<String>,
+    pub title: Option<String>,
+    pub is_active: bool,
+    pub scrollback: String,
+}
+
+impl LayoutNode {
+    /// The pane a subtree's first split-off context should spawn as.
+    pub fn first_leaf(&self) -> &PaneState {
+        match self {
+            LayoutNode::Leaf(p) => p,
+            LayoutNode::Split { children, .. } => children[0].1.first_leaf(),
+        }
+    }
+}
+
+impl SessionState {
+    pub fn load(path: &Path) -> Option<SessionState> {
+        let bytes = std::fs::read(path).ok()?;
+        let state: SessionState = serde_json::from_slice(&bytes).ok()?;
+        if state.version != SESSION_VERSION || state.windows.is_empty() {
+            return None;
+        }
+        Some(state)
+    }
+
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        let bytes = serde_json::to_vec(self).map_err(std::io::Error::other)?;
+        std::fs::write(path, bytes)
+    }
+
+    pub fn discard(path: &Path) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Keep names filesystem-safe: anything outside [A-Za-z0-9._-]
+/// becomes '-'.
+pub fn sanitize_name(name: &str) -> String {
+    name.trim()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Saved session names (sessions/*.json), sorted.
+pub fn list_sessions() -> Vec<String> {
+    let mut names: Vec<String> =
+        std::fs::read_dir(rio_backend::config::sessions_dir_path())
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter_map(|entry| {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "json") {
+                    path.file_stem().map(|s| s.to_string_lossy().into_owned())
+                } else {
+                    None
+                }
+            })
+            .collect();
+    names.sort();
+    names
+}
+
+/// Capture one window's tabs from the live context tree.
+pub fn capture_window<T: EventListener + Clone + Send + 'static>(
+    ctx_manager: &ContextManager<T>,
+    max_scrollback_lines: usize,
+    winit_window: &rio_window::window::Window,
+) -> WindowState {
+    let size = winit_window.inner_size();
+    let position = winit_window.outer_position().ok().map(|p| (p.x, p.y));
+    let tabs = ctx_manager
+        .grids()
+        .iter()
+        .map(|grid| TabState {
+            custom_title: grid.custom_title.clone(),
+            layout: grid.to_layout_node(&mut |ctx, is_active| {
+                capture_pane(ctx, is_active, max_scrollback_lines)
+            }),
+        })
+        .collect();
+
+    WindowState {
+        tabs,
+        active_tab: ctx_manager.current_index(),
+        size: (size.width, size.height),
+        position,
+    }
+}
+
+fn capture_pane<T: EventListener>(
+    ctx: &context::Context<T>,
+    is_active: bool,
+    max_scrollback_lines: usize,
+) -> PaneState {
+    #[cfg(not(target_os = "windows"))]
+    let mut cwd = teletypewriter::foreground_process_path(*ctx.main_fd, ctx.shell_pid)
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned());
+    #[cfg(target_os = "windows")]
+    let mut cwd: Option<String> = None;
+
+    let terminal = ctx.terminal.lock();
+    if cwd.is_none() {
+        cwd = terminal
+            .current_directory
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned());
+    }
+    let scrollback = terminal.scrollback_to_ansi(max_scrollback_lines);
+    drop(terminal);
+
+    PaneState {
+        cwd,
+        title: Some(ctx.title.content.clone()).filter(|t| !t.is_empty()),
+        is_active,
+        scrollback,
+    }
+}
+
+/// Rebuild one tab's split tree inside the current (single-pane) grid.
+/// The grid's sole pane must already have been spawned for
+/// `layout.first_leaf()`; this splits out the remaining panes and
+/// injects each leaf's scrollback.
+pub fn restore_tab_layout<T: EventListener + Clone + Send + 'static>(
+    ctx_manager: &mut ContextManager<T>,
+    layout: &LayoutNode,
+    sugarloaf: &mut rio_backend::sugarloaf::Sugarloaf,
+) {
+    build_node(ctx_manager, layout, sugarloaf);
+    ctx_manager.current_grid_mut().apply_layout_weights(layout);
+    restore_active_pane(ctx_manager, layout);
+}
+
+fn build_node<T: EventListener + Clone + Send + 'static>(
+    ctx_manager: &mut ContextManager<T>,
+    layout: &LayoutNode,
+    sugarloaf: &mut rio_backend::sugarloaf::Sugarloaf,
+) {
+    match layout {
+        LayoutNode::Leaf(pane) => inject_scrollback(ctx_manager, pane),
+        LayoutNode::Split {
+            direction,
+            children,
+        } => {
+            // Split the subtree's base leaf once per extra child (rio
+            // produces binary trees; >2 children rebuild as a nested
+            // chain, which keeps content and approximates ratios).
+            let base = ctx_manager.current_grid().current;
+            let mut leaves = vec![base];
+            for (_, child) in children.iter().skip(1) {
+                ctx_manager.split_with_dir(
+                    context::next_rich_text_id(),
+                    *direction == SplitDir::Vertical,
+                    sugarloaf,
+                    child.first_leaf().cwd.clone(),
+                );
+                leaves.push(ctx_manager.current_grid().current);
+            }
+            for (i, (_, child)) in children.iter().enumerate() {
+                ctx_manager.current_grid_mut().set_current(leaves[i]);
+                build_node(ctx_manager, child, sugarloaf);
+            }
+        }
+    }
+}
+
+fn inject_scrollback<T: EventListener + Clone + Send + 'static>(
+    ctx_manager: &mut ContextManager<T>,
+    pane: &PaneState,
+) {
+    if pane.scrollback.is_empty() {
+        return;
+    }
+    let ctx = ctx_manager.current_mut();
+    let mut processor = rio_backend::performer::handler::Processor::default();
+    let mut terminal = ctx.terminal.lock();
+    processor.advance(&mut *terminal, pane.scrollback.as_bytes());
+}
+
+fn restore_active_pane<T: EventListener + Clone + Send + 'static>(
+    ctx_manager: &mut ContextManager<T>,
+    layout: &LayoutNode,
+) {
+    // Leaves were built depth-first in the same order to_layout_node
+    // walks them, so re-walk and select the one flagged active.
+    fn find_active_index(node: &LayoutNode, next: &mut usize) -> Option<usize> {
+        match node {
+            LayoutNode::Leaf(p) => {
+                let idx = *next;
+                *next += 1;
+                p.is_active.then_some(idx)
+            }
+            LayoutNode::Split { children, .. } => children
+                .iter()
+                .find_map(|(_, c)| find_active_index(c, next)),
+        }
+    }
+    let mut counter = 0;
+    if let Some(idx) = find_active_index(layout, &mut counter) {
+        ctx_manager.select_pane_by_order(idx);
+    }
+}

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -9,6 +9,7 @@ pub mod layout;
 pub mod navigation;
 pub mod platform;
 pub mod renderer;
+pub mod session;
 pub mod theme;
 pub mod title;
 pub mod window;
@@ -89,6 +90,8 @@ pub struct Config {
     pub cursor: CursorConfig,
     #[serde(default = "Navigation::default")]
     pub navigation: Navigation,
+    #[serde(default = "session::Session::default")]
+    pub session: session::Session,
     #[serde(default = "Window::default")]
     pub window: Window,
     #[serde(default = "default_shell")]
@@ -219,6 +222,21 @@ pub fn config_dir_path() -> PathBuf {
 #[inline]
 pub fn config_file_path() -> PathBuf {
     config_dir_path().join("config.toml")
+}
+
+#[inline]
+pub fn session_file_path() -> PathBuf {
+    config_dir_path().join("session.json")
+}
+
+#[inline]
+pub fn sessions_dir_path() -> PathBuf {
+    config_dir_path().join("sessions")
+}
+
+#[inline]
+pub fn session_named_path(name: &str) -> PathBuf {
+    sessions_dir_path().join(format!("{name}.json"))
 }
 
 #[inline]
@@ -644,6 +662,7 @@ impl Default for Config {
             fonts: SugarloafFonts::default(),
             line_height: default_line_height(),
             navigation: Navigation::default(),
+            session: session::Session::default(),
             option_as_alt: default_option_as_alt(),
             margin: default_margin(),
             panel: Panel::default(),

--- a/rio-backend/src/config/session.rs
+++ b/rio-backend/src/config/session.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, Default)]
+pub enum SessionRestore {
+    #[serde(alias = "never")]
+    #[default]
+    Never,
+    #[serde(alias = "prompt")]
+    Prompt,
+    #[serde(alias = "always")]
+    Always,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+pub struct Session {
+    #[serde(default)]
+    pub restore: SessionRestore,
+    /// Upper bound of history+screen lines dumped per pane on save.
+    #[serde(
+        default = "default_max_scrollback_lines",
+        rename = "max-scrollback-lines"
+    )]
+    pub max_scrollback_lines: usize,
+}
+
+fn default_max_scrollback_lines() -> usize {
+    2000
+}
+
+impl Default for Session {
+    fn default() -> Session {
+        Session {
+            restore: SessionRestore::default(),
+            max_scrollback_lines: default_max_scrollback_lines(),
+        }
+    }
+}

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -1629,6 +1629,159 @@ impl<U: EventListener> Crosswords<U> {
         text.strip_suffix('\n').map(str::to_owned).unwrap_or(text)
     }
 
+    /// Serialize history + visible rows into a styled ANSI stream: text
+    /// plus minimal SGR runs, replayable through the parser to rebuild
+    /// the same content in a fresh terminal. At most the last
+    /// `max_lines` rows are emitted; trailing blank rows are dropped.
+    pub fn scrollback_to_ansi(&self, max_lines: usize) -> String {
+        use crate::config::colors::AnsiColor;
+        use crate::crosswords::style::{Style, StyleFlags};
+        use std::fmt::Write as _;
+
+        fn push_color(out: &mut String, color: AnsiColor, is_fg: bool) {
+            let (normal, bright, extended) =
+                if is_fg { (30, 90, 38) } else { (40, 100, 48) };
+            match color {
+                AnsiColor::Named(n) => {
+                    let idx = n as usize;
+                    match idx {
+                        0..=7 => {
+                            let _ = write!(out, "\x1b[{}m", normal + idx);
+                        }
+                        8..=15 => {
+                            let _ = write!(out, "\x1b[{}m", bright + idx - 8);
+                        }
+                        // Foreground/Background and the Dim* variants map
+                        // to the reset default, which SGR 0 already set.
+                        _ => {}
+                    }
+                }
+                AnsiColor::Indexed(i) => {
+                    let _ = write!(out, "\x1b[{extended};5;{i}m");
+                }
+                AnsiColor::Spec(rgb) => {
+                    let _ =
+                        write!(out, "\x1b[{extended};2;{};{};{}m", rgb.r, rgb.g, rgb.b);
+                }
+            }
+        }
+
+        fn push_sgr(out: &mut String, style: &Style) {
+            out.push_str("\x1b[0m");
+            if *style == Style::default() {
+                return;
+            }
+            let f = style.flags;
+            for (flag, code) in [
+                (StyleFlags::BOLD, 1),
+                (StyleFlags::DIM, 2),
+                (StyleFlags::ITALIC, 3),
+                (StyleFlags::UNDERLINE, 4),
+                (StyleFlags::UNDERCURL, 4),
+                (StyleFlags::DOTTED_UNDERLINE, 4),
+                (StyleFlags::DASHED_UNDERLINE, 4),
+                (StyleFlags::DOUBLE_UNDERLINE, 21),
+                (StyleFlags::INVERSE, 7),
+                (StyleFlags::HIDDEN, 8),
+                (StyleFlags::STRIKEOUT, 9),
+            ] {
+                if f.contains(flag) {
+                    let _ = write!(out, "\x1b[{code}m");
+                }
+            }
+            push_color(out, style.fg, true);
+            push_color(out, style.bg, false);
+        }
+
+        let bottom = self.grid.bottommost_line().0;
+        let top = self
+            .grid
+            .topmost_line()
+            .0
+            .max(bottom - max_lines.saturating_sub(1) as i32);
+
+        let mut out = String::new();
+        let mut current = Style::default();
+        let mut pending_newlines = 0usize;
+        let mut pending_blanks = 0usize;
+
+        for line in (top..=bottom).map(Line::from) {
+            let grid_line = &self.grid[line];
+            let line_length = grid_line.line_length();
+            let mut had_content = false;
+
+            for column in (0..line_length.0).map(Column::from) {
+                let cell = &grid_line[column];
+                if matches!(cell.wide(), Wide::Spacer | Wide::LeadingSpacer) {
+                    continue;
+                }
+
+                let c = cell.c();
+                let style = if cell.is_bg_only() {
+                    Style {
+                        bg: match cell.content_tag() {
+                            square::ContentTag::BgRgb => {
+                                let (r, g, b) = cell.bg_rgb();
+                                AnsiColor::Spec(crate::config::colors::ColorRgb {
+                                    r,
+                                    g,
+                                    b,
+                                })
+                            }
+                            _ => AnsiColor::Indexed(cell.bg_palette_index()),
+                        },
+                        ..Style::default()
+                    }
+                } else {
+                    self.grid.style_set.get(cell.style_id())
+                };
+
+                let is_blank = (c == '\0' || c == ' ')
+                    && style.bg == Style::default().bg
+                    && !style.flags.contains(StyleFlags::INVERSE);
+                if is_blank && cell.extras_id().is_none() {
+                    pending_blanks += 1;
+                    continue;
+                }
+
+                had_content = true;
+                for _ in 0..std::mem::take(&mut pending_newlines) {
+                    out.push_str("\r\n");
+                }
+                // Gap blanks flush in the previous style so a styled run
+                // starting after them doesn't paint them retroactively.
+                for _ in 0..std::mem::take(&mut pending_blanks) {
+                    out.push(' ');
+                }
+                if style != current {
+                    push_sgr(&mut out, &style);
+                    current = style;
+                }
+                out.push(if c == '\0' { ' ' } else { c });
+                if let Some(eid) = cell.extras_id() {
+                    if let Some(extras) = self.grid.extras_table.get(eid) {
+                        out.extend(extras.zerowidth.iter());
+                    }
+                }
+            }
+
+            pending_blanks = 0;
+            if grid_line[self.grid.last_column()].wrapline() {
+                // Soft-wrapped row: let replay re-wrap naturally.
+                if !had_content {
+                    pending_newlines += 1;
+                }
+            } else {
+                pending_newlines += 1;
+            }
+        }
+
+        if !out.is_empty() {
+            out.push_str("\x1b[0m\r\n");
+        }
+        out
+    }
+
     /// Convert a single line in the grid to a String. Used by Block selection;
     /// trailing blank cells are dropped. No trailing newline is appended —
     /// the caller controls row separation.
@@ -6683,5 +6836,53 @@ mod tests {
 
         // Cursor must be untouched.
         assert_eq!(cw.grid.cursor.pos, cursor_before);
+    }
+
+    /// scrollback_to_ansi output replayed into a fresh terminal must
+    /// reproduce the same text and cell styles.
+    #[test]
+    fn scrollback_ansi_round_trip() {
+        use crate::performer::handler::Processor;
+        let mut cw = new_term(20, 5);
+        let mut processor = Processor::default();
+        processor.advance(
+            &mut cw,
+            b"plain\r\n\x1b[1;31mbold red\x1b[0m\r\n\x1b[44m  \x1b[0m gap\r\n\x1b[38;5;208morange\x1b[0m",
+        );
+
+        let dump = cw.scrollback_to_ansi(100);
+
+        let mut replayed = new_term(20, 5);
+        let mut rp = Processor::default();
+        rp.advance(&mut replayed, dump.as_bytes());
+
+        for line in 0..4 {
+            for col in 0..20 {
+                let a = &cw.grid[Line(line)][Column(col)];
+                let b = &replayed.grid[Line(line)][Column(col)];
+                let (ca, cb) = (a.c(), b.c());
+                let norm = |c: char| if c == '\0' { ' ' } else { c };
+                assert_eq!(
+                    norm(ca),
+                    norm(cb),
+                    "text mismatch at ({line},{col}): {ca:?} vs {cb:?}"
+                );
+                let sa = cw.grid.style_set.get(a.style_id());
+                let sb = replayed.grid.style_set.get(b.style_id());
+                if !a.is_bg_only() && !b.is_bg_only() && norm(ca) != ' ' {
+                    assert_eq!(sa, sb, "style mismatch at ({line},{col})");
+                }
+            }
+        }
+
+        // The blue-bg blank cells must survive (bg-only or styled space).
+        let bg_cell = replayed.grid[Line(2)][Column(0)];
+        let has_bg = if bg_cell.is_bg_only() {
+            true
+        } else {
+            replayed.grid.style_set.get(bg_cell.style_id()).bg
+                != crate::crosswords::style::Style::default().bg
+        };
+        assert!(has_bg, "blue background lost in round trip");
     }
 }

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -203,6 +203,18 @@ pub enum RioEvent {
     /// Quit request.
     Quit,
 
+    /// Save the current session to disk (tabs/splits/CWDs/scrollback).
+    SaveSession,
+
+    /// Hide the transient "session saved" notice.
+    ClearSessionNotice,
+
+    /// Save the session under a chosen name (palette "Save Session As").
+    SaveSessionAs(String),
+
+    /// Restore a named session into the current window (append tabs).
+    RestoreSessionByName(String),
+
     /// Leave current terminal.
     CloseTerminal(usize),
 
@@ -281,6 +293,10 @@ impl Debug for RioEvent {
             }
             RioEvent::Exit => write!(f, "Exit"),
             RioEvent::Quit => write!(f, "Quit"),
+            RioEvent::SaveSession => write!(f, "SaveSession"),
+            RioEvent::ClearSessionNotice => write!(f, "ClearSessionNotice"),
+            RioEvent::SaveSessionAs(_) => write!(f, "SaveSessionAs"),
+            RioEvent::RestoreSessionByName(_) => write!(f, "RestoreSessionByName"),
             RioEvent::CloseTerminal(route) => write!(f, "CloseTerminal {route}"),
             RioEvent::CreateWindow => write!(f, "CreateWindow"),
             RioEvent::CloseWindow => write!(f, "CloseWindow"),


### PR DESCRIPTION
Adds browser-style session save/restore: on exit rio can save the open tabs — including each tab's split layout, every pane's working directory, and the styled scrollback text — and offer to resume it on the next launch.

## Behavior

New `[session]` config table (default `never`, zero change unless enabled):

```toml
[session]
restore = "prompt"          # never | prompt | always
max-scrollback-lines = 2000
```

- **`prompt`** — quitting asks `save session? yes (y) / no (n)` (Esc aborts the quit); launching with a saved session asks `resume last session?`. The implicit slot is consumed once restored, so a stale session never re-prompts.
- **`always`** — saves on every exit (all windows) and restores on launch, silently.
- **Save on demand** — `ctrl+shift+s` (`cmd+shift+s` on macOS), bindable as `savesession`; flashes a transient "session saved" notice.
- **Named sessions** — `rio --session work` binds an instance to `sessions/work.json` (restored on launch, saved back on exit); the command palette gains `Save Session As...` (type a new name or overwrite an existing one) and `Restore Session...` (fuzzy picker; appends the session's tabs to the current window). Named sessions are workspaces and are never auto-deleted.

Restored panes reopen as fresh shells at their saved directory with the previous styled output repainted above the prompt — like a browser restoring URLs, not page state; running programs are not resurrected.

## Implementation

- **`Crosswords::scrollback_to_ansi`** serializes history + screen into text with minimal SGR runs (style diffed cell-to-cell, bg-only cells emit their inline color, zero-width combiners preserved); restore replays it through a `Processor` into the fresh terminal. Covered by a dump→replay→compare round-trip test.
- **Capture** walks each `ContextGrid`'s taffy tree (container flex direction + child `flex_grow` give the split shape and ratios) into a serde model; CWD uses `foreground_process_path` with OSC 7 fallback — the same priority new-tab inheritance uses.
- **Restore** replays splits via `split_right`/`split_down`, re-applies child weights, and spawns each pane through the spawn pty path with the saved directory (the fork path has no chdir, so restored panes force `use_fork = false`). Restored tabs follow the same margin choreography as `create_tab`, and when the platform applies the requested window size immediately (Wayland emits no `Resized` then) the resize pipeline runs inline.
- Prompts reuse the `ConfirmQuit` overlay pattern; `confirm-before-quit` chains into the save prompt.

## Limitations (documented)

- Windows: per-pane CWD capture unavailable (`foreground_process_path` unimplemented there).
- Window position restore is a no-op on Wayland (compositor-owned placement); size restores everywhere.
- Closing the last shell with `exit` ends rio without a save prompt — saves trigger on quit actions.

Tested on Linux/Wayland: tabs + right/down splits with adjusted ratios, colored scrollback (`ls --color`, git log), all three modes, named sessions via CLI and palette, repeated save/restore cycles. `cargo fmt`, `clippy`, and the full test suite pass.