### PR TITLE
fix font reload caches, ttc faces and bold matching

### DIFF
--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -1264,6 +1264,21 @@ impl GridGlyphRasterizer {
         }
     }
 
+    /// Drop every cache keyed by `font_id`; a swapped font library
+    /// reuses the same ids.
+    pub fn clear_font_caches(&mut self) {
+        self.font_resolve.clear();
+        self.ascent_cache.clear();
+        self.synthesis_cache.clear();
+        for bucket in &mut self.run_cache {
+            bucket.clear();
+        }
+        #[cfg(target_os = "macos")]
+        self.handle_cache.clear();
+        #[cfg(not(target_os = "macos"))]
+        self.font_data_cache.clear();
+    }
+
     #[inline]
     fn resolve_font(
         &mut self,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -424,6 +424,11 @@ impl Screen<'_> {
 
         if should_update_font_library {
             self.sugarloaf.update_font(font_library);
+            // Caches keyed by font_id would serve the old font's data.
+            self.grid_rasterizer.clear_font_caches();
+            for grid in self.grids.values_mut() {
+                grid.clear_atlas();
+            }
         }
         let s = self.sugarloaf.style_mut();
         s.font_size = config.fonts.size;
@@ -4114,10 +4119,13 @@ impl Screen<'_> {
                         // (cursor_pos moved, etc.) take effect.
                     }
                     RowsToRebuild::All => {
+                        // Clear the flag before rebuilding so an
+                        // atlas-full clear inside `rebuild_row` can
+                        // re-set it for the recovery pass below.
+                        grid.mark_full_rebuild_done();
                         for y in 0..p.visible_rows.len() {
                             rebuild_row(p, y, grid, rasterizer);
                         }
-                        grid.mark_full_rebuild_done();
                     }
                     RowsToRebuild::Dirty => {
                         // Walk the snapshot rows; rebuild + clear the
@@ -4131,6 +4139,16 @@ impl Screen<'_> {
                             rebuild_row(p, y, grid, rasterizer);
                             p.visible_rows[y].dirty = false;
                         }
+                    }
+                }
+
+                // Atlas-full recovery: the backend cleared the atlas
+                // during the rebuild above, so rows written before the
+                // clear reference stale slots. Re-emit everything.
+                if grid.needs_full_rebuild() {
+                    grid.mark_full_rebuild_done();
+                    for y in 0..p.visible_rows.len() {
+                        rebuild_row(p, y, grid, rasterizer);
                     }
                 }
 

--- a/sugarloaf/src/font/mod.rs
+++ b/sugarloaf/src/font/mod.rs
@@ -18,6 +18,10 @@ pub mod windows;
 mod cjk_metrics_tests;
 
 pub const FONT_ID_REGULAR: usize = 0;
+// Style slot ids fixed by `FontLibraryData::load`'s insertion order.
+pub const FONT_ID_ITALIC: usize = 1;
+pub const FONT_ID_BOLD: usize = 2;
+pub const FONT_ID_BOLD_ITALIC: usize = 3;
 
 use crate::font::constants::*;
 use crate::font::fonts::{parse_unicode, FontStyle};
@@ -88,12 +92,88 @@ pub struct LookupAttrs {
     pub bold: bool,
 }
 
