### PR TITLE
quake mode with global hotkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ checksum = "3e6811e17f81fe246ef2bc553f76b6ee6ab41a694845df1d37e52a92b7bbd38a"
 dependencies = [
  "clipboard-win",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "smithay-clipboard",
  "x11-clipboard",
@@ -1111,6 +1111,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1865,6 +1874,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "once_cell",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
+
+[[package]]
 name = "glow"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2318,17 @@ dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags 2.13.0",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3015,6 +3052,17 @@ dependencies = [
  "objc2-core-image",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3988,7 +4036,7 @@ dependencies = [
  "memmap2",
  "objc-rs 0.3.1",
  "objc2 0.5.2",
- "objc2-app-kit",
+ "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "orbclient",
  "percent-encoding",
@@ -4033,6 +4081,7 @@ dependencies = [
  "dirs",
  "dunce",
  "futures",
+ "global-hotkey",
  "image",
  "libc",
  "lru",

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -17,6 +17,7 @@ name = "rio"
 path = "src/main.rs"
 
 [dependencies]
+global-hotkey = "0.8.0"
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "registry"] }
 wgpu = { workspace = true }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -37,6 +37,10 @@ pub struct Application<'a> {
     scheduler: Scheduler,
     app_id: Option<String>,
     global_hotkey: Option<crate::global_hotkey::GlobalHotkeyManager>,
+    /// Frontmost app when the quake window was shown, re-activated
+    /// when it hides so focus returns where the user was.
+    #[cfg(target_os = "macos")]
+    quake_previous_app: Option<i32>,
 }
 
 impl Application<'_> {
@@ -77,6 +81,8 @@ impl Application<'_> {
             scheduler,
             app_id,
             global_hotkey: None,
+            #[cfg(target_os = "macos")]
+            quake_previous_app: None,
         }
     }
 
@@ -188,6 +194,64 @@ impl Application<'_> {
         self.global_hotkey = Some(manager);
     }
 
+    /// The monitor the quake window should drop down on: the one
+    /// under the mouse cursor where the platform can tell us, the
+    /// primary monitor otherwise.
+    fn quake_monitor(
+        &self,
+        event_loop: &ActiveEventLoop,
+    ) -> Option<rio_window::monitor::MonitorHandle> {
+        #[cfg(target_os = "macos")]
+        {
+            use rio_window::platform::macos::ActiveEventLoopExtMacOS;
+            if let Some(monitor) = event_loop.cursor_monitor() {
+                return Some(monitor);
+            }
+        }
+        #[cfg(windows)]
+        {
+            if let Some(monitor) = windows_cursor_monitor(event_loop) {
+                return Some(monitor);
+            }
+        }
+        event_loop.primary_monitor()
+    }
+
+    /// Anchor the quake window to the top of `monitor`, horizontally
+    /// centered, sized by the configured percentages, then show it.
+    fn show_quake_window(
+        &mut self,
+        id: rio_window::window::WindowId,
+        event_loop: &ActiveEventLoop,
+    ) {
+        #[cfg(target_os = "macos")]
+        {
+            self.quake_previous_app =
+                rio_window::platform::macos::frontmost_application_pid();
+        }
+
+        let Some(route) = self.router.routes.get(&id) else {
+            return;
+        };
+        let window = &route.window.winit_window;
+        if let Some(monitor) = self.quake_monitor(event_loop) {
+            let msize = monitor.size();
+            let mpos = monitor.position();
+            let width = (msize.width as f32
+                * self.config.window.quake_width_percentage.clamp(0.1, 1.0))
+                as u32;
+            let height = (msize.height as f32
+                * self.config.window.quake_height_percentage.clamp(0.1, 1.0))
+                as u32;
+            let x = mpos.x + (msize.width.saturating_sub(width) / 2) as i32;
+            let _ = window
+                .request_inner_size(rio_window::dpi::PhysicalSize::new(width, height));
+            window.set_outer_position(rio_window::dpi::PhysicalPosition::new(x, mpos.y));
+        }
+        window.set_visible(true);
+        window.focus_window();
+    }
+
     /// Show, focus or hide the quake window; create it on first use.
     fn toggle_quake_window(&mut self, event_loop: &ActiveEventLoop) {
         let quake_id = self
@@ -203,9 +267,7 @@ impl Application<'_> {
                 &self.config,
             );
             if let Some(id) = self.router.quake_window_id {
-                if let Some(route) = self.router.routes.get(&id) {
-                    route.window.winit_window.focus_window();
-                }
+                self.show_quake_window(id, event_loop);
             }
             return;
         };
@@ -214,15 +276,42 @@ impl Application<'_> {
             let window = &route.window.winit_window;
             let visible = window.is_visible().unwrap_or(true);
             if !visible {
-                window.set_visible(true);
-                window.focus_window();
+                self.show_quake_window(id, event_loop);
             } else if window.has_focus() {
                 window.set_visible(false);
+                #[cfg(target_os = "macos")]
+                if let Some(pid) = self.quake_previous_app.take() {
+                    rio_window::platform::macos::activate_application(pid);
+                }
             } else {
-                window.focus_window();
+                self.show_quake_window(id, event_loop);
             }
         }
     }
+}
+
+/// Monitor under the cursor on Windows: `GetCursorPos` reports
+/// virtual-screen physical pixels, the same space monitor positions
+/// use, so a rect test finds the right one.
+#[cfg(windows)]
+fn windows_cursor_monitor(
+    event_loop: &ActiveEventLoop,
+) -> Option<rio_window::monitor::MonitorHandle> {
+    use windows_sys::Win32::Foundation::POINT;
+    use windows_sys::Win32::UI::WindowsAndMessaging::GetCursorPos;
+
+    let mut point = POINT { x: 0, y: 0 };
+    if unsafe { GetCursorPos(&mut point) } == 0 {
+        return None;
+    }
+    event_loop.available_monitors().find(|monitor| {
+        let pos = monitor.position();
+        let size = monitor.size();
+        point.x >= pos.x
+            && point.x < pos.x + size.width as i32
+            && point.y >= pos.y
+            && point.y < pos.y + size.height as i32
+    })
 }
 
 impl ApplicationHandler<EventPayload> for Application<'_> {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -36,6 +36,7 @@ pub struct Application<'a> {
     router: Router<'a>,
     scheduler: Scheduler,
     app_id: Option<String>,
+    global_hotkey: Option<crate::global_hotkey::GlobalHotkeyManager>,
 }
 
 impl Application<'_> {
@@ -75,6 +76,7 @@ impl Application<'_> {
             router,
             scheduler,
             app_id,
+            global_hotkey: None,
         }
     }
 
@@ -150,6 +152,79 @@ impl Application<'_> {
     }
 }
 
