### PR TITLE
keybinding fixes: ctrl combos, live reload, f-keys

### DIFF
--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -762,20 +762,40 @@ fn convert(config_key_binding: ConfigKeyBinding) -> Result<KeyBinding, String> {
             "home" => (Key::Named(Home), KeyLocation::Standard),
             "space" => (Key::Named(Space), KeyLocation::Standard),
             "delete" => (Key::Named(Delete), KeyLocation::Standard),
-            "esc" => (Key::Named(Escape), KeyLocation::Standard),
+            "esc" | "escape" => (Key::Named(Escape), KeyLocation::Standard),
             "insert" => (Key::Named(Insert), KeyLocation::Standard),
             "pageup" => (Key::Named(PageUp), KeyLocation::Standard),
             "pagedown" => (Key::Named(PageDown), KeyLocation::Standard),
             "end" => (Key::Named(End), KeyLocation::Standard),
             "up" => (Key::Named(ArrowUp), KeyLocation::Standard),
-            "back" => (Key::Named(Backspace), KeyLocation::Standard),
+            "back" | "backspace" => (Key::Named(Backspace), KeyLocation::Standard),
             "down" => (Key::Named(ArrowDown), KeyLocation::Standard),
             "left" => (Key::Named(ArrowLeft), KeyLocation::Standard),
             "right" => (Key::Named(ArrowRight), KeyLocation::Standard),
             "@" => (Key::Character("@".into()), KeyLocation::Standard),
             "colon" => (Key::Character(":".into()), KeyLocation::Standard),
             "." => (Key::Character(".".into()), KeyLocation::Standard),
-            "return" => (Key::Named(Enter), KeyLocation::Standard),
+            "return" | "enter" => (Key::Named(Enter), KeyLocation::Standard),
+            "f1" => (Key::Named(F1), KeyLocation::Standard),
+            "f2" => (Key::Named(F2), KeyLocation::Standard),
+            "f3" => (Key::Named(F3), KeyLocation::Standard),
+            "f4" => (Key::Named(F4), KeyLocation::Standard),
+            "f5" => (Key::Named(F5), KeyLocation::Standard),
+            "f6" => (Key::Named(F6), KeyLocation::Standard),
+            "f7" => (Key::Named(F7), KeyLocation::Standard),
+            "f8" => (Key::Named(F8), KeyLocation::Standard),
+            "f9" => (Key::Named(F9), KeyLocation::Standard),
+            "f10" => (Key::Named(F10), KeyLocation::Standard),
+            "f11" => (Key::Named(F11), KeyLocation::Standard),
+            "f12" => (Key::Named(F12), KeyLocation::Standard),
+            "f13" => (Key::Named(F13), KeyLocation::Standard),
+            "f14" => (Key::Named(F14), KeyLocation::Standard),
+            "f15" => (Key::Named(F15), KeyLocation::Standard),
+            "f16" => (Key::Named(F16), KeyLocation::Standard),
+            "f17" => (Key::Named(F17), KeyLocation::Standard),
+            "f18" => (Key::Named(F18), KeyLocation::Standard),
+            "f19" => (Key::Named(F19), KeyLocation::Standard),
+            "f20" => (Key::Named(F20), KeyLocation::Standard),
             "[" => (Key::Character("[".into()), KeyLocation::Standard),
             "]" => (Key::Character("]".into()), KeyLocation::Standard),
             "{" => (Key::Character("{".into()), KeyLocation::Standard),
@@ -839,7 +859,17 @@ fn convert(config_key_binding: ConfigKeyBinding) -> Result<KeyBinding, String> {
         }
     }
 
-    let mut action: Action = config_key_binding.action.into();
+    let action_str = config_key_binding.action;
+    let mut action: Action = action_str.clone().into();
+    // An unknown action parses as `None`, which would silently unbind
+    // the default on this key. Reject it so the config error is loud
+    // and the default stays.
+    if action == Action::None
+        && !action_str.is_empty()
+        && action_str.to_lowercase() != "none"
+    {
+        return Err(format!("unknown action '{action_str}'"));
+    }
     if !config_key_binding.esc.is_empty() {
         action = Action::Esc(config_key_binding.esc);
     }