+/// Whether the font registered under `font_id` carries a glyph for
+/// every codepoint in `cluster`.
+fn cluster_covered(
+    cluster: &mut CharCluster,
+    library: &FontLibraryData,
+    font_id: usize,
+    font: &FontData,
+) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        // Ask the CTFont directly whether it carries a glyph for each
+        // codepoint. Avoids the `get_data` byte load, so the fallback
+        // walk no longer touches the font file(s) at all.
+        let _ = (library, font_id);
+        let handle_opt = if let Some(path) = &font.path {
+            crate::font::macos::FontHandle::from_path(path)
+        } else if let Some(bytes) = &font.data {
+            crate::font::macos::FontHandle::from_bytes(bytes.as_ref())
+        } else {
+            None
+        };
+        if let Some(handle) = handle_opt {
+            let status = cluster.map(|ch| {
+                // Non-zero u16 == "has glyph"; swash's cluster.map only
+                // distinguishes zero vs non-zero, so `1` is fine as a
+                // placeholder when CTFont carries the codepoint.
+                if crate::font::macos::font_has_char(&handle, ch) {
+                    1
+                } else {
+                    0
+                }
+            });
+            status != Status::Discard
+        } else {
+            false
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = font;
+        if let Some((shared_data, offset, key)) = library.get_data(&font_id) {
+            let font_ref = FontRef {
+                data: shared_data.as_ref(),
+                offset,
+                key,
+            };
+            let charmap = font_ref.charmap();
+            let status = cluster.map(|ch| charmap.map(ch));
+            status != Status::Discard
+        } else {
+            false
+        }
+    }
+}
+
 pub fn lookup_for_font_match(
     cluster: &mut CharCluster,
     synth: &mut Synthesis,
     library: &FontLibraryData,
     spec: Option<LookupAttrs>,
 ) -> Option<(usize, bool)> {
+    // The configured slot for the requested style is authoritative
+    // whenever it covers the cluster. Fonts routinely ship bold as
+    // 600 or report styles the weight-based walk rejects, which used
+    // to send bold/italic cells to the regular face (#1110).
+    if let Some(spec) = spec {
+        let slot = match (spec.bold, spec.italic) {
+            (false, true) => FONT_ID_ITALIC,
+            (true, false) => FONT_ID_BOLD,
+            (true, true) => FONT_ID_BOLD_ITALIC,
+            (false, false) => FONT_ID_REGULAR,
+        };
+        let slot = library.resolve_id(slot);
+        if let Some(FontEntry::Owned(font)) = library.inner.get(&slot) {
+            if cluster_covered(cluster, library, slot, font) {
+                *synth = font.synth;
+                return Some((slot, font.is_emoji));
+            }
+        }
+    }
+
     let mut search_result = None;
 
     let fonts_len: usize = library.inner.len();
@@ -116,52 +196,7 @@ pub fn lookup_for_font_match(
             }
         }
 