+impl Application<'_> {
+    /// Register a system-wide hotkey for every `ToggleQuake` binding
+    /// in the config, so the quake window opens while Rio is
+    /// unfocused. Failures are logged and ignored: pure Wayland has
+    /// no global hotkey API, the compositor keybinding + a regular
+    /// binding cover it there.
+    fn setup_quake_hotkey(&mut self) {
+        let mut triggers: Vec<String> = Vec::new();
+        for binding in &self.config.bindings.keys {
+            if binding.action.to_lowercase() == "togglequake" {
+                let mods = binding.with.replace(' ', "").replace('|', "+");
+                if mods.is_empty() {
+                    triggers.push(binding.key.clone());
+                } else {
+                    triggers.push(format!("{}+{}", mods, binding.key));
+                }
+            }
+        }
+        if triggers.is_empty() {
+            return;
+        }
+
+        let mut manager = match crate::global_hotkey::GlobalHotkeyManager::new(
+            self.event_proxy.clone(),
+        ) {
+            Some(manager) => manager,
+            None => return,
+        };
+        for trigger in &triggers {
+            if let Err(err) = manager.register_hotkey(trigger) {
+                tracing::warn!("quake hotkey '{trigger}': {err}");
+            }
+        }
+        self.global_hotkey = Some(manager);
+    }
+
+    /// Show, focus or hide the quake window; create it on first use.
+    fn toggle_quake_window(&mut self, event_loop: &ActiveEventLoop) {
+        let quake_id = self
+            .router
+            .quake_window_id
+            .filter(|id| self.router.routes.contains_key(id));
+
+        let Some(id) = quake_id else {
+            self.router.quake_window_id = None;
+            self.router.create_quake_window(
+                event_loop,
+                self.event_proxy.clone(),
+                &self.config,
+            );
+            if let Some(id) = self.router.quake_window_id {
+                if let Some(route) = self.router.routes.get(&id) {
+                    route.window.winit_window.focus_window();
+                }
+            }
+            return;
+        };
+
+        if let Some(route) = self.router.routes.get_mut(&id) {
+            let window = &route.window.winit_window;
+            let visible = window.is_visible().unwrap_or(true);
+            if !visible {
+                window.set_visible(true);
+                window.focus_window();
+            } else if window.has_focus() {
+                window.set_visible(false);
+            } else {
+                window.focus_window();
+            }
+        }
+    }
+}
+
 impl ApplicationHandler<EventPayload> for Application<'_> {
     fn resumed(&mut self, _active_event_loop: &ActiveEventLoop) {}
 
@@ -192,6 +267,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             None,
             self.app_id.as_deref(),
         );
+
+        if cause == StartCause::Init {
+            self.setup_quake_hotkey();
+        }
 
         // Schedule title updates every 2s
         let timer_id = TimerId::new(Topic::UpdateTitles, 0);
@@ -760,6 +839,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     None,
                     self.app_id.as_deref(),
                 );
+            }
+            RioEventType::Rio(RioEvent::ToggleQuake) => {
+                self.toggle_quake_window(event_loop);
             }
             #[cfg(target_os = "macos")]
             RioEventType::Rio(RioEvent::CreateNativeTab(working_dir_overwrite)) => {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -201,20 +201,9 @@ impl Application<'_> {
         &self,
         event_loop: &ActiveEventLoop,
     ) -> Option<rio_window::monitor::MonitorHandle> {
-        #[cfg(target_os = "macos")]
-        {
-            use rio_window::platform::macos::ActiveEventLoopExtMacOS;
-            if let Some(monitor) = event_loop.cursor_monitor() {
-                return Some(monitor);
-            }
-        }
-        #[cfg(windows)]
-        {
-            if let Some(monitor) = windows_cursor_monitor(event_loop) {
-                return Some(monitor);
-            }
-        }
-        event_loop.primary_monitor()
+        event_loop
+            .cursor_monitor()
+            .or_else(|| event_loop.primary_monitor())
     }
 
     /// Anchor the quake window to the top of `monitor`, horizontally
@@ -288,30 +277,6 @@ impl Application<'_> {
             }
         }
     }