@@ -872,6 +902,77 @@ fn convert(config_key_binding: ConfigKeyBinding) -> Result<KeyBinding, String> {
         action,
         mode: res_mode.mode,
         notmode: res_mode.not_mode,
+    })
+}
+
+/// Legacy (non-kitty) C0 byte for a ctrl+character combo, using the
+/// same table and modifier discipline as kitty. The platform is
+/// inconsistent about synthesizing these (ctrl+6, ctrl+/), so the byte
+/// is computed here instead of trusting the reported text. Returns
+/// `None` when the combo has no C0 identity or carries modifiers
+/// beyond ctrl (plus alt, which the caller encodes as an ESC prefix,
+/// and shift when it only serves to produce the character itself).
+///
+/// `i`, `m` and `[` are intentionally absent per fixterms: their C0
+/// bytes collide with Tab, Enter and Escape, and the platform text
+/// already carries them in legacy mode.
+pub fn ctrl_seq(key: &Key, text: &str, mods: ModifiersState) -> Option<u8> {
+    if !mods.control_key() {
+        return None;
+    }
+
+    let mut c = {
+        let mut it = text.chars();
+        match (it.next(), it.next()) {
+            (Some(c), None) if c.is_ascii() => c,
+            _ => {
+                // No single-byte text: fall back to the logical key.
+                // Covers layouts whose key produces a non-ASCII char
+                // (cyrillic) and platforms reporting no text at all.
+                let Key::Character(ch) = key else {
+                    return None;
+                };
+                let mut it = ch.chars();
+                let (Some(c), None) = (it.next(), it.next()) else {
+                    return None;
+                };
+                if !c.is_ascii() {
+                    return None;
+                }
+                c
+            }
+        }
+    };
+
+    let mut rest = mods & !(ModifiersState::CONTROL | ModifiersState::ALT);
+    // Shift is consumed when it only produced the character itself
+    // (ctrl+shift+6 arrives as '^'); for letters it stays, so
+    // ctrl+shift+a remains distinguishable from ctrl+a.
+    if rest.shift_key() && !c.is_ascii_uppercase() && c != '@' {
+        rest &= !ModifiersState::SHIFT;
+    }
+    if c.is_ascii_uppercase() && !rest.shift_key() {
+        // Caps lock without shift.
+        c = c.to_ascii_lowercase();
+    }
+    if !rest.is_empty() {
+        return None;
+    }
+
+    Some(match c {
+        ' ' | '2' | '@' => 0x00,
+        '3' => 0x1b,
+        '4' | '\\' => 0x1c,
+        '5' | ']' => 0x1d,
+        '6' | '^' | '~' => 0x1e,
+        '7' | '/' | '_' => 0x1f,
+        '8' | '?' => 0x7f,
+        '0' => b'0',
+        '1' => b'1',
+        '9' => b'9',
+        'i' | 'm' => return None,
+        c @ 'a'..='z' => (c as u8) - b'a' + 1,
+        _ => return None,
     })
 }
 