-        #[cfg(target_os = "macos")]
-        let matched = {
-            // Ask the CTFont directly whether it carries a glyph for each
-            // codepoint. Avoids the `get_data` byte load — the fallback
-            // walk no longer touches the font file(s) at all.
-            let handle_opt = if let Some(path) = &font.path {
-                crate::font::macos::FontHandle::from_path(path)
-            } else if let Some(bytes) = &font.data {
-                crate::font::macos::FontHandle::from_bytes(bytes.as_ref())
-            } else {
-                None
-            };
-            if let Some(handle) = handle_opt {
-                let status = cluster.map(|ch| {
-                    // Non-zero u16 == "has glyph"; swash's cluster.map only
-                    // distinguishes zero vs non-zero, so `1` is fine as a
-                    // placeholder when CTFont carries the codepoint.
-                    if crate::font::macos::font_has_char(&handle, ch) {
-                        1
-                    } else {
-                        0
-                    }
-                });
-                status != Status::Discard
-            } else {
-                false
-            }
-        };
-
-        #[cfg(not(target_os = "macos"))]
-        let matched = {
-            if let Some((shared_data, offset, key)) = library.get_data(&font_id) {
-                let font_ref = FontRef {
-                    data: shared_data.as_ref(),
-                    offset,
-                    key,
-                };
-                let charmap = font_ref.charmap();
-                let status = cluster.map(|ch| charmap.map(ch));
-                status != Status::Discard
-            } else {
-                false
-            }
-        };
-
-        if matched {
+        if cluster_covered(cluster, library, font_id, font) {
             *synth = font_synth;
             search_result = Some((font_id, is_emoji));
             break;
@@ -1298,6 +1333,8 @@ impl FontData {
             .map(|m| m.for_rich_text())
     }
 
+    /// `face_index` addresses a face inside a TTC/OTC collection;
+    /// parsing index 0 would load whichever face sits first.
     #[inline]
     pub fn from_data(
         data: SharedData,
@@ -1305,8 +1342,9 @@ impl FontData {
         evictable: bool,
         slot: Slot,
         font_spec: &SugarloafFont,
+        face_index: u32,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let font = FontRef::from_index(&data, 0)
+        let font = FontRef::from_index(&data, face_index as usize)
             .ok_or_else(|| format!("Failed to load font from path: {:?}", path))?;
         let (offset, key) = (font.offset, font.key);
 
@@ -1314,17 +1352,19 @@ impl FontData {
         let style = attributes.style();
         let weight = attributes.weight();
 
+        // Semibold threshold: families shipping bold at 600 must not
+        // get faux-bold stacked on the real bold face.
         let (should_embolden, should_italicize) = synth_decisions(
             slot,
             font_spec,
-            weight >= Weight(700),
+            weight >= Weight(600),
             style == Style::Italic,
         );
 
         let stretch = attributes.stretch();
         let synth = attributes.synthesize(attributes);
         let is_emoji = has_color_tables(&font);
-        let postscript_name = parse_postscript_name(&data);
+        let postscript_name = parse_postscript_name(&data, face_index);
 
         let data = (!evictable).then_some(data);
 
@@ -1481,7 +1521,7 @@ impl FontData {
         let stretch = attributes.stretch();
         let synth = attributes.synthesize(attributes);
         let is_emoji = has_color_tables(&font);
-        let postscript_name = parse_postscript_name(data);
+        let postscript_name = parse_postscript_name(data, 0);
 
         #[cfg(target_os = "macos")]
         let handle = {
@@ -1531,7 +1571,7 @@ impl FontData {
         let synth = attributes.synthesize(attributes);
         let is_emoji = has_color_tables(&font);
 
-        let postscript_name = parse_postscript_name(data);
+        let postscript_name = parse_postscript_name(data, 0);
         Ok(Self {
             data: Some(SharedData::new(data.to_vec())),
             offset,
@@ -1587,7 +1627,7 @@ impl FontData {
         let stretch = attributes.stretch();
         let synth = attributes.synthesize(attributes);
         let is_emoji = has_color_tables(&font);
-        let postscript_name = parse_postscript_name(&data);
+        let postscript_name = parse_postscript_name(&data, face_index);
 
         Ok(Self {
             data: Some(data),
@@ -1614,8 +1654,8 @@ impl FontData {
 /// without re-parsing. Falls back to the family name (ID 1) if the
 /// PS name is missing — a font without a usable name can't participate
 /// in the cascade-mapping anyway, so `None` is fine.
-fn parse_postscript_name(data: &[u8]) -> Option<String> {
-    let face = ttf_parser::Face::parse(data, 0).ok()?;
+fn parse_postscript_name(data: &[u8], face_index: u32) -> Option<String> {
+    let face = ttf_parser::Face::parse(data, face_index).ok()?;
     face.names()
         .into_iter()
         .find(|n| n.name_id == ttf_parser::name_id::POST_SCRIPT_NAME && n.is_unicode())
@@ -1742,7 +1782,7 @@ fn find_font(
         match db.query(&query) {
             Some(id) => {
                 match db.face_source(id) {
-                    Some((crate::font::loader::Source::File(ref path), _index)) => {
+                    Some((crate::font::loader::Source::File(ref path), index)) => {
                         // File source - load from path
                         if let Some(font_data_arc) =
                             load_from_font_source(&path.to_path_buf())
@@ -1753,6 +1793,7 @@ fn find_font(
                                 evictable,
                                 slot,
                                 &font_spec,
+                                index,
                             ) {
                                 Ok(d) => {
                                     tracing::info!(
@@ -1771,7 +1812,7 @@ fn find_font(
                             }
                         }
                     }
-                    Some((crate::font::loader::Source::Binary(font_data), _index)) => {
+                    Some((crate::font::loader::Source::Binary(font_data), index)) => {
                         // Binary source - use data directly
                         tracing::debug!(
                             "Using binary font data, {} bytes",
@@ -1784,6 +1825,7 @@ fn find_font(
                             evictable,
                             slot,
                             &font_spec,
+                            index,
                         ) {
                             Ok(d) => {
                                 tracing::info!("Font '{}' loaded from memory", family);
@@ -1907,6 +1949,55 @@ mod alias_tests {
         assert_eq!(bold_italic.wght_variation, Some(constants::WGHT_BOLD));
         assert_eq!(regular.wght_variation, None);
         assert_eq!(italic.wght_variation, None);
+    }
+
+    /// The user-configured bold slot must win for bold cells even when
+    /// the face reports a sub-700 weight (families shipping bold at
+    /// 600, Nerd Font patches). Regression test for #1110: the
+    /// weight-based walk used to reject the slot and send bold text
+    /// to the regular face.
+    #[test]
+    fn bold_slot_wins_regardless_of_weight_metadata() {
+        use std::sync::Arc;
+
+        let mut data = FontLibraryData::default();
+        data.insert(
+            FontData::from_static_slice(constants::FONT_CASCADIA_CODE_NF)
+                .expect("load regular"),
+        );
+        data.insert(
+            FontData::from_static_slice(constants::FONT_CASCADIA_CODE_NF_ITALIC)
+                .expect("load italic"),
+        );
+        // Simulate a family whose bold face reports weight 600.
+        let bold = FontData::from_static_slice_with_wght(
+            constants::FONT_CASCADIA_CODE_NF,
+            Some(600.0),
+        )
+        .expect("load bold");
+        assert!(!bold.is_bold(), "test premise: bold face under 700");
+        data.insert(bold);
+        data.insert_alias(FONT_ID_REGULAR);
+
+        let lib = FontLibrary {
+            inner: Arc::new(parking_lot::RwLock::new(data)),
+        };
+
+        let mut style = crate::SpanStyle::default();
+        style.font_attrs = swash::Attributes::new(
+            swash::Stretch::NORMAL,
+            swash::Weight::BOLD,
+            swash::Style::Normal,
+        );
+        let (font_id, _) = lib
+            .inner
+            .read()
+            .find_best_font_match_strict('A', &style, None)
+            .expect("cluster must resolve");
+        assert_eq!(
+            font_id, FONT_ID_BOLD,
+            "bold cells must use the configured bold slot"
+        );
     }
 
     /// Aliases share the target's `metrics_cache`, so requesting

--- a/sugarloaf/src/font_cache.rs
+++ b/sugarloaf/src/font_cache.rs
@@ -153,8 +153,14 @@ pub(crate) fn compute_advance(
     font_id: usize,
     ch: char,
 ) -> Option<AdvanceInfo> {
-    let (data, offset, _key) = font_ctx.get_data(&font_id)?;
-    let font_ref = swash::FontRef::from_index(&data, offset as usize)?;
+    let (data, offset, key) = font_ctx.get_data(&font_id)?;
+    // `offset` is a table-directory byte offset, not a collection face
+    // index, so reconstruct the FontRef directly.
+    let font_ref = swash::FontRef {
+        data: data.as_ref(),
+        offset,
+        key,
+    };
     let glyph_id = font_ref.charmap().map(ch as u32);
     let metrics = font_ref.glyph_metrics(&[]);
     Some(AdvanceInfo {

--- a/sugarloaf/src/grid/cpu.rs
+++ b/sugarloaf/src/grid/cpu.rs
@@ -161,6 +161,11 @@ impl CpuGridAtlas {
         true
     }
 
+    pub fn clear(&mut self) {
+        self.allocator.clear();
+        self.slots.clear();
+    }
+
     #[inline]
     pub fn pixels(&self) -> &[u8] {
         &self.pixels
@@ -266,18 +271,33 @@ impl CpuGridRenderer {
         self.atlas_grayscale.lookup(key)
     }
 
+    /// Drop every cached glyph and force a full rebuild. Called when
+    /// the font library is swapped, since the new library reuses font ids.
+    pub fn clear_atlas(&mut self) {
+        self.atlas_grayscale.clear();
+        self.atlas_color.clear();
+        self.needs_full_rebuild = true;
+    }
+
     pub fn insert_glyph(
         &mut self,
         key: GlyphKey,
         glyph: RasterizedGlyph<'_>,
     ) -> Option<AtlasSlot> {
-        if let Some(slot) = self.atlas_grayscale.insert(key, glyph) {
-            return Some(slot);
-        }
-        if self.atlas_grayscale.grow() {
-            self.atlas_grayscale.insert(key, glyph)
-        } else {
-            None
+        let mut cleared = false;
+        loop {
+            if let Some(slot) = self.atlas_grayscale.insert(key, glyph) {
+                return Some(slot);
+            }
+            if self.atlas_grayscale.grow() {
+                continue;
+            }
+            if cleared {
+                return None;
+            }
+            self.atlas_grayscale.clear();
+            self.needs_full_rebuild = true;
+            cleared = true;
         }
     }
 
@@ -291,13 +311,20 @@ impl CpuGridRenderer {
         key: GlyphKey,
         glyph: RasterizedGlyph<'_>,
     ) -> Option<AtlasSlot> {
-        if let Some(slot) = self.atlas_color.insert(key, glyph) {
-            return Some(slot);
-        }
-        if self.atlas_color.grow() {
-            self.atlas_color.insert(key, glyph)
-        } else {
-            None
+        let mut cleared = false;
+        loop {
+            if let Some(slot) = self.atlas_color.insert(key, glyph) {
+                return Some(slot);
+            }
+            if self.atlas_color.grow() {
+                continue;
+            }
+            if cleared {
+                return None;
+            }
+            self.atlas_color.clear();
+            self.needs_full_rebuild = true;
+            cleared = true;
         }
     }
 

--- a/sugarloaf/src/grid/metal.rs
+++ b/sugarloaf/src/grid/metal.rs
@@ -253,7 +253,6 @@ impl MetalGlyphAtlas {
         Some(slot)
     }
 
-    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.allocator.clear();
         self.slots.clear();
@@ -436,22 +435,43 @@ impl MetalGridRenderer {
         self.atlas_grayscale.lookup(key)
     }
 
+    /// Drop every cached glyph and force a full rebuild. Called when
+    /// the font library is swapped, since the new library reuses font ids.
+    pub fn clear_atlas(&mut self) {
+        self.atlas_grayscale.clear();
+        if let Some(atlas) = &mut self.atlas_color {
+            atlas.clear();
+        }
+        self.needs_full_rebuild = true;
+        self.fg_dirty = [true; FRAMES_IN_FLIGHT];
+        self.bg_dirty = [true; FRAMES_IN_FLIGHT];
+    }
+
     /// Pack + upload a grayscale rasterized glyph. On atlas-full,
     /// grows the atlas (doubles the texture, blits old texels into
-    /// the top-left) and retries once. Returns `None` only if the
-    /// atlas is at `ATLAS_MAX_SIZE` and still can't fit the glyph.
+    /// the top-left) and retries. At `ATLAS_MAX_SIZE` the atlas is
+    /// cleared once and every row rebuilt; `None` only for a glyph
+    /// too large for the max-size atlas.
     pub fn insert_glyph(
         &mut self,
         key: GlyphKey,
         glyph: RasterizedGlyph<'_>,
     ) -> Option<AtlasSlot> {
+        let mut cleared = false;
         loop {
             if let Some(slot) = self.atlas_grayscale.insert(key, glyph) {
                 return Some(slot);
             }
-            if !self.atlas_grayscale.grow(&self.device, &self.command_queue) {
+            if self.atlas_grayscale.grow(&self.device, &self.command_queue) {
+                continue;
+            }
+            if cleared {
                 return None;
             }
+            self.atlas_grayscale.clear();
+            self.needs_full_rebuild = true;
+            self.fg_dirty = [true; FRAMES_IN_FLIGHT];
+            cleared = true;
         }
     }
 
@@ -471,13 +491,21 @@ impl MetalGridRenderer {
             self.atlas_color = Some(MetalGlyphAtlas::new_color(&self.device));
         }
         let atlas = self.atlas_color.as_mut().unwrap();
+        let mut cleared = false;
         loop {
             if let Some(slot) = atlas.insert(key, glyph) {
                 return Some(slot);
             }
-            if !atlas.grow(&self.device, &self.command_queue) {
+            if atlas.grow(&self.device, &self.command_queue) {
+                continue;
+            }
+            if cleared {
                 return None;
             }
+            atlas.clear();
+            self.needs_full_rebuild = true;
+            self.fg_dirty = [true; FRAMES_IN_FLIGHT];
+            cleared = true;
         }
     }
 

--- a/sugarloaf/src/grid/mod.rs
+++ b/sugarloaf/src/grid/mod.rs
@@ -101,6 +101,21 @@ impl GridRenderer {
         }
     }
 
+    /// Drop every cached glyph and force a full row rebuild. Must be
+    /// called when the font library is swapped, since atlas slots are keyed
+    /// by font id and the new library reuses the same ids.
+    pub fn clear_atlas(&mut self) {
+        match self {
+            #[cfg(target_os = "macos")]
+            GridRenderer::Metal(r) => r.clear_atlas(),
+            #[cfg(feature = "wgpu")]
+            GridRenderer::Wgpu(r) => r.clear_atlas(),
+            #[cfg(target_os = "linux")]
+            GridRenderer::Vulkan(r) => r.clear_atlas(),
+            GridRenderer::Cpu(r) => r.clear_atlas(),
+        }
+    }
+
     /// Overwrite `row`'s background + foreground cells. `bg` must have
     /// exactly `cols` entries; `fg` is variable length (base glyph +
     /// decorations). Callers that want to clear a row should use

--- a/sugarloaf/src/grid/vulkan.rs
+++ b/sugarloaf/src/grid/vulkan.rs
@@ -381,6 +381,16 @@ impl VulkanGlyphAtlas {
         });
         Some(slot)
     }
+
+    /// Forget every cached glyph. Pages are kept and their allocators
+    /// reset; the caller forces a full row rebuild before the next draw.
+    pub fn clear(&mut self) {
+        self.slots.clear();
+        for page in &mut self.pages {
+            page.allocator.clear();
+            page.pending.clear();
+        }
+    }
 }
 
 /// Allocate a fresh atlas page: create the image + view, transition
@@ -901,23 +911,44 @@ impl VulkanGridRenderer {
         self.atlas_color.lookup(key)
     }
 
-    #[inline]
+    /// Drop every cached glyph and force a full rebuild. Called when
+    /// the font library is swapped, since the new library reuses font ids.
+    pub fn clear_atlas(&mut self) {
+        self.atlas_grayscale.clear();
+        self.atlas_color.clear();
+        self.needs_full_rebuild = true;
+        self.fg_dirty = [true; FRAMES_IN_FLIGHT];
+        self.bg_dirty = [true; FRAMES_IN_FLIGHT];
+    }
+
+    /// The atlas's own `insert` walks existing pages and appends a
+    /// new one when none fit. At `MAX_PAGES` the atlas is cleared
+    /// once and every row rebuilt.
     pub fn insert_glyph(
         &mut self,
         key: GlyphKey,
         glyph: RasterizedGlyph<'_>,
     ) -> Option<AtlasSlot> {
-        // The atlas's own `insert` walks existing pages and appends a
-        // new one when none fit, so the renderer doesn't need to retry.
+        if let Some(slot) = self.atlas_grayscale.insert(key, glyph) {
+            return Some(slot);
+        }
+        self.atlas_grayscale.clear();
+        self.needs_full_rebuild = true;
+        self.fg_dirty = [true; FRAMES_IN_FLIGHT];
         self.atlas_grayscale.insert(key, glyph)
     }
 
-    #[inline]
     pub fn insert_glyph_color(
         &mut self,
         key: GlyphKey,
         glyph: RasterizedGlyph<'_>,
     ) -> Option<AtlasSlot> {
+        if let Some(slot) = self.atlas_color.insert(key, glyph) {
+            return Some(slot);
+        }
+        self.atlas_color.clear();
+        self.needs_full_rebuild = true;
+        self.fg_dirty = [true; FRAMES_IN_FLIGHT];
         self.atlas_color.insert(key, glyph)
     }
 

--- a/sugarloaf/src/grid/webgpu.rs
+++ b/sugarloaf/src/grid/webgpu.rs
@@ -144,7 +144,6 @@ impl WgpuGlyphAtlas {
         Some(slot)
     }
 
-    #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.allocator.clear();
         self.slots.clear();
@@ -405,11 +404,29 @@ impl WgpuGridRenderer {
         self.atlas_color.lookup(key)
     }
 
+    /// Drop every cached glyph and force a full rebuild. Called when
+    /// the font library is swapped, since the new library reuses font ids.
+    pub fn clear_atlas(&mut self) {
+        self.atlas_grayscale.clear();
+        self.atlas_color.clear();
+        self.needs_full_rebuild = true;
+        self.fg_dirty = true;
+        self.bg_dirty = true;
+    }
+
+    /// The wgpu atlas is fixed-size (no grow yet), so on atlas-full
+    /// clear it once and rebuild every row.
     pub fn insert_glyph(
         &mut self,
         key: GlyphKey,
         glyph: RasterizedGlyph<'_>,
     ) -> Option<AtlasSlot> {
+        if let Some(slot) = self.atlas_grayscale.insert(key, glyph) {
+            return Some(slot);
+        }
+        self.atlas_grayscale.clear();
+        self.needs_full_rebuild = true;
+        self.fg_dirty = true;
         self.atlas_grayscale.insert(key, glyph)
     }
 
@@ -418,6 +435,12 @@ impl WgpuGridRenderer {
         key: GlyphKey,
         glyph: RasterizedGlyph<'_>,
     ) -> Option<AtlasSlot> {
+        if let Some(slot) = self.atlas_color.insert(key, glyph) {
+            return Some(slot);
+        }
+        self.atlas_color.clear();
+        self.needs_full_rebuild = true;
+        self.fg_dirty = true;
         self.atlas_color.insert(key, glyph)
     }
 

--- a/sugarloaf/src/layout/mod.rs
+++ b/sugarloaf/src/layout/mod.rs
@@ -282,8 +282,14 @@ pub fn compute_cell_metrics(
         {
             font_library.inner.try_read().and_then(|lib| {
                 let id = 0;
-                let (data, offset, _key) = lib.get_data(&id)?;
-                let font_ref = swash::FontRef::from_index(&data, offset as usize)?;
+                let (data, offset, key) = lib.get_data(&id)?;
+                // `offset` is a table-directory byte offset, not a
+                // collection face index.
+                let font_ref = swash::FontRef {
+                    data: data.as_ref(),
+                    offset,
+                    key,
+                };
                 let m = font_ref.metrics(&[]);
                 let upem = m.units_per_em as f32;
                 let s = font_size / upem;


### PR DESCRIPTION
Fixes three root causes behind the font-rendering issue cluster:

**Stale caches on font reload.** `Screen.grid_rasterizer` (font resolutions, shaped-run cache, ascent/synthesis caches, CT handles) and the per-pane grid atlases were never cleared when the font library was swapped. The new library reuses the same font ids, so stale entries served the old font's shaping/metrics/bitmaps (#1639) or panicked indexing past the new library's length (#1352-class reports, likely #1246/#1381 corruption). `update_config` now clears the rasterizer caches and every grid atlas on font change.

**Atlas exhaustion silently dropped glyphs.** When an atlas hit max size (or `MAX_PAGES` on Vulkan, fixed size on wgpu), `insert_glyph` returned `None` forever and characters just stopped rendering (#1168's disappearing text). All four backends now clear the atlas once and force a full row rebuild; the emit loop re-runs against the fresh atlas within the same frame.

**TTC collections loaded the wrong face.** The config-font path discarded font-kit's face index (`FontData::from_data` always parsed face 0), so families inside .ttc containers rendered the wrong face (#1302, likely part of #1236/#1246). Also fixed two spots passing a table-directory byte offset as a face index (`layout/mod.rs`, `font_cache.rs`) and PS-name extraction for collection faces.

**Bold/italic ignored the configured slot (#1110).** The lookup walk trusted `weight >= 700` metadata over the user's per-slot font config, sending bold cells to the regular face for families that ship bold at 600 (Nerd Font patches, Operator Mono). The configured slot now wins whenever it covers the cluster, and the synthesis threshold no longer stacks faux-bold on real semibold-as-bold faces (#818). Regression test included.

Refs #1639 #1352 #1302 #1110 #818 #1246 #1381 #1168