-}
-
-/// Monitor under the cursor on Windows: `GetCursorPos` reports
-/// virtual-screen physical pixels, the same space monitor positions
-/// use, so a rect test finds the right one.
-#[cfg(windows)]
-fn windows_cursor_monitor(
-    event_loop: &ActiveEventLoop,
-) -> Option<rio_window::monitor::MonitorHandle> {
-    use windows_sys::Win32::Foundation::POINT;
-    use windows_sys::Win32::UI::WindowsAndMessaging::GetCursorPos;
-
-    let mut point = POINT { x: 0, y: 0 };
-    if unsafe { GetCursorPos(&mut point) } == 0 {
-        return None;
-    }
-    event_loop.available_monitors().find(|monitor| {
-        let pos = monitor.position();
-        let size = monitor.size();
-        point.x >= pos.x
-            && point.x < pos.x + size.width as i32
-            && point.y >= pos.y
-            && point.y < pos.y + size.height as i32
-    })
 }
 
 impl ApplicationHandler<EventPayload> for Application<'_> {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -165,17 +165,7 @@ impl Application<'_> {
     /// no global hotkey API, the compositor keybinding + a regular
     /// binding cover it there.
     fn setup_quake_hotkey(&mut self) {
-        let mut triggers: Vec<String> = Vec::new();
-        for binding in &self.config.bindings.keys {
-            if binding.action.to_lowercase() == "togglequake" {
-                let mods = binding.with.replace(' ', "").replace('|', "+");
-                if mods.is_empty() {
-                    triggers.push(binding.key.clone());
-                } else {
-                    triggers.push(format!("{}+{}", mods, binding.key));
-                }
-            }
-        }
+        let triggers = crate::global_hotkey::quake_triggers(&self.config.bindings.keys);
         if triggers.is_empty() {
             return;
         }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -165,6 +165,9 @@ impl Application<'_> {
     /// global hotkey API, the compositor keybinding + a regular
     /// binding cover it there.
     fn setup_quake_hotkey(&mut self) {
+        // Drop any previous manager first: registering a chord the old
+        // manager still holds fails on Windows and X11.
+        self.global_hotkey = None;
         self.global_hotkey = crate::global_hotkey::setup(
             self.event_proxy.clone(),
             &self.config.bindings.keys,
@@ -492,6 +495,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 };
 
                 let has_font_updates = self.config.fonts != config.fonts;
+                let has_binding_updates = self.config.bindings != config.bindings;
 
                 let font_library_errors = if has_font_updates {
                     let new_font_library = rio_backend::sugarloaf::font::FontLibrary::new(
@@ -504,6 +508,12 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 };
 
                 self.config = config;
+
+                // Dropping the old manager unregisters its hotkeys, so
+                // ToggleQuake binding edits apply without restarting.
+                if has_binding_updates {
+                    self.setup_quake_hotkey();
+                }
 
                 let mut has_checked_adaptive_colors = false;
                 for (_id, route) in self.router.routes.iter_mut() {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -36,7 +36,7 @@ pub struct Application<'a> {
     router: Router<'a>,
     scheduler: Scheduler,
     app_id: Option<String>,
-    global_hotkey: Option<crate::global_hotkey::GlobalHotkeyManager>,
+    global_hotkey: Option<crate::global_hotkey::GlobalHotkeys>,
     /// Frontmost app when the quake window was shown, re-activated
     /// when it hides so focus returns where the user was.
     #[cfg(target_os = "macos")]
@@ -161,27 +161,14 @@ impl Application<'_> {
 impl Application<'_> {
     /// Register a system-wide hotkey for every `ToggleQuake` binding
     /// in the config, so the quake window opens while Rio is
-    /// unfocused. Failures are logged and ignored: pure Wayland has
-    /// no global hotkey API, the compositor keybinding + a regular
+    /// unfocused. No-op when quake is not bound; pure Wayland has no
+    /// global hotkey API, the compositor keybinding + a regular
     /// binding cover it there.
     fn setup_quake_hotkey(&mut self) {
-        let triggers = crate::global_hotkey::quake_triggers(&self.config.bindings.keys);
-        if triggers.is_empty() {
-            return;
-        }
-
-        let mut manager = match crate::global_hotkey::GlobalHotkeyManager::new(
+        self.global_hotkey = crate::global_hotkey::setup(
             self.event_proxy.clone(),
-        ) {
-            Some(manager) => manager,
-            None => return,
-        };
-        for trigger in &triggers {
-            if let Err(err) = manager.register_hotkey(trigger) {
-                tracing::warn!("quake hotkey '{trigger}': {err}");
-            }
-        }
-        self.global_hotkey = Some(manager);
+            &self.config.bindings.keys,
+        );
     }
 
     /// The monitor the quake window should drop down on: the one

--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -236,6 +236,7 @@ impl From<String> for Action {
             "increasefontsize" => Some(Action::IncreaseFontSize),
             "decreasefontsize" => Some(Action::DecreaseFontSize),
             "createwindow" => Some(Action::WindowCreateNew),
+            "togglequake" => Some(Action::ToggleQuake),
             "createtab" => Some(Action::TabCreateNew),
             "movecurrenttabtoprev" => Some(Action::MoveCurrentTabToPrev),
             "movecurrenttabtonext" => Some(Action::MoveCurrentTabToNext),
@@ -458,6 +459,10 @@ pub enum Action {
 
     /// Select everything, including the scrollback history.
     SelectAll,
+
+    /// Show or hide the quake-style dropdown window. Also registered
+    /// as a system-wide hotkey when bound in `[bindings]`.
+    ToggleQuake,
 
     /// Toggle vi mode.
     ToggleViMode,

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -569,6 +569,12 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     }
 
     #[inline]
+    pub fn toggle_quake(&self) {
+        self.event_proxy
+            .send_event(RioEvent::ToggleQuake, self.window_id);
+    }
+
+    #[inline]
     pub fn close_unfocused_tabs(&mut self) {
         let current_route_id = self.current().route_id;
         self.contexts

--- a/frontends/rioterm/src/global_hotkey.rs
+++ b/frontends/rioterm/src/global_hotkey.rs
@@ -1,0 +1,205 @@
+//! System-wide hotkey registration for the quake window. Uses the
+//! `global-hotkey` crate: Carbon `RegisterEventHotKey` on macOS (no
+//! accessibility permission needed), `RegisterHotKey` on Windows and
+//! `XGrabKey` on X11. Pure Wayland has no global hotkey API; users
+//! bind a compositor key to a regular Rio binding instead.
+
+use crate::event::EventProxy;
+use global_hotkey::{hotkey::HotKey, GlobalHotKeyManager};
+use rio_backend::event::{RioEvent, RioEventType};
+
+pub struct GlobalHotkeyManagerHandle {
+    manager: GlobalHotKeyManager,
+    event_proxy: EventProxy,
+    listener_started: bool,
+}
+
+pub use GlobalHotkeyManagerHandle as GlobalHotkeyManager;
+
+impl GlobalHotkeyManagerHandle {
+    pub fn new(event_proxy: EventProxy) -> Option<Self> {
+        let manager = match GlobalHotKeyManager::new() {
+            Ok(manager) => manager,
+            Err(err) => {
+                tracing::warn!("global hotkeys unavailable: {err}");
+                return None;
+            }
+        };
+        Some(Self {
+            manager,
+            event_proxy,
+            listener_started: false,
+        })
+    }
+
+    pub fn register_hotkey(&mut self, trigger: &str) -> Result<(), String> {
+        let hotkey = parse_hotkey(trigger)?;
+        self.manager
+            .register(hotkey)
+            .map_err(|err| err.to_string())?;
+        tracing::info!("registered global hotkey: {trigger}");
+
+        if !self.listener_started {
+            self.listener_started = true;
+            self.start_listener();
+        }
+        Ok(())
+    }
+
+    fn start_listener(&self) {
+        let event_proxy = self.event_proxy.clone();
+        std::thread::spawn(move || {
+            use global_hotkey::{GlobalHotKeyEvent, HotKeyState};
+            while let Ok(event) = GlobalHotKeyEvent::receiver().recv() {
+                if event.state == HotKeyState::Pressed {
+                    event_proxy
+                        .send_event(RioEventType::Rio(RioEvent::ToggleQuake), unsafe {
+                            rio_window::window::WindowId::dummy()
+                        });
+                }
+            }
+        });
+    }
+}
+
+/// Parse a binding-style trigger ("super+shift+q", "f12") into a
+/// `HotKey`. Accepts the same modifier names as `[bindings]` `with`.
+fn parse_hotkey(trigger: &str) -> Result<HotKey, String> {
+    use global_hotkey::hotkey::{Code, Modifiers};
+
+    let lowered = trigger.to_lowercase();
+    let mut modifiers = Modifiers::empty();
+    let mut code = None;
+
+    for part in lowered.split('+') {
+        match part.trim() {
+            "cmd" | "super" | "command" => modifiers |= Modifiers::SUPER,
+            "ctrl" | "control" => modifiers |= Modifiers::CONTROL,
+            "alt" | "option" => modifiers |= Modifiers::ALT,
+            "shift" => modifiers |= Modifiers::SHIFT,
+            "escape" | "esc" => code = Some(Code::Escape),
+            "space" => code = Some(Code::Space),
+            "enter" | "return" => code = Some(Code::Enter),
+            "tab" => code = Some(Code::Tab),
+            "back" | "backspace" => code = Some(Code::Backspace),
+            "delete" => code = Some(Code::Delete),
+            "home" => code = Some(Code::Home),
+            "end" => code = Some(Code::End),
+            "pageup" => code = Some(Code::PageUp),
+            "pagedown" => code = Some(Code::PageDown),
+            "up" => code = Some(Code::ArrowUp),
+            "down" => code = Some(Code::ArrowDown),
+            "left" => code = Some(Code::ArrowLeft),
+            "right" => code = Some(Code::ArrowRight),
+            "f1" => code = Some(Code::F1),
+            "f2" => code = Some(Code::F2),
+            "f3" => code = Some(Code::F3),
+            "f4" => code = Some(Code::F4),
+            "f5" => code = Some(Code::F5),
+            "f6" => code = Some(Code::F6),
+            "f7" => code = Some(Code::F7),
+            "f8" => code = Some(Code::F8),
+            "f9" => code = Some(Code::F9),
+            "f10" => code = Some(Code::F10),
+            "f11" => code = Some(Code::F11),
+            "f12" => code = Some(Code::F12),
+            "`" | "grave" | "backquote" => code = Some(Code::Backquote),
+            "'" | "quote" => code = Some(Code::Quote),
+            "," | "comma" => code = Some(Code::Comma),
+            "." | "period" => code = Some(Code::Period),
+            "/" | "slash" => code = Some(Code::Slash),
+            "\\" | "backslash" => code = Some(Code::Backslash),
+            ";" | "semicolon" => code = Some(Code::Semicolon),
+            "-" | "minus" => code = Some(Code::Minus),
+            "=" | "equal" => code = Some(Code::Equal),
+            "[" | "bracketleft" => code = Some(Code::BracketLeft),
+            "]" | "bracketright" => code = Some(Code::BracketRight),
+            key if key.len() == 1 => {
+                let ch = key.chars().next().unwrap();
+                code = Some(match ch {
+                    'a'..='z' => letter_code(ch),
+                    '0'..='9' => digit_code(ch),
+                    _ => return Err(format!("unsupported key '{key}'")),
+                });
+            }
+            other => return Err(format!("unknown key or modifier '{other}'")),
+        }
+    }
+
+    let code = code.ok_or_else(|| "no key in trigger".to_string())?;
+    Ok(HotKey::new(
+        (!modifiers.is_empty()).then_some(modifiers),
+        code,
+    ))
+}
+
+fn letter_code(ch: char) -> global_hotkey::hotkey::Code {
+    use global_hotkey::hotkey::Code::*;
+    match ch {
+        'a' => KeyA,
+        'b' => KeyB,
+        'c' => KeyC,
+        'd' => KeyD,
+        'e' => KeyE,
+        'f' => KeyF,
+        'g' => KeyG,
+        'h' => KeyH,
+        'i' => KeyI,
+        'j' => KeyJ,
+        'k' => KeyK,
+        'l' => KeyL,
+        'm' => KeyM,
+        'n' => KeyN,
+        'o' => KeyO,
+        'p' => KeyP,
+        'q' => KeyQ,
+        'r' => KeyR,
+        's' => KeyS,
+        't' => KeyT,
+        'u' => KeyU,
+        'v' => KeyV,
+        'w' => KeyW,
+        'x' => KeyX,
+        'y' => KeyY,
+        'z' => KeyZ,
+        _ => unreachable!(),
+    }
+}
+
+fn digit_code(ch: char) -> global_hotkey::hotkey::Code {
+    use global_hotkey::hotkey::Code::*;
+    match ch {
+        '0' => Digit0,
+        '1' => Digit1,
+        '2' => Digit2,
+        '3' => Digit3,
+        '4' => Digit4,
+        '5' => Digit5,
+        '6' => Digit6,
+        '7' => Digit7,
+        '8' => Digit8,
+        '9' => Digit9,
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use global_hotkey::hotkey::{Code, Modifiers};
+
+    #[test]
+    fn parse_hotkey_forms() {
+        let hk = parse_hotkey("super+shift+q").unwrap();
+        assert_eq!(
+            hk,
+            HotKey::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyQ)
+        );
+        let hk = parse_hotkey("control+`").unwrap();
+        assert_eq!(hk, HotKey::new(Some(Modifiers::CONTROL), Code::Backquote));
+        let hk = parse_hotkey("f12").unwrap();
+        assert_eq!(hk, HotKey::new(None, Code::F12));
+        assert!(parse_hotkey("super+banana").is_err());
+        assert!(parse_hotkey("super+shift").is_err());
+    }
+}

--- a/frontends/rioterm/src/global_hotkey.rs
+++ b/frontends/rioterm/src/global_hotkey.rs
@@ -8,58 +8,69 @@ use crate::event::EventProxy;
 use global_hotkey::{hotkey::HotKey, GlobalHotKeyManager};
 use rio_backend::event::{RioEvent, RioEventType};
 
-pub struct GlobalHotkeyManagerHandle {
-    manager: GlobalHotKeyManager,
-    event_proxy: EventProxy,
-    listener_started: bool,
+/// Keeps the OS hotkey registrations alive for the app's lifetime.
+pub struct GlobalHotkeys {
+    _manager: GlobalHotKeyManager,
 }
 
-pub use GlobalHotkeyManagerHandle as GlobalHotkeyManager;
-
-impl GlobalHotkeyManagerHandle {
-    pub fn new(event_proxy: EventProxy) -> Option<Self> {
-        let manager = match GlobalHotKeyManager::new() {
-            Ok(manager) => manager,
+/// Register a system-wide hotkey for every `ToggleQuake` binding.
+/// Nothing is created when no binding exists or none of the triggers
+/// parse: the manager itself owns OS resources (a Carbon handler on
+/// macOS, a hidden window on Windows, an X connection thread on X11)
+/// that a quake-less config should never pay for.
+pub fn setup(
+    event_proxy: EventProxy,
+    keys: &[rio_backend::config::bindings::KeyBinding],
+) -> Option<GlobalHotkeys> {
+    let hotkeys: Vec<(String, HotKey)> = quake_triggers(keys)
+        .into_iter()
+        .filter_map(|trigger| match parse_hotkey(&trigger) {
+            Ok(hotkey) => Some((trigger, hotkey)),
             Err(err) => {
-                tracing::warn!("global hotkeys unavailable: {err}");
-                return None;
+                tracing::warn!("quake hotkey '{trigger}': {err}");
+                None
             }
-        };
-        Some(Self {
-            manager,
-            event_proxy,
-            listener_started: false,
         })
+        .collect();
+    if hotkeys.is_empty() {
+        return None;
     }
 
-    pub fn register_hotkey(&mut self, trigger: &str) -> Result<(), String> {
-        let hotkey = parse_hotkey(trigger)?;
-        self.manager
-            .register(hotkey)
-            .map_err(|err| err.to_string())?;
-        tracing::info!("registered global hotkey: {trigger}");
-
-        if !self.listener_started {
-            self.listener_started = true;
-            self.start_listener();
+    let manager = match GlobalHotKeyManager::new() {
+        Ok(manager) => manager,
+        Err(err) => {
+            tracing::warn!("global hotkeys unavailable: {err}");
+            return None;
         }
-        Ok(())
+    };
+
+    let mut registered = false;
+    for (trigger, hotkey) in hotkeys {
+        match manager.register(hotkey) {
+            Ok(()) => {
+                registered = true;
+                tracing::info!("registered global hotkey: {trigger}");
+            }
+            Err(err) => tracing::warn!("quake hotkey '{trigger}': {err}"),
+        }
+    }
+    if !registered {
+        return None;
     }
 
-    fn start_listener(&self) {
-        let event_proxy = self.event_proxy.clone();
-        std::thread::spawn(move || {
-            use global_hotkey::{GlobalHotKeyEvent, HotKeyState};
-            while let Ok(event) = GlobalHotKeyEvent::receiver().recv() {
-                if event.state == HotKeyState::Pressed {
-                    event_proxy
-                        .send_event(RioEventType::Rio(RioEvent::ToggleQuake), unsafe {
-                            rio_window::window::WindowId::dummy()
-                        });
-                }
+    std::thread::spawn(move || {
+        use global_hotkey::{GlobalHotKeyEvent, HotKeyState};
+        while let Ok(event) = GlobalHotKeyEvent::receiver().recv() {
+            if event.state == HotKeyState::Pressed {
+                event_proxy
+                    .send_event(RioEventType::Rio(RioEvent::ToggleQuake), unsafe {
+                        rio_window::window::WindowId::dummy()
+                    });
             }
-        });
-    }
+        }
+    });
+
+    Some(GlobalHotkeys { _manager: manager })
 }
 
 /// Triggers for every `ToggleQuake` binding in the config, in the

--- a/frontends/rioterm/src/global_hotkey.rs
+++ b/frontends/rioterm/src/global_hotkey.rs
@@ -58,16 +58,22 @@ pub fn setup(
         return None;
     }
 
-    std::thread::spawn(move || {
-        use global_hotkey::{GlobalHotKeyEvent, HotKeyState};
-        while let Ok(event) = GlobalHotKeyEvent::receiver().recv() {
-            if event.state == HotKeyState::Pressed {
-                event_proxy
-                    .send_event(RioEventType::Rio(RioEvent::ToggleQuake), unsafe {
-                        rio_window::window::WindowId::dummy()
-                    });
+    // The crate's event receiver is a process-wide channel; one
+    // listener serves every manager, including managers recreated on
+    // config reload.
+    static LISTENER: std::sync::Once = std::sync::Once::new();
+    LISTENER.call_once(move || {
+        std::thread::spawn(move || {
+            use global_hotkey::{GlobalHotKeyEvent, HotKeyState};
+            while let Ok(event) = GlobalHotKeyEvent::receiver().recv() {
+                if event.state == HotKeyState::Pressed {
+                    event_proxy
+                        .send_event(RioEventType::Rio(RioEvent::ToggleQuake), unsafe {
+                            rio_window::window::WindowId::dummy()
+                        });
+                }
             }
-        }
+        });
     });
 
     Some(GlobalHotkeys { _manager: manager })

--- a/frontends/rioterm/src/global_hotkey.rs
+++ b/frontends/rioterm/src/global_hotkey.rs
@@ -62,6 +62,22 @@ impl GlobalHotkeyManagerHandle {
     }
 }
 
+/// Triggers for every `ToggleQuake` binding in the config, in the
+/// format `parse_hotkey` accepts.
+pub fn quake_triggers(keys: &[rio_backend::config::bindings::KeyBinding]) -> Vec<String> {
+    keys.iter()
+        .filter(|binding| binding.action.to_lowercase() == "togglequake")
+        .map(|binding| {
+            let mods = binding.with.replace(' ', "").replace('|', "+");
+            if mods.is_empty() {
+                binding.key.clone()
+            } else {
+                format!("{}+{}", mods, binding.key)
+            }
+        })
+        .collect()
+}
+
 /// Parse a binding-style trigger ("super+shift+q", "f12") into a
 /// `HotKey`. Accepts the same modifier names as `[bindings]` `with`.
 fn parse_hotkey(trigger: &str) -> Result<HotKey, String> {
@@ -77,12 +93,15 @@ fn parse_hotkey(trigger: &str) -> Result<HotKey, String> {
             "ctrl" | "control" => modifiers |= Modifiers::CONTROL,
             "alt" | "option" => modifiers |= Modifiers::ALT,
             "shift" => modifiers |= Modifiers::SHIFT,
+            // The bindings parser accepts "none" as a no-op modifier.
+            "none" => {}
             "escape" | "esc" => code = Some(Code::Escape),
             "space" => code = Some(Code::Space),
             "enter" | "return" => code = Some(Code::Enter),
             "tab" => code = Some(Code::Tab),
             "back" | "backspace" => code = Some(Code::Backspace),
             "delete" => code = Some(Code::Delete),
+            "insert" => code = Some(Code::Insert),
             "home" => code = Some(Code::Home),
             "end" => code = Some(Code::End),
             "pageup" => code = Some(Code::PageUp),
@@ -114,6 +133,24 @@ fn parse_hotkey(trigger: &str) -> Result<HotKey, String> {
             "=" | "equal" => code = Some(Code::Equal),
             "[" | "bracketleft" => code = Some(Code::BracketLeft),
             "]" | "bracketright" => code = Some(Code::BracketRight),
+            "numpadenter" => code = Some(Code::NumpadEnter),
+            "numpadadd" => code = Some(Code::NumpadAdd),
+            "numpadsubtract" => code = Some(Code::NumpadSubtract),
+            "numpadmultiply" => code = Some(Code::NumpadMultiply),
+            "numpaddivide" => code = Some(Code::NumpadDivide),
+            "numpaddecimal" => code = Some(Code::NumpadDecimal),
+            "numpadcomma" => code = Some(Code::NumpadComma),
+            "numpadequals" => code = Some(Code::NumpadEqual),
+            "numpad0" => code = Some(Code::Numpad0),
+            "numpad1" => code = Some(Code::Numpad1),
+            "numpad2" => code = Some(Code::Numpad2),
+            "numpad3" => code = Some(Code::Numpad3),
+            "numpad4" => code = Some(Code::Numpad4),
+            "numpad5" => code = Some(Code::Numpad5),
+            "numpad6" => code = Some(Code::Numpad6),
+            "numpad7" => code = Some(Code::Numpad7),
+            "numpad8" => code = Some(Code::Numpad8),
+            "numpad9" => code = Some(Code::Numpad9),
             key if key.len() == 1 => {
                 let ch = key.chars().next().unwrap();
                 code = Some(match ch {
@@ -201,5 +238,35 @@ mod tests {
         assert_eq!(hk, HotKey::new(None, Code::F12));
         assert!(parse_hotkey("super+banana").is_err());
         assert!(parse_hotkey("super+shift").is_err());
+        // Parity with the bindings parser.
+        let hk = parse_hotkey("none+f12").unwrap();
+        assert_eq!(hk, HotKey::new(None, Code::F12));
+        let hk = parse_hotkey("control+numpad5").unwrap();
+        assert_eq!(hk, HotKey::new(Some(Modifiers::CONTROL), Code::Numpad5));
+        let hk = parse_hotkey("shift+insert").unwrap();
+        assert_eq!(hk, HotKey::new(Some(Modifiers::SHIFT), Code::Insert));
+    }
+
+    #[test]
+    fn quake_triggers_from_bindings() {
+        use rio_backend::config::bindings::KeyBinding;
+        let binding = |key: &str, with: &str, action: &str| KeyBinding {
+            key: key.into(),
+            with: with.into(),
+            action: action.into(),
+            esc: String::new(),
+            mode: String::new(),
+        };
+        let keys = vec![
+            binding("q", "super | shift", "ToggleQuake"),
+            binding("f12", "", "togglequake"),
+            binding("f12", "none", "togglequake"),
+            binding("w", "super", "quit"),
+        ];
+        let triggers = quake_triggers(&keys);
+        assert_eq!(triggers, vec!["super+shift+q", "f12", "none+f12"]);
+        for trigger in &triggers {
+            assert!(parse_hotkey(trigger).is_ok(), "{trigger} must parse");
+        }
     }
 }

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -9,6 +9,7 @@ mod bindings;
 mod cli;
 mod constants;
 mod context;
+mod global_hotkey;
 mod grid_emit;
 mod hints;
 mod ime;

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -721,23 +721,11 @@ impl<'a> RouteWindow<'a> {
         let mut window_builder =
             create_window_builder(window_name, config, tab_id, app_id, quake);
 
-        // Anchor the quake window to the top of the primary monitor,
-        // horizontally centered, sized by the configured percentages.
+        // The quake window starts hidden; the caller anchors it to the
+        // monitor under the cursor and shows it (position changes on
+        // every toggle, not just at creation).
         if quake {
-            if let Some(monitor) = event_loop.primary_monitor() {
-                let msize = monitor.size();
-                let mpos = monitor.position();
-                let width = (msize.width as f32
-                    * config.window.quake_width_percentage.clamp(0.1, 1.0))
-                    as u32;
-                let height = (msize.height as f32
-                    * config.window.quake_height_percentage.clamp(0.1, 1.0))
-                    as u32;
-                let x = mpos.x + (msize.width.saturating_sub(width) / 2) as i32;
-                window_builder = window_builder
-                    .with_inner_size(rio_window::dpi::PhysicalSize::new(width, height))
-                    .with_position(rio_window::dpi::PhysicalPosition::new(x, mpos.y));
-            }
+            window_builder = window_builder.with_visible(false);
         }
 
         #[cfg(not(any(target_os = "macos", windows)))]

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -365,6 +365,7 @@ pub struct Router<'a> {
     propagated_report: Option<RioError>,
     pub font_library: Box<rio_backend::sugarloaf::font::FontLibrary>,
     pub config_route: Option<WindowId>,
+    pub quake_window_id: Option<WindowId>,
     pub clipboard: Clipboard,
     current_tab_id: u64,
 }
@@ -390,6 +391,7 @@ impl Router<'_> {
             routes: FxHashMap::default(),
             propagated_report,
             config_route: None,
+            quake_window_id: None,
             font_library: Box::new(font_library),
             clipboard,
             current_tab_id: 0,
@@ -463,6 +465,7 @@ impl Router<'_> {
             None,
             None,
             None,
+            false,
         );
         let id = window.winit_window.id();
         let route = Route::new(Assistant::new(), RoutePath::Terminal, window);
@@ -526,6 +529,7 @@ impl Router<'_> {
             tab_id.as_deref(),
             open_url,
             app_id,
+            false,
         );
         let id = window.winit_window.id();
 
@@ -541,6 +545,38 @@ impl Router<'_> {
         }
 
         self.routes.insert(id, route);
+    }
+
+    /// Create the quake dropdown window: borderless, always on top,
+    /// anchored to the top of the primary monitor. Created lazily on
+    /// the first toggle and reused afterwards.
+    pub fn create_quake_window<'a>(
+        &'a mut self,
+        event_loop: &'a ActiveEventLoop,
+        event_proxy: EventProxy,
+        config: &'a rio_backend::config::Config,
+    ) {
+        let window = RouteWindow::from_target(
+            event_loop,
+            event_proxy,
+            config,
+            &self.font_library,
+            RIO_TITLE,
+            None,
+            None,
+            None,
+            true,
+        );
+        let id = window.winit_window.id();
+        self.routes.insert(
+            id,
+            Route {
+                window,
+                path: RoutePath::Terminal,
+                assistant: Assistant::new(),
+            },
+        );
+        self.quake_window_id = Some(id);
     }
 
     #[cfg(target_os = "macos")]
@@ -562,6 +598,7 @@ impl Router<'_> {
             tab_id,
             open_url,
             None,
+            false,
         );
         self.routes.insert(
             window.winit_window.id(),
@@ -678,10 +715,30 @@ impl<'a> RouteWindow<'a> {
         tab_id: Option<&str>,
         open_url: Option<String>,
         app_id: Option<&str>,
+        quake: bool,
     ) -> RouteWindow<'a> {
         #[allow(unused_mut)]
         let mut window_builder =
-            create_window_builder(window_name, config, tab_id, app_id);
+            create_window_builder(window_name, config, tab_id, app_id, quake);
+
+        // Anchor the quake window to the top of the primary monitor,
+        // horizontally centered, sized by the configured percentages.
+        if quake {
+            if let Some(monitor) = event_loop.primary_monitor() {
+                let msize = monitor.size();
+                let mpos = monitor.position();
+                let width = (msize.width as f32
+                    * config.window.quake_width_percentage.clamp(0.1, 1.0))
+                    as u32;
+                let height = (msize.height as f32
+                    * config.window.quake_height_percentage.clamp(0.1, 1.0))
+                    as u32;
+                let x = mpos.x + (msize.width.saturating_sub(width) / 2) as i32;
+                window_builder = window_builder
+                    .with_inner_size(rio_window::dpi::PhysicalSize::new(width, height))
+                    .with_position(rio_window::dpi::PhysicalPosition::new(x, mpos.y));
+            }
+        }
 
         #[cfg(not(any(target_os = "macos", windows)))]
         if let Some(token) = event_loop.read_token_from_env() {

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -20,6 +20,7 @@ pub fn create_window_builder(
     config: &Config,
     #[allow(unused_variables)] tab_id: Option<&str>,
     #[allow(unused_variables)] app_id: Option<&str>,
+    quake: bool,
 ) -> WindowAttributes {
     let image_icon = image_rs::load_from_memory(LOGO_ICON).unwrap();
     let icon = Icon::from_rgba(
@@ -40,6 +41,12 @@ pub fn create_window_builder(
         .with_transparent(config.window.opacity < 1.)
         .with_blur(config.window.blur.into())
         .with_window_icon(Some(icon));
+
+    if quake {
+        window_builder = window_builder
+            .with_decorations(false)
+            .with_window_level(rio_window::window::WindowLevel::AlwaysOnTop);
+    }
 
     match config.window.decorations {
         Decorations::Disabled => {

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -150,22 +150,27 @@ pub fn create_window_builder(
         window_builder = window_builder.with_cloaked(true);
     }
 
-    match config.window.mode {
-        WindowMode::Fullscreen => {
-            window_builder =
-                window_builder.with_fullscreen(Some(Fullscreen::Borderless(None)));
-        }
-        WindowMode::Maximized => {
-            window_builder = window_builder.with_maximized(true);
-        }
-        _ => {
-            window_builder =
-                window_builder.with_inner_size(rio_window::dpi::LogicalSize {
-                    width: config.window.width,
-                    height: config.window.height,
-                })
-        }
-    };
+    // The quake window ignores `window.mode`: a fullscreen or
+    // maximized mode would defeat the dropdown, and its geometry is
+    // recomputed from the target monitor on every show anyway.
+    if !quake {
+        match config.window.mode {
+            WindowMode::Fullscreen => {
+                window_builder =
+                    window_builder.with_fullscreen(Some(Fullscreen::Borderless(None)));
+            }
+            WindowMode::Maximized => {
+                window_builder = window_builder.with_maximized(true);
+            }
+            _ => {
+                window_builder =
+                    window_builder.with_inner_size(rio_window::dpi::LogicalSize {
+                        width: config.window.width,
+                        height: config.window.height,
+                    })
+            }
+        };
+    }
 
     window_builder
 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1145,6 +1145,9 @@ impl Screen<'_> {
                     Act::WindowCreateNew => {
                         self.context_manager.create_new_window();
                     }
+                    Act::ToggleQuake => {
+                        self.context_manager.toggle_quake();
+                    }
                     Act::CloseCurrentSplitOrTab => {
                         self.close_split_or_tab(clipboard);
                     }

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -1274,6 +1274,30 @@ mod tests {
     }
 
     #[test]
+    fn test_window_quake_config() {
+        let result = create_temporary_config(
+            "window-quake",
+            r#"
+            [window]
+            quake-width-percentage = 0.8
+            quake-height-percentage = 0.5
+        "#,
+        );
+        assert_eq!(result.window.quake_width_percentage, 0.8);
+        assert_eq!(result.window.quake_height_percentage, 0.5);
+
+        let result = create_temporary_config(
+            "window-quake-defaults",
+            r#"
+            [window]
+            width = 800
+        "#,
+        );
+        assert_eq!(result.window.quake_width_percentage, 1.0);
+        assert_eq!(result.window.quake_height_percentage, 0.4);
+    }
+
+    #[test]
     fn test_window_colorspace_default() {
         let result = create_temporary_config(
             "window-colorspace-default",

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -228,6 +228,18 @@ pub struct Window {
     pub columns: Option<u16>,
     #[serde(default = "Option::default")]
     pub rows: Option<u16>,
+    /// Quake window width as a fraction of the monitor width.
+    #[serde(
+        rename = "quake-width-percentage",
+        default = "default_quake_width_percentage"
+    )]
+    pub quake_width_percentage: f32,
+    /// Quake window height as a fraction of the monitor height.
+    #[serde(
+        rename = "quake-height-percentage",
+        default = "default_quake_height_percentage"
+    )]
+    pub quake_height_percentage: f32,
 }
 
 impl Default for Window {
@@ -252,8 +264,18 @@ impl Default for Window {
             colorspace: Colorspace::default(),
             columns: None,
             rows: None,
+            quake_width_percentage: default_quake_width_percentage(),
+            quake_height_percentage: default_quake_height_percentage(),
         }
     }
+}
+
+fn default_quake_width_percentage() -> f32 {
+    1.0
+}
+
+fn default_quake_height_percentage() -> f32 {
+    0.4
 }
 
 impl Colorspace {

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -118,6 +118,7 @@ pub enum RioEvent {
     HideOtherApplications,
     UpdateConfig,
     CreateWindow,
+    ToggleQuake,
     CloseWindow,
     CreateNativeTab(Option<String>),
     CreateConfigEditor,
@@ -283,6 +284,7 @@ impl Debug for RioEvent {
             RioEvent::Quit => write!(f, "Quit"),
             RioEvent::CloseTerminal(route) => write!(f, "CloseTerminal {route}"),
             RioEvent::CreateWindow => write!(f, "CreateWindow"),
+            RioEvent::ToggleQuake => write!(f, "ToggleQuake"),
             RioEvent::CloseWindow => write!(f, "CloseWindow"),
             RioEvent::CreateNativeTab(_) => write!(f, "CreateNativeTab"),
             RioEvent::SelectNativeTabByIndex(tab_index) => {

--- a/rio-window/Cargo.toml
+++ b/rio-window/Cargo.toml
@@ -113,7 +113,8 @@ features = [
     "NSWindow",
     "NSWindowScripting",
     "NSWindowTabGroup",
-    "NSWorkspace"
+    "NSWorkspace",
+    "libc"
 ]
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/rio-window/src/event_loop.rs
+++ b/rio-window/src/event_loop.rs
@@ -446,6 +446,17 @@ impl ActiveEventLoop {
             .map(|inner| MonitorHandle { inner })
     }
 
+    /// Returns the monitor currently under the mouse cursor, regardless
+    /// of which application is focused.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **Linux / Web / Orbital:** Always returns `None` for now.
+    #[inline]
+    pub fn cursor_monitor(&self) -> Option<MonitorHandle> {
+        self.p.cursor_monitor().map(|inner| MonitorHandle { inner })
+    }
+
     /// Returns the primary monitor of the system.
     ///
     /// Returns `None` if it can't identify any monitor as a primary one.

--- a/rio-window/src/platform/macos.rs
+++ b/rio-window/src/platform/macos.rs
@@ -505,6 +505,30 @@ impl MonitorHandleExtMacOS for MonitorHandle {
 }
 
 /// Additional methods on [`ActiveEventLoop`] that are specific to macOS.
+/// Process id of the frontmost application, or `None` when that is
+/// this process, so a caller restoring focus never re-activates
+/// itself.
+pub fn frontmost_application_pid() -> Option<i32> {
+    let workspace = unsafe { objc2_app_kit::NSWorkspace::sharedWorkspace() };
+    let app = unsafe { workspace.frontmostApplication() }?;
+    let pid = unsafe { app.processIdentifier() };
+    (pid != std::process::id() as i32).then_some(pid)
+}
+
+/// Bring the application owning `pid` back to the front.
+pub fn activate_application(pid: i32) {
+    let app = unsafe {
+        objc2_app_kit::NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
+    };
+    if let Some(app) = app {
+        unsafe {
+            app.activateWithOptions(
+                objc2_app_kit::NSApplicationActivationOptions::empty(),
+            )
+        };
+    }
+}
+
 pub trait ActiveEventLoopExtMacOS {
     /// Hide the entire application. In most applications this is typically triggered with
     /// Command-H.
@@ -518,11 +542,19 @@ pub trait ActiveEventLoopExtMacOS {
     fn set_allows_automatic_window_tabbing(&self, enabled: bool);
     /// Returns whether the system can automatically organize windows into tabs.
     fn allows_automatic_window_tabbing(&self) -> bool;
+    /// The monitor currently under the mouse cursor, regardless of
+    /// which application is focused.
+    fn cursor_monitor(&self) -> Option<crate::monitor::MonitorHandle>;
 }
 
 impl ActiveEventLoopExtMacOS for ActiveEventLoop {
     fn hide_application(&self) {
         self.p.hide_application()
+    }
+
+    fn cursor_monitor(&self) -> Option<crate::monitor::MonitorHandle> {
+        crate::platform_impl::cursor_monitor()
+            .map(|inner| crate::monitor::MonitorHandle { inner })
     }
 
     fn hide_other_applications(&self) {

--- a/rio-window/src/platform/macos.rs
+++ b/rio-window/src/platform/macos.rs
@@ -542,19 +542,11 @@ pub trait ActiveEventLoopExtMacOS {
     fn set_allows_automatic_window_tabbing(&self, enabled: bool);
     /// Returns whether the system can automatically organize windows into tabs.
     fn allows_automatic_window_tabbing(&self) -> bool;
-    /// The monitor currently under the mouse cursor, regardless of
-    /// which application is focused.
-    fn cursor_monitor(&self) -> Option<crate::monitor::MonitorHandle>;
 }
 
 impl ActiveEventLoopExtMacOS for ActiveEventLoop {
     fn hide_application(&self) {
         self.p.hide_application()
-    }
-
-    fn cursor_monitor(&self) -> Option<crate::monitor::MonitorHandle> {
-        crate::platform_impl::cursor_monitor()
-            .map(|inner| crate::monitor::MonitorHandle { inner })
     }
 
     fn hide_other_applications(&self) {

--- a/rio-window/src/platform_impl/linux/mod.rs
+++ b/rio-window/src/platform_impl/linux/mod.rs
@@ -905,6 +905,11 @@ impl ActiveEventLoop {
     }
 
     #[inline]
+    pub fn cursor_monitor(&self) -> Option<MonitorHandle> {
+        None
+    }
+
+    #[inline]
     pub fn listen_device_events(&self, allowed: DeviceEvents) {
         x11_or_wayland!(match self; Self(evlp) => evlp.listen_device_events(allowed))
     }

--- a/rio-window/src/platform_impl/macos/event_loop.rs
+++ b/rio-window/src/platform_impl/macos/event_loop.rs
@@ -105,6 +105,11 @@ impl ActiveEventLoop {
     }
 
     #[inline]
+    pub fn cursor_monitor(&self) -> Option<MonitorHandle> {
+        monitor::cursor_monitor()
+    }
+
+    #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
     #[inline]

--- a/rio-window/src/platform_impl/macos/mod.rs
+++ b/rio-window/src/platform_impl/macos/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle,
     PlatformSpecificEventLoopAttributes,
 };
-pub(crate) use self::monitor::{cursor_monitor, MonitorHandle, VideoModeHandle};
+pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::WindowId;
 pub(crate) use self::window_delegate::PlatformSpecificWindowAttributes;
 use crate::event::DeviceId as RootDeviceId;

--- a/rio-window/src/platform_impl/macos/mod.rs
+++ b/rio-window/src/platform_impl/macos/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle,
     PlatformSpecificEventLoopAttributes,
 };
-pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
+pub(crate) use self::monitor::{cursor_monitor, MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::WindowId;
 pub(crate) use self::window_delegate::PlatformSpecificWindowAttributes;
 use crate::event::DeviceId as RootDeviceId;

--- a/rio-window/src/platform_impl/macos/monitor.rs
+++ b/rio-window/src/platform_impl/macos/monitor.rs
@@ -20,6 +20,42 @@ use objc2_foundation::{
 use super::ffi;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 
+/// The display currently under the mouse cursor. `CGEvent` reports
+/// the cursor in the same top-left-origin global space that
+/// `CGDisplayBounds` uses, so no coordinate flip is needed.
+pub fn cursor_monitor() -> Option<MonitorHandle> {
+    use core_graphics::event::CGEvent;
+    use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+
+    let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).ok()?;
+    let location = CGEvent::new(source).ok()?.location();
+    let mut display_id: CGDirectDisplayID = 0;
+    let mut count: u32 = 0;
+    let result = unsafe {
+        cursor_ffi::CGGetDisplaysWithPoint(location, 1, &mut display_id, &mut count)
+    };
+    if result == 0 && count > 0 {
+        Some(MonitorHandle::new(display_id))
+    } else {
+        None
+    }
+}
+
+mod cursor_ffi {
+    use core_graphics::display::CGDirectDisplayID;
+    use core_graphics::geometry::CGPoint;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        pub fn CGGetDisplaysWithPoint(
+            point: CGPoint,
+            max_displays: u32,
+            displays: *mut CGDirectDisplayID,
+            matching_display_count: *mut u32,
+        ) -> i32;
+    }
+}
+
 #[derive(Clone)]
 pub struct VideoModeHandle {
     size: PhysicalSize<u32>,

--- a/rio-window/src/platform_impl/orbital/event_loop.rs
+++ b/rio-window/src/platform_impl/orbital/event_loop.rs
@@ -840,6 +840,10 @@ impl ActiveEventLoop {
         Some(MonitorHandle)
     }
 
+    pub fn cursor_monitor(&self) -> Option<MonitorHandle> {
+        None
+    }
+
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         let mut v = VecDeque::with_capacity(1);
         v.push_back(MonitorHandle);

--- a/rio-window/src/platform_impl/web/event_loop/window_target.rs
+++ b/rio-window/src/platform_impl/web/event_loop/window_target.rs
@@ -692,6 +692,10 @@ impl ActiveEventLoop {
         None
     }
 
+    pub fn cursor_monitor(&self) -> Option<MonitorHandle> {
+        None
+    }
+
     #[inline]
     pub fn raw_display_handle_raw_window_handle(
         &self,

--- a/rio-window/src/platform_impl/windows/event_loop.rs
+++ b/rio-window/src/platform_impl/windows/event_loop.rs
@@ -546,7 +546,7 @@ impl ActiveEventLoop {
             return None;
         }
         let hmonitor = unsafe { MonitorFromPoint(point, MONITOR_DEFAULTTONULL) };
-        if hmonitor == 0 {
+        if hmonitor.is_null() {
             return None;
         }
         Some(MonitorHandle::new(hmonitor))

--- a/rio-window/src/platform_impl/windows/event_loop.rs
+++ b/rio-window/src/platform_impl/windows/event_loop.rs
@@ -23,8 +23,9 @@ use windows_sys::Win32::Foundation::{
     GetLastError, FALSE, HANDLE, HWND, LPARAM, LRESULT, POINT, RECT, WAIT_FAILED, WPARAM,
 };
 use windows_sys::Win32::Graphics::Gdi::{
-    GetMonitorInfoW, MonitorFromRect, MonitorFromWindow, RedrawWindow, ScreenToClient,
-    ValidateRect, MONITORINFO, MONITOR_DEFAULTTONULL, RDW_INTERNALPAINT, SC_SCREENSAVE,
+    GetMonitorInfoW, MonitorFromPoint, MonitorFromRect, MonitorFromWindow, RedrawWindow,
+    ScreenToClient, ValidateRect, MONITORINFO, MONITOR_DEFAULTTONULL, RDW_INTERNALPAINT,
+    SC_SCREENSAVE,
 };
 use windows_sys::Win32::System::Ole::RevokeDragDrop;
 use windows_sys::Win32::System::Threading::{
@@ -537,6 +538,18 @@ impl ActiveEventLoop {
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = monitor::primary_monitor();
         Some(monitor)
+    }
+
+    pub fn cursor_monitor(&self) -> Option<MonitorHandle> {
+        let mut point = POINT { x: 0, y: 0 };
+        if unsafe { GetCursorPos(&mut point) } == 0 {
+            return None;
+        }
+        let hmonitor = unsafe { MonitorFromPoint(point, MONITOR_DEFAULTTONULL) };
+        if hmonitor == 0 {
+            return None;
+        }
+        Some(MonitorHandle::new(hmonitor))
     }
 
     pub fn raw_display_handle_raw_window_handle(


### PR DESCRIPTION
Quake-style dropdown terminal, phase 1 of the plan for #89.

**New `ToggleQuake` binding action.** Bind it like any other action:

```toml
[bindings]
keys = [{ key = "'", with = "super", action = "ToggleQuake" }]
```

Any `ToggleQuake` binding is also registered as a **system-wide hotkey**, so the quake window opens while Rio is unfocused or has no window on the current screen. The hotkey uses the `global-hotkey` crate: Carbon `RegisterEventHotKey` on macOS (the iTerm2 mechanism, no accessibility permission needed), `RegisterHotKey` on Windows, `XGrabKey` on X11. Pure Wayland has no global hotkey API; there the in-app binding still works and a compositor keybinding can cover the global case once single-instance IPC lands (#868, planned as phase 2).

**The quake window** is created lazily on first toggle and reused: borderless, always on top, anchored to the top of the primary monitor and horizontally centered, sized by two new options:

```toml
[window]
quake-width-percentage = 1.0
quake-height-percentage = 0.4
```

Toggle semantics: hidden shows and focuses, visible and focused hides, visible but unfocused just focuses. Closing the quake window is fine; the next toggle recreates it.

The quake window drops down on the monitor under the mouse cursor (falling back to primary), re-anchoring on every toggle. On macOS, hiding it re-activates the app that was frontmost when it appeared, so focus lands back where the user was working.

Known phase 1 limits, to be addressed in a follow-up with rio-window additions: on macOS the window does not yet join all Spaces or float over fullscreen apps (needs `NSWindowCollectionBehavior`), and showing it activates Rio rather than acting as a nonactivating panel.

Refs #89
