### PR TITLE
fonts.antialias option with fontconfig defaults on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4606,6 +4606,7 @@ dependencies = [
  "swash",
  "thiserror 2.0.18",
  "tiny-skia 0.12.0",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "ttf-parser",
  "twox-hash",

--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -1163,6 +1163,17 @@ struct RunCacheEntry {
     glyphs: Vec<ShapedGlyph>,
 }
 
+/// Library-wide render settings snapshot, refreshed lazily after
+/// `clear_font_caches`.
+#[derive(Clone)]
+struct LibrarySettings {
+    /// Read by the swash rasterizer; CoreText has no hinting toggle.
+    #[cfg_attr(target_os = "macos", allow(dead_code))]
+    hinting: bool,
+    antialias: bool,
+    features: std::sync::Arc<Vec<rio_backend::sugarloaf::swash::Setting<u16>>>,
+}
+
 pub struct GridGlyphRasterizer {
     /// Cache of `(char, style_flags, route_id) → (font_id, is_emoji)`
     /// resolutions. The route_id is part of the key because Glyph
@@ -1215,10 +1226,7 @@ pub struct GridGlyphRasterizer {
     /// Library-wide `(hinting, features)` snapshot, refreshed lazily
     /// after `clear_font_caches` so shaping and rasterization don't
     /// take the library lock per run.
-    lib_settings: Option<(
-        bool,
-        std::sync::Arc<Vec<rio_backend::sugarloaf::swash::Setting<u16>>>,
-    )>,
+    lib_settings: Option<LibrarySettings>,
     /// Per-font `wght` axis pin, mirrored from `FontData.wght_variation`.
     #[cfg(not(target_os = "macos"))]
     wght_cache: FxHashMap<u32, Option<f32>>,
@@ -1299,16 +1307,14 @@ impl GridGlyphRasterizer {
 
     /// Library-wide `(hinting, features)`, cached until the next
     /// `clear_font_caches`.
-    fn library_settings(
-        &mut self,
-        font_library: &FontLibrary,
-    ) -> (
-        bool,
-        std::sync::Arc<Vec<rio_backend::sugarloaf::swash::Setting<u16>>>,
-    ) {
+    fn library_settings(&mut self, font_library: &FontLibrary) -> LibrarySettings {
         if self.lib_settings.is_none() {
             let lib = font_library.inner.read();
-            self.lib_settings = Some((lib.hinting, lib.features.clone()));
+            self.lib_settings = Some(LibrarySettings {
+                hinting: lib.hinting,
+                antialias: lib.antialias,
+                features: lib.features.clone(),
+            });
         }
         self.lib_settings.clone().unwrap()
     }
@@ -1488,7 +1494,7 @@ fn shape_run_ct(
     size_bucket: u16,
     font_library: &FontLibrary,
 ) -> Option<(Vec<ShapedGlyph>, i16)> {
-    let (_, features) = rasterizer.library_settings(font_library);
+    let features = rasterizer.library_settings(font_library).features;
     let handle = match rasterizer.handle_cache.entry(font_id) {
         std::collections::hash_map::Entry::Occupied(e) => e.into_mut().clone(),
         std::collections::hash_map::Entry::Vacant(e) => {
@@ -1547,7 +1553,7 @@ fn shape_run_swash(
 ) -> Option<(Vec<ShapedGlyph>, i16)> {
     use rio_backend::sugarloaf::swash::{FontRef, Setting};
 
-    let (_, features) = rasterizer.library_settings(font_library);
+    let features = rasterizer.library_settings(font_library).features;
     let wght = *rasterizer.wght_cache.entry(font_id).or_insert_with(|| {
         let lib = font_library.inner.read();
         lib.try_get(&(font_id as usize))
@@ -2516,6 +2522,11 @@ fn rasterize_glyph_native(
     synthetic_italic: bool,
 ) -> Option<RawGlyph> {
     let handle = rasterizer.handle_cache.get(&font_id)?.clone();
+    let antialias = rasterizer
+        .lib_settings
+        .as_ref()
+        .map(|s| s.antialias)
+        .unwrap_or(true);
     let raw = rio_backend::sugarloaf::font::macos::rasterize_glyph(
         &handle,
         glyph_id,
@@ -2523,6 +2534,7 @@ fn rasterize_glyph_native(
         is_emoji,
         synthetic_italic,
         synthetic_bold,
+        antialias,
     )?;
     Some(RawGlyph {
         width: raw.width,
@@ -2562,11 +2574,11 @@ fn rasterize_glyph_native(
 
     // Shaping runs before rasterization, so `lib_settings` and
     // `wght_cache` are already populated for this font.
-    let hinting = rasterizer
+    let (hinting, antialias) = rasterizer
         .lib_settings
         .as_ref()
-        .map(|s| s.0)
-        .unwrap_or(true);
+        .map(|s| (s.hinting, s.antialias))
+        .unwrap_or((true, true));
     const WGHT_TAG: u32 = u32::from_be_bytes(*b"wght");
     let wght_var = rasterizer
         .wght_cache
@@ -2612,6 +2624,9 @@ fn rasterize_glyph_native(
         return None;
     }
     let is_color = image.content == Content::Color;
+    if !antialias && !is_color {
+        rio_backend::sugarloaf::font::threshold_mask(&mut image.data);
+    }
     Some(RawGlyph {
         width: image.placement.width,
         height: image.placement.height,

--- a/sugarloaf/Cargo.toml
+++ b/sugarloaf/Cargo.toml
@@ -122,6 +122,7 @@ ash = "0.38.0"
 
 [dev-dependencies]
 rio-window = { workspace = true }
+toml = "0.9.2"
 png = "0.17.16"
 deflate = "1.0.0"
 criterion = { workspace = true }

--- a/sugarloaf/src/font/fonts.rs
+++ b/sugarloaf/src/font/fonts.rs
@@ -132,8 +132,14 @@ fn default_font_family() -> String {
 pub struct SugarloafFonts {
     #[serde(default = "default_font_size")]
     pub size: f32,
-    #[serde(default = "default_bool_true")]
-    pub hinting: bool,
+    /// `None` falls back to the platform default: the fontconfig
+    /// setting on Linux, `true` elsewhere.
+    #[serde(default = "Option::default")]
+    pub hinting: Option<bool>,
+    /// `None` falls back to the platform default: the fontconfig
+    /// setting on Linux, `true` elsewhere.
+    #[serde(default = "Option::default")]
+    pub antialias: Option<bool>,
     #[serde(default = "Option::default")]
     pub features: Option<Vec<String>>,
     #[serde(default = "Option::default")]
@@ -156,6 +162,23 @@ pub struct SugarloafFonts {
     pub additional_dirs: Option<Vec<String>>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hinting_and_antialias_parse_and_default_to_unset() {
+        let fonts: SugarloafFonts = toml::from_str("").unwrap();
+        assert_eq!(fonts.hinting, None);
+        assert_eq!(fonts.antialias, None);
+
+        let fonts: SugarloafFonts =
+            toml::from_str("hinting = false\nantialias = false").unwrap();
+        assert_eq!(fonts.hinting, Some(false));
+        assert_eq!(fonts.antialias, Some(false));
+    }
+}
+
 pub fn parse_unicode(input: &str) -> Option<char> {
     if let Ok(unicode) = u32::from_str_radix(input, 16) {
         if let Some(result) = char::from_u32(unicode) {
@@ -170,7 +193,8 @@ impl Default for SugarloafFonts {
     fn default() -> SugarloafFonts {
         SugarloafFonts {
             features: None,
-            hinting: true,
+            hinting: None,
+            antialias: None,
             size: default_font_size(),
             family: None,
             regular: SugarloafFont::default(),

--- a/sugarloaf/src/font/linux.rs
+++ b/sugarloaf/src/font/linux.rs
@@ -14,8 +14,9 @@ use std::sync::OnceLock;
 // pull them in explicitly.
 use fontconfig_sys as fc;
 use fontconfig_sys::constants::{
-    FC_CHARSET, FC_FAMILY, FC_FILE, FC_INDEX, FC_LANG, FC_MONO, FC_SLANT,
-    FC_SLANT_ITALIC, FC_SPACING, FC_WEIGHT, FC_WEIGHT_BOLD,
+    FC_ANTIALIAS, FC_CHARSET, FC_FAMILY, FC_FILE, FC_HINTING, FC_HINT_NONE,
+    FC_HINT_STYLE, FC_INDEX, FC_LANG, FC_MONO, FC_RGBA, FC_SLANT, FC_SLANT_ITALIC,
+    FC_SPACING, FC_WEIGHT, FC_WEIGHT_BOLD,
 };
 
 /// Process-global fontconfig handle. `FcConfigGetCurrent` returns a
@@ -208,6 +209,85 @@ unsafe fn pattern_path_and_index(pattern: *mut fc::FcPattern) -> Option<(PathBuf
         let mut index: i32 = 0;
         let _ = fc::FcPatternGetInteger(pattern, FC_INDEX.as_ptr(), 0, &mut index);
         Some((PathBuf::from(path_str), index.max(0) as u32))
+    }
+}
+
+/// Rendering preferences fontconfig reports for a family, used as
+/// defaults when the Rio config leaves them unset. `rgba` carries the
+/// `FC_RGBA_*` subpixel order for the renderer.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FcRenderSettings {
+    pub antialias: Option<bool>,
+    pub hinting: Option<bool>,
+    pub rgba: Option<i32>,
+}
+
+/// Query fontconfig for the render settings it would apply to
+/// `family`, honoring the user's fonts.conf match rules the same way
+/// other fontconfig consumers do.
+pub fn render_settings(family: &str) -> FcRenderSettings {
+    let cfg = fc_config();
+    if cfg.is_null() {
+        return FcRenderSettings::default();
+    }
+
+    unsafe {
+        let pattern = fc::FcPatternCreate();
+        if pattern.is_null() {
+            return FcRenderSettings::default();
+        }
+
+        if let Ok(family_c) = CString::new(family) {
+            fc::FcPatternAddString(
+                pattern,
+                FC_FAMILY.as_ptr(),
+                family_c.as_ptr() as *const fc::FcChar8,
+            );
+        }
+        fc::FcConfigSubstitute(cfg, pattern, fc::FcMatchPattern);
+        fc::FcDefaultSubstitute(pattern);
+
+        let mut result: fc::FcResult = 0;
+        let matched = fc::FcFontMatch(cfg, pattern, &mut result);
+
+        let mut out = FcRenderSettings::default();
+        if !matched.is_null() && result == fc::FcResultMatch {
+            let mut b: fc::FcBool = 0;
+            if fc::FcPatternGetBool(matched, FC_ANTIALIAS.as_ptr(), 0, &mut b)
+                == fc::FcResultMatch
+            {
+                out.antialias = Some(b != 0);
+            }
+
+            // Hinting is off when either the boolean is false or the
+            // style is `hintnone`; fontconfig tools treat them as one
+            // setting split across two keys.
+            let mut hinting: Option<bool> = None;
+            if fc::FcPatternGetBool(matched, FC_HINTING.as_ptr(), 0, &mut b)
+                == fc::FcResultMatch
+            {
+                hinting = Some(b != 0);
+            }
+            let mut style: i32 = 0;
+            if fc::FcPatternGetInteger(matched, FC_HINT_STYLE.as_ptr(), 0, &mut style)
+                == fc::FcResultMatch
+                && style == FC_HINT_NONE
+            {
+                hinting = Some(false);
+            }
+            out.hinting = hinting;
+
+            let mut rgba: i32 = 0;
+            if fc::FcPatternGetInteger(matched, FC_RGBA.as_ptr(), 0, &mut rgba)
+                == fc::FcResultMatch
+            {
+                out.rgba = Some(rgba);
+            }
+
+            fc::FcPatternDestroy(matched);
+        }
+        fc::FcPatternDestroy(pattern);
+        out
     }
 }
 

--- a/sugarloaf/src/font/macos.rs
+++ b/sugarloaf/src/font/macos.rs
@@ -451,6 +451,7 @@ pub fn rasterize_glyph(
     is_color: bool,
     synthetic_italic: bool,
     synthetic_bold: bool,
+    antialias: bool,
 ) -> Option<RasterizedGlyph> {
     let ct_font = if synthetic_italic {
         ct_font_sheared(&handle.base_font, size_px as f64)
@@ -568,9 +569,9 @@ pub fn rasterize_glyph(
         (bytes, cx)
     };
 
-    cx.set_should_antialias(true);
-    cx.set_allows_antialiasing(true);
-    cx.set_should_smooth_fonts(true);
+    cx.set_should_antialias(antialias);
+    cx.set_allows_antialiasing(antialias);
+    cx.set_should_smooth_fonts(antialias);
     cx.set_gray_fill_color(0.0, 1.0);
     // Synthetic bold via fill+stroke. Line width scales with size
     // (1/14 of points, floored at 1 device pixel) so bold weight looks
@@ -1724,7 +1725,7 @@ mod tests {
             .expect("static bytes should parse");
         let size = 18.0;
         let gid = glyph_id_for_char(&handle, size as f64, 'M');
-        let g = rasterize_glyph(&handle, gid, size, false, false, false)
+        let g = rasterize_glyph(&handle, gid, size, false, false, false, true)
             .expect("rasterize returned None");
         assert!(g.width > 0 && g.height > 0);
         // Inked: at least one non-zero alpha pixel.
@@ -1736,7 +1737,7 @@ mod tests {
         let handle = FontHandle::from_bytes(FONT_CASCADIA_CODE_NF).expect("load font");
         let size = 24.0;
         let gid = glyph_id_for_char(&handle, size as f64, 'A');
-        let g = rasterize_glyph(&handle, gid, size, false, false, false)
+        let g = rasterize_glyph(&handle, gid, size, false, false, false, true)
             .expect("rasterize returned None");
 
         assert!(g.width > 0, "A should have non-zero width");
@@ -1816,7 +1817,7 @@ mod tests {
         let handle = FontHandle::from_bytes(FONT_CASCADIA_CODE_NF).expect("load font");
         let size = 24.0;
         let gid = glyph_id_for_char(&handle, size as f64, ' ');
-        let g = rasterize_glyph(&handle, gid, size, false, false, false)
+        let g = rasterize_glyph(&handle, gid, size, false, false, false, true)
             .expect("rasterize returned None");
 
         // Space carries advance but no ink; rasterizer should short-circuit.

--- a/sugarloaf/src/font/mod.rs
+++ b/sugarloaf/src/font/mod.rs
@@ -568,6 +568,7 @@ pub struct FontLibraryData {
     pub inner: FxHashMap<usize, FontEntry>,
     pub symbol_maps: Option<Vec<SymbolMap>>,
     pub hinting: bool,
+    pub antialias: bool,
     /// Parsed `fonts.features` entries, applied at shape time on every
     /// platform. Empty when the user set none.
     pub features: Arc<Vec<swash::Setting<u16>>>,
@@ -595,6 +596,7 @@ impl Default for FontLibraryData {
         Self {
             inner: FxHashMap::default(),
             hinting: true,
+            antialias: true,
             features: Arc::new(Vec::new()),
             symbol_maps: None,
             primary_metrics_cache: FxHashMap::default(),
@@ -878,8 +880,11 @@ impl FontLibraryData {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn load(&mut self, mut spec: SugarloafFonts) -> Vec<SugarloafFont> {
-        // Configure hinting through spec
-        self.hinting = spec.hinting;
+        // Explicit config wins; unset values fall back to the platform
+        // default, which on Linux comes from fontconfig (resolved after
+        // the regular font is known, below).
+        self.hinting = spec.hinting.unwrap_or(true);
+        self.antialias = spec.antialias.unwrap_or(true);
         self.features = Arc::new(
             spec.features
                 .as_deref()
@@ -895,6 +900,30 @@ impl FontLibraryData {
             font_family_overwrite.clone_into(&mut spec.bold.family);
             font_family_overwrite.clone_into(&mut spec.bold_italic.family);
             font_family_overwrite.clone_into(&mut spec.italic.family);
+        }
+
+        // On Linux, unset hinting/antialias fall back to what
+        // fontconfig would apply to the primary family, so fonts.conf
+        // rules (antialias=false for pixel fonts, hintnone, etc.) are
+        // honored without Rio-specific config.
+        #[cfg(all(
+            unix,
+            not(target_os = "macos"),
+            not(target_os = "android"),
+            not(target_arch = "wasm32")
+        ))]
+        if spec.hinting.is_none() || spec.antialias.is_none() {
+            let fc = crate::font::linux::render_settings(&spec.regular.family);
+            if spec.hinting.is_none() {
+                if let Some(hinting) = fc.hinting {
+                    self.hinting = hinting;
+                }
+            }
+            if spec.antialias.is_none() {
+                if let Some(antialias) = fc.antialias {
+                    self.antialias = antialias;
+                }
+            }
         }
 
         // On macOS we resolve fonts through CoreText (see `find_font` below)
@@ -1719,6 +1748,15 @@ use tracing::{info, warn};
 enum FindResult {
     Found(FontData),
     NotFound(SugarloafFont),
+}
+
+/// Collapse an 8-bit coverage mask to hard edges. Used when
+/// antialiasing is disabled: swash/zeno have no aliased render mode,
+/// so the mask is thresholded post-render.
+pub fn threshold_mask(data: &mut [u8]) {
+    for px in data.iter_mut() {
+        *px = if *px >= 128 { 255 } else { 0 };
+    }
 }
 
 /// Parse `fonts.features` entries into OpenType feature settings.

--- a/sugarloaf/src/text.rs
+++ b/sugarloaf/src/text.rs
@@ -523,6 +523,7 @@ impl Text {
                 /* is_emoji: */ false,
                 run.synthetic_italic,
                 run.synthetic_bold,
+                self.font_library.inner.read().antialias,
             )?;
             let is_color = raw.is_color;
             let raster = crate::grid::RasterizedGlyph {
@@ -590,6 +591,7 @@ impl Text {
                     run.synthetic_bold,
                     run.synthetic_italic,
                     self.font_library.inner.read().hinting,
+                    self.font_library.inner.read().antialias,
                     run.wght_variation,
                 )?;
                 let is_color = raw.is_color;
@@ -635,6 +637,7 @@ impl Text {
                     run.synthetic_bold,
                     run.synthetic_italic,
                     self.font_library.inner.read().hinting,
+                    self.font_library.inner.read().antialias,
                     run.wght_variation,
                 )?;
                 let is_color = raw.is_color;
@@ -701,6 +704,7 @@ impl Text {
                 /* is_emoji: */ false,
                 run.synthetic_italic,
                 run.synthetic_bold,
+                self.font_library.inner.read().antialias,
             )?;
             (
                 raw.width,
@@ -722,6 +726,7 @@ impl Text {
                 run.synthetic_bold,
                 run.synthetic_italic,
                 self.font_library.inner.read().hinting,
+                self.font_library.inner.read().antialias,
                 run.wght_variation,
             )?;
             (
@@ -1209,6 +1214,7 @@ fn rasterize_swash_glyph(
     synthetic_bold: bool,
     synthetic_italic: bool,
     hint: bool,
+    antialias: bool,
     wght_variation: Option<f32>,
 ) -> Option<SwashRawGlyph> {
     use swash::scale::{
@@ -1272,6 +1278,9 @@ fn rasterize_swash_glyph(
     }
 
     let is_color = image.content == Content::Color;
+    if !antialias && !is_color {
+        crate::font::threshold_mask(&mut image.data);
+    }
     Some(SwashRawGlyph {
         width: image.placement.width,
         height: image.placement.height,


### PR DESCRIPTION
First part of the rasterization quality work in #732.

**New `fonts.antialias` option.** On macOS it maps to the CGContext antialiasing and font smoothing setters; on swash platforms the coverage mask is thresholded post render since zeno has no aliased mode (the approach validated in the #732 thread). Verified on macOS: with `antialias = false`, intermediate gray edge pixels in a text region drop from 2.6% to 0.4%.

**fontconfig settings become the Linux defaults.** When `fonts.hinting` or `fonts.antialias` are not set in Rio's config, the values fontconfig would apply to the primary family are used (`FcFontMatch` on the configured family, honoring fonts.conf match rules). `hintstyle = hintnone` counts as hinting off, matching how other fontconfig consumers treat the split keys. Explicit Rio config always wins. Both options are now tri state in config (`hinting` keeps accepting `true`/`false`).

The fontconfig query also reads the `rgba` subpixel order, which the follow-up subpixel rendering PR will consume.

Notes: aliased output is a thresholded grayscale mask, not FreeType-identical monochrome hinting; pixel-perfect parity needs X+Y grid rounding in skrifa (googlefonts/fontations#1496, unmerged). This matches what the reporter's own experiment produced and liked.

Refs #732