@@ -995,8 +1096,6 @@ pub fn platform_key_bindings(
         "0", ModifiersState::SUPER; Action::ResetFontSize;
         "=", ModifiersState::SUPER; Action::IncreaseFontSize;
         "+", ModifiersState::SUPER; Action::IncreaseFontSize;
-        "+", ModifiersState::SUPER; Action::IncreaseFontSize;
-        "-", ModifiersState::SUPER; Action::DecreaseFontSize;
         "-", ModifiersState::SUPER; Action::DecreaseFontSize;
         Key::Named(Insert), ModifiersState::SHIFT, ~BindingMode::VI, ~BindingMode::SEARCH;
             Action::Esc("\x1b[2;2~".into());
@@ -1093,8 +1192,6 @@ pub fn platform_key_bindings(
         "0", ModifiersState::CONTROL;  Action::ResetFontSize;
         "=", ModifiersState::CONTROL;  Action::IncreaseFontSize;
         "+", ModifiersState::CONTROL;  Action::IncreaseFontSize;
-        "+", ModifiersState::CONTROL;  Action::IncreaseFontSize;
-        "-", ModifiersState::CONTROL;  Action::DecreaseFontSize;
         "-", ModifiersState::CONTROL;  Action::DecreaseFontSize;
         "n", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::WindowCreateNew;
         ",", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::ConfigEditor;
@@ -1157,8 +1254,6 @@ pub fn platform_key_bindings(
         "0", ModifiersState::CONTROL; Action::ResetFontSize;
         "=", ModifiersState::CONTROL; Action::IncreaseFontSize;
         "+", ModifiersState::CONTROL; Action::IncreaseFontSize;
-        "+", ModifiersState::CONTROL; Action::IncreaseFontSize;
-        "-", ModifiersState::CONTROL; Action::DecreaseFontSize;
         "-", ModifiersState::CONTROL; Action::DecreaseFontSize;
         Key::Named(Enter), ModifiersState::ALT; Action::ToggleFullscreen;
         "n", ModifiersState::CONTROL | ModifiersState::SHIFT; Action::WindowCreateNew;
@@ -1531,6 +1626,94 @@ mod tests {
             .iter()
             .any(|b| matches!(b.action, Action::Scroll(_)));
         assert!(has_scroll_actions);
+    }
+
+    #[test]
+    fn ctrl_seq_map() {
+        let ctrl = ModifiersState::CONTROL;
+        let shift = ModifiersState::SHIFT;
+        let alt = ModifiersState::ALT;
+        let key = |s: &str| Key::Character(s.into());
+
+        // macOS shape: the platform reports the plain char as text.
+        assert_eq!(ctrl_seq(&key("6"), "6", ctrl), Some(0x1e));
+        assert_eq!(ctrl_seq(&key("/"), "/", ctrl), Some(0x1f));
+        // Windows shape: no text at all.
+        assert_eq!(ctrl_seq(&key("6"), "", ctrl), Some(0x1e));
+        // ctrl+shift+6 arrives as '^': shift is consumed.
+        assert_eq!(ctrl_seq(&key("^"), "^", ctrl | shift), Some(0x1e));
+        // Alt passes through; the caller adds the ESC prefix.
+        assert_eq!(ctrl_seq(&key("6"), "6", ctrl | alt), Some(0x1e));
+        // Letters map, except the fixterms exclusions.
+        assert_eq!(ctrl_seq(&key("q"), "q", ctrl), Some(0x11));
+        assert_eq!(ctrl_seq(&key("i"), "i", ctrl), None);
+        assert_eq!(ctrl_seq(&key("m"), "m", ctrl), None);
+        // ctrl+shift+letter stays distinguishable: no C0 collapse.
+        assert_eq!(ctrl_seq(&key("A"), "A", ctrl | shift), None);
+        // Digit passthrough per kitty.
+        assert_eq!(ctrl_seq(&key("1"), "1", ctrl), Some(b'1'));
+        // Super combos never collapse to C0.
+        assert_eq!(ctrl_seq(&key("6"), "6", ctrl | ModifiersState::SUPER), None);
+        assert_eq!(ctrl_seq(&key("6"), "6", ModifiersState::empty()), None);
+        assert_eq!(ctrl_seq(&Key::Named(Enter), "", ctrl), None);
+    }
+
+    #[test]
+    fn unknown_action_is_rejected_and_default_survives() {
+        let bindings = bindings!(
+            KeyBinding;
+            "q", ModifiersState::SUPER; Action::Quit;
+        );
+        let config_bindings = vec![ConfigKeyBinding {
+            key: String::from("q"),
+            action: String::from("quitt"),
+            with: String::from("super"),
+            esc: String::from(""),
+            mode: String::from(""),
+        }];
+        let new_bindings = config_key_bindings(config_bindings, bindings);
+        assert_eq!(new_bindings.len(), 1);
+        assert_eq!(new_bindings[0].action, Action::Quit);
+    }
+
+    #[test]
+    fn function_keys_parse_in_config() {
+        for (name, named) in [("f1", F1), ("f5", F5), ("f12", F12), ("f20", F20)] {
+            let config_bindings = vec![ConfigKeyBinding {
+                key: String::from(name),
+                action: String::from("quit"),
+                with: String::from(""),
+                esc: String::from(""),
+                mode: String::from(""),
+            }];
+            let new_bindings = config_key_bindings(config_bindings, Vec::new());
+            assert_eq!(new_bindings.len(), 1, "{name} must parse");
+            assert_eq!(
+                new_bindings[0].trigger,
+                BindingKey::Keycode {
+                    key: Key::Named(named),
+                    location: KeyLocation::Standard
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn defaults_have_no_duplicate_triggers() {
+        let config = rio_backend::config::Config::default();
+        let bindings = default_key_bindings(&config);
+        for (i, a) in bindings.iter().enumerate() {
+            for b in bindings.iter().skip(i + 1) {
+                assert!(
+                    !(a.trigger == b.trigger
+                        && a.mods == b.mods
+                        && a.mode == b.mode
+                        && a.notmode == b.notmode
+                        && a.action == b.action),
+                    "duplicate default binding: {a:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -438,6 +438,10 @@ impl Screen<'_> {
         self.sugarloaf
             .update_filters(config.renderer.filters.as_slice());
 
+        // Rebuild bindings so `[bindings]` edits live-reload like the
+        // rest of the config instead of waiting for a new window.
+        self.bindings = crate::bindings::default_key_bindings(config);
+
         // Preserve existing Island (tab state) and update its colors
         let old_island = self.renderer.island.take();
         let was_focused = self.renderer.is_window_focused;
@@ -771,7 +775,32 @@ impl Screen<'_> {
 
         let build_key_sequence = Self::should_build_sequence(key, text, mode, mods);
 
-        let bytes = if build_key_sequence {
+        // Legacy ctrl encoding runs before trusting the platform text:
+        // the OS is inconsistent about synthesizing C0 characters for
+        // combos like ctrl+6 or ctrl+/ (macOS reports the plain char,
+        // Windows reports nothing), so the byte is computed from the
+        // kitty C0 table directly. Gated on the exact flag set that
+        // makes `build_key_sequence` produce CSI u (`kitty_seq`), so
+        // kitty-protocol encoding is untouched in every mode where it
+        // applies.
+        let kitty_seq = mode.intersects(
+            Mode::REPORT_ALL_KEYS_AS_ESC
+                | Mode::DISAMBIGUATE_ESC_CODES
+                | Mode::REPORT_EVENT_TYPES,
+        );
+        let ctrl_c0 = if kitty_seq {
+            None
+        } else {
+            crate::bindings::ctrl_seq(&key.logical_key, text, mods)
+        };
+
+        let bytes = if let Some(c0) = ctrl_c0 {
+            if mods.alt_key() {
+                vec![b'\x1b', c0]
+            } else {
+                vec![c0]
+            }
+        } else if build_key_sequence {
             crate::bindings::kitty_keyboard::build_key_sequence(key, mods, mode)
         } else {
             let mut bytes = Vec::with_capacity(text.len() + 1);


### PR DESCRIPTION
Fixes the common root causes behind the keybinding issue cluster:

**ctrl+digit and ctrl+punctuation now reach the pty (#863, #1328).** Platforms are inconsistent about synthesizing C0 control characters: xkbcommon does the full transform on Linux, macOS reports the plain character for combos like ctrl+6 and ctrl+/, and Windows reports nothing at all, so the key either lost its ctrl or was silently dropped. Rio now computes the C0 byte itself in legacy mode using the same table and modifier discipline as kitty (ctrl+6 = 0x1E, ctrl+/ = 0x1F, shift consumed for non-letters so ctrl+shift+6 works, i/m/[ excluded per fixterms), consulted before trusting the platform text. Under the kitty protocol nothing changes, combos encode as CSI u as before. This may also improve the Windows TUI reports (#1540, #1467).

**`[bindings]` live-reloads.** Bindings were built once at window creation and never rebuilt on config reload, so editing a remap looked broken until a new window was opened. This is likely why "my remap doesn't work" reports kept coming after the override fix landed in 0.2.31. They now rebuild in `update_config` like everything else.

**Typos no longer silently unbind defaults.** An unknown `action` string parsed as `None`, which both did nothing and removed the default on that key. Unknown actions are now rejected with an error and the default stays.

**Function keys are bindable (#1225's config half).** `key = "f1"` through `"f20"` now parse in `[bindings]`; previously only F1-F4 existed as defaults and no F key was accepted in user config. Also added `"enter"`, `"escape"` and `"backspace"` aliases alongside the existing `"return"`/`"esc"`/`"back"`.

**Font size actions fired twice per keypress.** The `+` and `-` defaults were declared twice on every platform, and every matching binding executes, so each press changed the font size by two steps. Duplicates removed and a regression test asserts the default table stays duplicate free.

Note on Quit (#892): the missing `RioEvent::Quit` handling was already fixed on main by 89c5744eff, so custom `action = "quit"` bindings work on Linux/Windows now; nothing further needed here.

Refs #863 #1328 #1225 #892 #1228 #861 #741 #1540 #1467