### PR TITLE
font features, hinting and weight config, update swash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,9 +4631,9 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
+checksum = "6c2499c2d826531388872b2268718aed907a39bd785ab0dcfe57fab26283f92e"
 dependencies = [
  "skrifa 0.42.1",
  "yazi",

--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -1212,6 +1212,17 @@ pub struct GridGlyphRasterizer {
     #[cfg(target_os = "macos")]
     handle_cache: FxHashMap<u32, rio_backend::sugarloaf::font::macos::FontHandle>,
 
+    /// Library-wide `(hinting, features)` snapshot, refreshed lazily
+    /// after `clear_font_caches` so shaping and rasterization don't
+    /// take the library lock per run.
+    lib_settings: Option<(
+        bool,
+        std::sync::Arc<Vec<rio_backend::sugarloaf::swash::Setting<u16>>>,
+    )>,
+    /// Per-font `wght` axis pin, mirrored from `FontData.wght_variation`.
+    #[cfg(not(target_os = "macos"))]
+    wght_cache: FxHashMap<u32, Option<f32>>,
+
     // non-macOS: swash wants UTF-8, so keep a `String` scratch.
     #[cfg(not(target_os = "macos"))]
     run_str_scratch: String,
@@ -1255,6 +1266,9 @@ impl GridGlyphRasterizer {
             run_str_scratch: String::new(),
             #[cfg(target_os = "macos")]
             handle_cache: FxHashMap::default(),
+            lib_settings: None,
+            #[cfg(not(target_os = "macos"))]
+            wght_cache: FxHashMap::default(),
             #[cfg(not(target_os = "macos"))]
             shape_ctx: rio_backend::sugarloaf::swash::shape::ShapeContext::new(),
             #[cfg(not(target_os = "macos"))]
@@ -1273,10 +1287,30 @@ impl GridGlyphRasterizer {
         for bucket in &mut self.run_cache {
             bucket.clear();
         }
+        self.lib_settings = None;
         #[cfg(target_os = "macos")]
         self.handle_cache.clear();
         #[cfg(not(target_os = "macos"))]
-        self.font_data_cache.clear();
+        {
+            self.wght_cache.clear();
+            self.font_data_cache.clear();
+        }
+    }
+
+    /// Library-wide `(hinting, features)`, cached until the next
+    /// `clear_font_caches`.
+    fn library_settings(
+        &mut self,
+        font_library: &FontLibrary,
+    ) -> (
+        bool,
+        std::sync::Arc<Vec<rio_backend::sugarloaf::swash::Setting<u16>>>,
+    ) {
+        if self.lib_settings.is_none() {
+            let lib = font_library.inner.read();
+            self.lib_settings = Some((lib.hinting, lib.features.clone()));
+        }
+        self.lib_settings.clone().unwrap()
     }
 
     #[inline]
@@ -1454,10 +1488,20 @@ fn shape_run_ct(
     size_bucket: u16,
     font_library: &FontLibrary,
 ) -> Option<(Vec<ShapedGlyph>, i16)> {
+    let (_, features) = rasterizer.library_settings(font_library);
     let handle = match rasterizer.handle_cache.entry(font_id) {
         std::collections::hash_map::Entry::Occupied(e) => e.into_mut().clone(),
         std::collections::hash_map::Entry::Vacant(e) => {
             let h = font_library.ct_font(font_id as usize)?;
+            // Configured OpenType features are baked into the cached
+            // CTFont so both shaping and rasterization honor them.
+            let h = if features.is_empty() {
+                h
+            } else {
+                let pairs: Vec<(u32, u16)> =
+                    features.iter().map(|s| (s.tag, s.value)).collect();
+                h.clone().with_features(&pairs).unwrap_or(h)
+            };
             e.insert(h.clone());
             h
         }
@@ -1501,7 +1545,14 @@ fn shape_run_swash(
     size_bucket: u16,
     font_library: &FontLibrary,
 ) -> Option<(Vec<ShapedGlyph>, i16)> {
-    use rio_backend::sugarloaf::swash::FontRef;
+    use rio_backend::sugarloaf::swash::{FontRef, Setting};
+
+    let (_, features) = rasterizer.library_settings(font_library);
+    let wght = *rasterizer.wght_cache.entry(font_id).or_insert_with(|| {
+        let lib = font_library.inner.read();
+        lib.try_get(&(font_id as usize))
+            .and_then(|f| f.wght_variation)
+    });
 
     let font_entry = rasterizer
         .font_data_cache
@@ -1525,10 +1576,17 @@ fn shape_run_swash(
             m.ascent.round().clamp(i16::MIN as f32, i16::MAX as f32) as i16
         });
 
+    const WGHT_TAG: u32 = u32::from_be_bytes(*b"wght");
+    let wght_var = wght.map(|v| Setting {
+        tag: WGHT_TAG,
+        value: v,
+    });
     let mut shaper = rasterizer
         .shape_ctx
         .builder(font_ref)
         .size(size_u16 as f32)
+        .features(features.iter().copied())
+        .variations(wght_var.iter().copied())
         .build();
     shaper.add_str(&rasterizer.run_str_scratch);
     let mut glyphs: Vec<ShapedGlyph> = Vec::new();
@@ -2492,7 +2550,7 @@ fn rasterize_glyph_native(
             Render, Source, StrikeWith,
         },
         zeno::{Angle, Format, Transform},
-        FontRef,
+        FontRef, Setting,
     };
 
     let font_entry = rasterizer.font_data_cache.get(&font_id)?.clone();
@@ -2502,12 +2560,29 @@ fn rasterize_glyph_native(
         key: font_entry.2,
     };
 
-    let hinting = font_library_hinting(rasterizer);
+    // Shaping runs before rasterization, so `lib_settings` and
+    // `wght_cache` are already populated for this font.
+    let hinting = rasterizer
+        .lib_settings
+        .as_ref()
+        .map(|s| s.0)
+        .unwrap_or(true);
+    const WGHT_TAG: u32 = u32::from_be_bytes(*b"wght");
+    let wght_var = rasterizer
+        .wght_cache
+        .get(&font_id)
+        .copied()
+        .flatten()
+        .map(|v| Setting {
+            tag: WGHT_TAG,
+            value: v,
+        });
     let mut scaler = rasterizer
         .scale_ctx
         .builder(font_ref)
         .hint(hinting)
         .size(size_u16 as f32)
+        .variations(wght_var.iter().copied())
         .build();
 
     let sources: &[Source] = &[
@@ -2545,18 +2620,6 @@ fn rasterize_glyph_native(
         is_color,
         bytes: image.data,
     })
-}
-
-/// Hinting is a library-wide setting. Read once per rasterize; the
-/// RwLock read is cheap. (Caching it locally would require reset
-/// plumbing on config reload.)
-#[cfg(not(target_os = "macos"))]
-#[inline]
-fn font_library_hinting(_r: &GridGlyphRasterizer) -> bool {
-    // TODO: thread through from a cache to avoid the lock per glyph.
-    // For now the lock on swash rasterize is a small fraction of
-    // render time; optimise if profiling flags it.
-    true
 }
 
 #[cfg(test)]

--- a/sugarloaf/Cargo.toml
+++ b/sugarloaf/Cargo.toml
@@ -62,7 +62,7 @@ half = "2.6.0"
 num-traits = "0.2.19"
 yazi = { version = "0.2.1", optional = true }
 zeno = "0.3.3"
-swash = "0.2.7"
+swash = "0.2.10"
 futures = { workspace = true }
 tiny-skia = "0.12.0"
 wide = "1.2.0"

--- a/sugarloaf/src/font/fonts.rs
+++ b/sugarloaf/src/font/fonts.rs
@@ -82,6 +82,10 @@ pub struct SugarloafFont {
     pub family: String,
     #[serde(default)]
     pub style: FontStyle,
+    /// CSS-style weight (100..900). Steers face selection where the
+    /// platform supports it and pins the `wght` axis on variable fonts.
+    #[serde(default = "Option::default")]
+    pub weight: Option<u16>,
 }
 
 impl Default for SugarloafFont {
@@ -89,6 +93,7 @@ impl Default for SugarloafFont {
         Self {
             family: default_font_family(),
             style: FontStyle::Default,
+            weight: None,
         }
     }
 }

--- a/sugarloaf/src/font/macos.rs
+++ b/sugarloaf/src/font/macos.rs
@@ -29,10 +29,11 @@ use core_text::{
     font::{CTFont, CTFontRef},
     font_collection,
     font_descriptor::{
-        self, kCTFontBoldTrait, kCTFontFamilyNameAttribute, kCTFontItalicTrait,
-        kCTFontMonoSpaceTrait, kCTFontOrientationDefault, kCTFontStyleNameAttribute,
-        kCTFontSymbolicTrait, kCTFontTraitsAttribute, kCTFontVariationAttribute,
-        CTFontDescriptor, CTFontDescriptorCopyAttribute, CTFontDescriptorRef,
+        self, kCTFontBoldTrait, kCTFontFamilyNameAttribute,
+        kCTFontFeatureSettingsAttribute, kCTFontItalicTrait, kCTFontMonoSpaceTrait,
+        kCTFontOrientationDefault, kCTFontStyleNameAttribute, kCTFontSymbolicTrait,
+        kCTFontTraitsAttribute, kCTFontVariationAttribute, CTFontDescriptor,
+        CTFontDescriptorCopyAttribute, CTFontDescriptorRef,
     },
     font_manager,
     line::CTLine,
@@ -324,6 +325,68 @@ impl FontHandle {
             unsafe { CFString::wrap_under_get_rule(kCTFontVariationAttribute) };
         let attrs: CFDictionary<CFString, CFType> =
             CFDictionary::from_CFType_pairs(&[(var_attr_key, variation.as_CFType())]);
+        let desc = font_descriptor::new_from_attributes(&attrs);
+
+        let derived_ref = unsafe {
+            CTFontCreateCopyWithAttributes(
+                self.base_font.as_concrete_TypeRef(),
+                0.0,
+                std::ptr::null(),
+                desc.as_concrete_TypeRef(),
+            )
+        };
+        if derived_ref.is_null() {
+            return None;
+        }
+        let derived = unsafe { CTFont::wrap_under_create_rule(derived_ref) };
+        Some(Self { base_font: derived })
+    }
+
+    /// Return a derived `FontHandle` with OpenType feature settings
+    /// applied through `kCTFontFeatureSettingsAttribute`. Each entry is
+    /// a `(tag, value)` pair, e.g. `(u32::from_be_bytes(*b"liga"), 0)`
+    /// to disable standard ligatures. CoreText applies these to both
+    /// shaping and rasterization for the derived font.
+    pub fn with_features(self, features: &[(u32, u16)]) -> Option<Self> {
+        use core_foundation::array::CFArray;
+        use core_foundation::base::TCFType;
+        use core_foundation::dictionary::CFDictionary;
+        use core_foundation::number::CFNumber;
+        use core_foundation::string::CFString;
+
+        if features.is_empty() {
+            return Some(self);
+        }
+
+        extern "C" {
+            static kCTFontOpenTypeFeatureTag: core_foundation::string::CFStringRef;
+            static kCTFontOpenTypeFeatureValue: core_foundation::string::CFStringRef;
+        }
+
+        let tag_key = unsafe { CFString::wrap_under_get_rule(kCTFontOpenTypeFeatureTag) };
+        let value_key =
+            unsafe { CFString::wrap_under_get_rule(kCTFontOpenTypeFeatureValue) };
+
+        let entries: Vec<CFDictionary<CFString, CFType>> = features
+            .iter()
+            .filter_map(|(tag, value)| {
+                let bytes = tag.to_be_bytes();
+                let name = std::str::from_utf8(&bytes).ok()?;
+                Some(CFDictionary::from_CFType_pairs(&[
+                    (tag_key.clone(), CFString::new(name).as_CFType()),
+                    (value_key.clone(), CFNumber::from(*value as i64).as_CFType()),
+                ]))
+            })
+            .collect();
+        if entries.is_empty() {
+            return Some(self);
+        }
+        let settings = CFArray::from_CFTypes(&entries);
+
+        let attr_key =
+            unsafe { CFString::wrap_under_get_rule(kCTFontFeatureSettingsAttribute) };
+        let attrs: CFDictionary<CFString, CFType> =
+            CFDictionary::from_CFType_pairs(&[(attr_key, settings.as_CFType())]);
         let desc = font_descriptor::new_from_attributes(&attrs);
 
         let derived_ref = unsafe {

--- a/sugarloaf/src/font/mod.rs
+++ b/sugarloaf/src/font/mod.rs
@@ -568,6 +568,9 @@ pub struct FontLibraryData {
     pub inner: FxHashMap<usize, FontEntry>,
     pub symbol_maps: Option<Vec<SymbolMap>>,
     pub hinting: bool,
+    /// Parsed `fonts.features` entries, applied at shape time on every
+    /// platform. Empty when the user set none.
+    pub features: Arc<Vec<swash::Setting<u16>>>,
     // Cache primary font metrics for consistent cell dimensions (consistent metrics approach)
     primary_metrics_cache: FxHashMap<u32, Metrics>,
     /// PostScript-name → `font_id` lookup, populated on `insert`. Used
@@ -592,6 +595,7 @@ impl Default for FontLibraryData {
         Self {
             inner: FxHashMap::default(),
             hinting: true,
+            features: Arc::new(Vec::new()),
             symbol_maps: None,
             primary_metrics_cache: FxHashMap::default(),
             postscript_to_id: FxHashMap::default(),
@@ -876,6 +880,12 @@ impl FontLibraryData {
     pub fn load(&mut self, mut spec: SugarloafFonts) -> Vec<SugarloafFont> {
         // Configure hinting through spec
         self.hinting = spec.hinting;
+        self.features = Arc::new(
+            spec.features
+                .as_deref()
+                .map(parse_font_features)
+                .unwrap_or_default(),
+        );
 
         let mut fonts_not_fount: Vec<SugarloafFont> = vec![];
 
@@ -1350,14 +1360,19 @@ impl FontData {
 
         let attributes = font.attributes();
         let style = attributes.style();
-        let weight = attributes.weight();
+        // An explicit user weight pins the `wght` axis and overrides the
+        // face's reported weight so lookup and synthesis match intent.
+        let weight = match font_spec.weight {
+            Some(w) => Weight(w),
+            None => attributes.weight(),
+        };
 
         // Semibold threshold: families shipping bold at 600 must not
         // get faux-bold stacked on the real bold face.
         let (should_embolden, should_italicize) = synth_decisions(
             slot,
             font_spec,
-            weight >= Weight(600),
+            font_spec.weight.is_some() || weight >= Weight(600),
             style == Style::Italic,
         );
 
@@ -1373,7 +1388,7 @@ impl FontData {
             offset,
             should_italicize,
             should_embolden,
-            wght_variation: None,
+            wght_variation: font_spec.weight.map(f32::from),
             key,
             synth,
             style,
@@ -1448,6 +1463,15 @@ impl FontData {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let handle = crate::font::macos::FontHandle::from_path(&path)
             .ok_or_else(|| format!("CoreText refused {}", path.display()))?;
+        // Pin the `wght` axis when the user configured a weight so the
+        // stored CTFont shapes and rasterizes at that weight.
+        let handle = match font_spec.weight {
+            Some(w) => handle
+                .clone()
+                .with_wght_variation(f32::from(w))
+                .unwrap_or(handle),
+            None => handle,
+        };
         let attrs = crate::font::macos::font_attributes(&handle);
 
         let style = if attrs.is_italic {
@@ -1455,10 +1479,17 @@ impl FontData {
         } else {
             swash::Style::Normal
         };
-        let weight = swash::Weight(attrs.weight);
+        let weight = match font_spec.weight {
+            Some(w) => swash::Weight(w),
+            None => swash::Weight(attrs.weight),
+        };
 
-        let (should_embolden, should_italicize) =
-            synth_decisions(slot, font_spec, attrs.is_bold, attrs.is_italic);
+        let (should_embolden, should_italicize) = synth_decisions(
+            slot,
+            font_spec,
+            font_spec.weight.is_some() || attrs.is_bold,
+            attrs.is_italic,
+        );
 
         let postscript_name = Some(handle.postscript_name());
         Ok(Self {
@@ -1472,7 +1503,7 @@ impl FontData {
             synth: Synthesis::default(),
             should_embolden,
             should_italicize,
-            wght_variation: None,
+            wght_variation: font_spec.weight.map(f32::from),
             is_emoji: attrs.is_color,
             metrics_cache: FxHashMap::default(),
             handle: Some(handle),
@@ -1690,6 +1721,41 @@ enum FindResult {
     NotFound(SugarloafFont),
 }
 
+/// Parse `fonts.features` entries into OpenType feature settings.
+/// Accepts `"ss01"`, `"+ss01"`, `"-liga"` and `"cv01=2"` forms.
+pub fn parse_font_features(entries: &[String]) -> Vec<swash::Setting<u16>> {
+    let mut out: Vec<swash::Setting<u16>> = Vec::with_capacity(entries.len());
+    for raw in entries {
+        let s = raw.trim();
+        let (name, value) = if let Some(rest) = s.strip_prefix('-') {
+            (rest.trim(), 0u16)
+        } else if let Some(rest) = s.strip_prefix('+') {
+            (rest.trim(), 1u16)
+        } else if let Some((name, v)) = s.split_once('=') {
+            match v.trim().parse::<u16>() {
+                Ok(v) => (name.trim(), v),
+                Err(_) => {
+                    warn!("ignoring invalid font feature '{raw}'");
+                    continue;
+                }
+            }
+        } else {
+            (s, 1u16)
+        };
+        if name.is_empty() || name.len() > 4 || !name.is_ascii() {
+            warn!("ignoring invalid font feature '{raw}'");
+            continue;
+        }
+        let mut tag = [b' '; 4];
+        tag[..name.len()].copy_from_slice(name.as_bytes());
+        out.push(swash::Setting {
+            tag: u32::from_be_bytes(tag),
+            value,
+        });
+    }
+    out
+}
+
 /// Whether to apply faux-bold / faux-italic on top of the matched face.
 /// Synth fires only when the slot's bold/italic intent isn't already
 /// satisfied by the matched face, and never when the user pinned an
@@ -1762,10 +1828,10 @@ fn find_font(
             ..crate::font::loader::Query::default()
         };
 
-        query.weight = if slot.is_bold() {
-            crate::font::loader::Weight::BOLD
-        } else {
-            crate::font::loader::Weight::NORMAL
+        query.weight = match font_spec.weight {
+            Some(w) => crate::font::loader::Weight(w),
+            None if slot.is_bold() => crate::font::loader::Weight::BOLD,
+            None => crate::font::loader::Weight::NORMAL,
         };
 
         query.style = if slot.is_italic() {
@@ -1998,6 +2064,25 @@ mod alias_tests {
             font_id, FONT_ID_BOLD,
             "bold cells must use the configured bold slot"
         );
+    }
+
+    #[test]
+    fn parse_font_features_forms() {
+        let entries: Vec<String> = ["ss01", "+dlig", "-liga", "cv01=2", "bogus_tag", ""]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let parsed = parse_font_features(&entries);
+        let tag = |s: &str| {
+            let mut t = [b' '; 4];
+            t[..s.len()].copy_from_slice(s.as_bytes());
+            u32::from_be_bytes(t)
+        };
+        assert_eq!(parsed.len(), 4);
+        assert_eq!((parsed[0].tag, parsed[0].value), (tag("ss01"), 1));
+        assert_eq!((parsed[1].tag, parsed[1].value), (tag("dlig"), 1));
+        assert_eq!((parsed[2].tag, parsed[2].value), (tag("liga"), 0));
+        assert_eq!((parsed[3].tag, parsed[3].value), (tag("cv01"), 2));
     }
 
     /// Aliases share the target's `metrics_cache`, so requesting


### PR DESCRIPTION
Brings three font config options back to life:

**`fonts.features` now applies.** The config was parsed but dropped before reaching either shaper since the 0.4 rework (#1125, #1032). Features are now parsed once at library load (accepting `"ss01"`, `"+ss01"`, `"-liga"` and `"cv01=2"` forms; the documented bare-tag form keeps working) and applied at shape time: swash gets them through the shaper builder, CoreText through feature settings baked into the cached CTFont, so shaping and rasterization stay consistent. Verified on macOS: `features = ["-calt", "-liga"]` renders `=> -> != ===` as discrete characters instead of ligatures, which is the ask in #1258. Feature changes also live-reload now since the config diff triggers a font library rebuild.

**`fonts.hinting` now applies to the terminal grid.** The grid rasterization path hardcoded hinting on with a TODO; it now reads the library setting through a cached snapshot (no lock per glyph).

**Per-slot `weight` is back (#1577).** `[fonts.bold] weight = 600` steers face selection on Linux/Windows (font-kit query) and pins the `wght` axis on variable fonts on every platform (derived CTFont on macOS, swash variations on Linux/Windows). An explicit weight also suppresses synthetic bold so the exact weight the user asked for is what renders. This additionally fixes variable-font weight never being applied in the Linux/Windows grid path: the shaper and scaler now pass `wght` through, matching what the UI text path already did.

Also updates swash 0.2.7 to 0.2.10, which fixes a hinting-cache regression that rebuilt hinting state per glyph (0.2.8 was yanked; 0.2.10 is the current release).

Refs #1125 #1032 #1258 #1577