### PR TITLE
osc 133 semantic prompts and osc 1337 user vars

### DIFF
--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -237,6 +237,8 @@ impl From<String> for Action {
             "decreasefontsize" => Some(Action::DecreaseFontSize),
             "createwindow" => Some(Action::WindowCreateNew),
             "togglequake" => Some(Action::ToggleQuake),
+            "scrolltoprevprompt" => Some(Action::ScrollToPrevPrompt),
+            "scrolltonextprompt" => Some(Action::ScrollToNextPrompt),
             "createtab" => Some(Action::TabCreateNew),
             "movecurrenttabtoprev" => Some(Action::MoveCurrentTabToPrev),
             "movecurrenttabtonext" => Some(Action::MoveCurrentTabToNext),
@@ -463,6 +465,13 @@ pub enum Action {
     /// Show or hide the quake-style dropdown window. Also registered
     /// as a system-wide hotkey when bound in `[bindings]`.
     ToggleQuake,
+
+    /// Scroll so the previous OSC 133 prompt is at the top of the
+    /// viewport. Requires shell integration emitting semantic prompts.
+    ScrollToPrevPrompt,
+
+    /// Scroll so the next OSC 133 prompt is at the top of the viewport.
+    ScrollToNextPrompt,
 
     /// Toggle vi mode.
     ToggleViMode,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1182,6 +1182,24 @@ impl Screen<'_> {
                     Act::ResetFontSize => {
                         self.change_font_size(FontSizeAction::Reset);
                     }
+                    Act::ScrollToPrevPrompt => {
+                        let current = self.context_manager.current_mut();
+                        let rtid = current.rich_text_id;
+                        let mut terminal = current.terminal.lock();
+                        terminal.scroll_to_prompt(false);
+                        drop(terminal);
+                        self.renderer.scrollbar.notify_scroll(rtid);
+                        self.mark_dirty();
+                    }
+                    Act::ScrollToNextPrompt => {
+                        let current = self.context_manager.current_mut();
+                        let rtid = current.rich_text_id;
+                        let mut terminal = current.terminal.lock();
+                        terminal.scroll_to_prompt(true);
+                        drop(terminal);
+                        self.renderer.scrollbar.notify_scroll(rtid);
+                        self.mark_dirty();
+                    }
                     Act::ScrollPageUp => {
                         // Move vi mode cursor.
                         let current = self.context_manager.current_mut();

--- a/rio-backend/src/crosswords/grid/row.rs
+++ b/rio-backend/src/crosswords/grid/row.rs
@@ -9,6 +9,18 @@ use std::cmp::max;
 use std::ops::{Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive};
 use std::{ptr, slice};
 
+/// Row-level semantic prompt mark from OSC 133 shell integration.
+/// An index for prompt navigation, following the same model other
+/// terminals use: a run of `Prompt`/`PromptContinuation` rows is one
+/// prompt; everything else is `None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SemanticPrompt {
+    #[default]
+    None,
+    Prompt,
+    PromptContinuation,
+}
+
 /// A row in the grid.
 #[derive(Clone, Debug)]
 pub struct Row<T> {
@@ -27,6 +39,10 @@ pub struct Row<T> {
 
     pub has_extras: bool,
 
+    /// OSC 133 semantic prompt mark. Travels with the row into
+    /// scrollback; cleared when the row is recycled.
+    pub semantic_prompt: SemanticPrompt,
+
     /// Per-row dirty bit set on every write through `IndexMut` /
     /// `last_mut` / `iter_mut` / `reset` / `append*` / `front_split_off`.
     /// Read + cleared by the renderer's snapshot path so it can copy
@@ -43,6 +59,7 @@ impl<T> Default for Row<T> {
             occ: 0,
             kitty_virtual_placeholder: false,
             has_extras: false,
+            semantic_prompt: SemanticPrompt::None,
             dirty: true,
         }
     }
@@ -81,6 +98,7 @@ impl<T: Clone + Default> Row<T> {
             occ: 0,
             kitty_virtual_placeholder: false,
             has_extras: false,
+            semantic_prompt: SemanticPrompt::None,
             dirty: true,
         }
     }
@@ -97,6 +115,7 @@ impl<T: Clone + Default> Row<T> {
         self.occ = src.occ;
         self.kitty_virtual_placeholder = src.kitty_virtual_placeholder;
         self.has_extras = src.has_extras;
+        self.semantic_prompt = src.semantic_prompt;
     }
 
     /// Increase the number of columns in the row.
@@ -154,6 +173,7 @@ impl<T: Clone + Default> Row<T> {
         self.occ = 0;
         self.kitty_virtual_placeholder = false;
         self.has_extras = false;
+        self.semantic_prompt = SemanticPrompt::None;
         self.dirty = true;
     }
 }
@@ -167,6 +187,7 @@ impl<T> Row<T> {
             occ,
             kitty_virtual_placeholder: false,
             has_extras: true,
+            semantic_prompt: SemanticPrompt::None,
             dirty: true,
         }
     }

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -454,6 +454,8 @@ where
     pub route_id: usize,
     title_stack: Vec<String>,
     pub current_directory: Option<std::path::PathBuf>,
+    /// Shell state from `OSC 1337 ; SetUserVar` (iTerm2 style).
+    pub user_vars: rustc_hash::FxHashMap<String, String>,
 
     /// Whether a `TerminalDamaged` event is already in flight to the renderer.
     /// Set by PTY thread before sending; cleared by renderer after extracting damage.
@@ -513,6 +515,7 @@ impl<U: EventListener> Crosswords<U> {
             route_id,
             title_stack: Default::default(),
             current_directory: None,
+            user_vars: rustc_hash::FxHashMap::default(),
             damage_event_in_flight: false,
             keyboard_mode_stack: Default::default(),
             keyboard_mode_idx: 0,
@@ -616,6 +619,36 @@ impl<U: EventListener> Crosswords<U> {
     #[inline]
     pub fn clear_saved_history(&mut self) {
         self.clear_screen(ClearMode::Saved);
+    }
+
+    /// Scroll so the previous (`forward = false`) or next prompt row
+    /// starts at the top of the viewport. Prompts come from OSC 133
+    /// marks; a run of consecutive prompt rows counts as one prompt.
+    pub fn scroll_to_prompt(&mut self, forward: bool) {
+        use crate::crosswords::grid::row::SemanticPrompt;
+
+        let display_offset = self.grid.display_offset() as i32;
+        let history = self.grid.history_size() as i32;
+        let screen_lines = self.grid.screen_lines() as i32;
+        let top = -display_offset;
+
+        let is_marked =
+            |line: i32| self.grid[Line(line)].semantic_prompt != SemanticPrompt::None;
+        // First row of a prompt run: marked, with an unmarked row (or
+        // the top of history) above it.
+        let is_prompt_start =
+            |line: i32| is_marked(line) && (line == -history || !is_marked(line - 1));
+
+        let target = if forward {
+            (top + 1..screen_lines).find(|line| is_prompt_start(*line))
+        } else {
+            (-history..top).rev().find(|line| is_prompt_start(*line))
+        };
+
+        if let Some(line) = target {
+            let new_offset = (-line).max(0);
+            self.scroll_display(Scroll::Delta(new_offset - display_offset));
+        }
     }
 
     #[inline]
@@ -2555,6 +2588,18 @@ impl<U: EventListener> Handler for Crosswords<U> {
     fn set_current_directory(&mut self, path: std::path::PathBuf) {
         trace!("Setting working directory {:?}", path);
         self.current_directory = Some(path);
+    }
+
+    fn set_semantic_prompt(
+        &mut self,
+        mark: crate::crosswords::grid::row::SemanticPrompt,
+    ) {
+        let row = self.grid.cursor.pos.row;
+        self.grid[row].semantic_prompt = mark;
+    }
+
+    fn set_user_var(&mut self, name: String, value: String) {
+        self.user_vars.insert(name, value);
     }
 
     #[inline]
@@ -4592,6 +4637,97 @@ mod tests {
 
     fn registry_len(cw: &Crosswords<VoidListener>) -> usize {
         cw.glyph_registry.as_ref().map_or(0, |r| r.len())
+    }
+
+    #[test]
+    fn semantic_prompt_marks_and_navigation() {
+        use crate::crosswords::grid::row::SemanticPrompt;
+
+        let mut cw = make_crosswords();
+        // Three prompts, each followed by two lines of output. The
+        // 4-row screen pushes earlier prompts into scrollback.
+        for _ in 0..3 {
+            cw.set_semantic_prompt(SemanticPrompt::Prompt);
+            cw.linefeed();
+            cw.linefeed();
+            cw.linefeed();
+        }
+        assert_eq!(cw.grid.history_size(), 6);
+        assert_eq!(cw.grid[Line(-6)].semantic_prompt, SemanticPrompt::Prompt);
+        assert_eq!(cw.grid[Line(-3)].semantic_prompt, SemanticPrompt::Prompt);
+        assert_eq!(cw.grid[Line(0)].semantic_prompt, SemanticPrompt::Prompt);
+
+        cw.scroll_to_prompt(false);
+        assert_eq!(cw.display_offset(), 3);
+        cw.scroll_to_prompt(false);
+        assert_eq!(cw.display_offset(), 6);
+        // No prompt further up: stays put.
+        cw.scroll_to_prompt(false);
+        assert_eq!(cw.display_offset(), 6);
+
+        cw.scroll_to_prompt(true);
+        assert_eq!(cw.display_offset(), 3);
+        cw.scroll_to_prompt(true);
+        assert_eq!(cw.display_offset(), 0);
+        cw.scroll_to_prompt(true);
+        assert_eq!(cw.display_offset(), 0);
+    }
+
+    #[test]
+    fn semantic_prompt_run_counts_as_one() {
+        use crate::crosswords::grid::row::SemanticPrompt;
+
+        let mut cw = make_crosswords();
+        for _ in 0..6 {
+            cw.linefeed();
+        }
+        // A two-row prompt: continuation directly below the start.
+        cw.grid[Line(-3)].semantic_prompt = SemanticPrompt::Prompt;
+        cw.grid[Line(-2)].semantic_prompt = SemanticPrompt::PromptContinuation;
+
+        cw.scroll_to_prompt(false);
+        assert_eq!(cw.display_offset(), 3);
+        cw.scroll_to_prompt(false);
+        assert_eq!(cw.display_offset(), 3);
+    }
+
+    #[test]
+    fn shell_integration_oscs_dispatch_from_raw_bytes() {
+        use crate::crosswords::grid::row::SemanticPrompt;
+        use crate::performer::handler::Processor;
+
+        let size = CrosswordsSize::new(40, 5);
+        let window_id = crate::event::WindowId::from(0);
+        let mut cw = Crosswords::new(
+            size,
+            CursorShape::Block,
+            VoidListener {},
+            window_id,
+            0,
+            10_000,
+        );
+        let mut processor = Processor::default();
+
+        // A prompt mark, a full A/B/C/D cycle with options, and a
+        // user var ("hello" in base64), bell-terminated like shells
+        // emit them.
+        let bytes = b"]133;A;aid=1prompt]133;Bcmd
+]133;Cout
+]133;D;0]1337;SetUserVar=foo=aGVsbG8=";
+        processor.advance(&mut cw, bytes);
+
+        assert_eq!(cw.grid[Line(0)].semantic_prompt, SemanticPrompt::Prompt);
+        assert_eq!(cw.grid[Line(1)].semantic_prompt, SemanticPrompt::None);
+        assert_eq!(cw.user_vars.get("foo").map(String::as_str), Some("hello"));
+    }
+
+    #[test]
+    fn user_vars_are_stored() {
+        let mut cw = make_crosswords();
+        assert!(cw.user_vars.is_empty());
+        cw.set_user_var("k".to_string(), "v".to_string());
+        cw.set_user_var("k".to_string(), "v2".to_string());
+        assert_eq!(cw.user_vars.get("k").map(String::as_str), Some("v2"));
     }
 
     #[test]

--- a/rio-backend/src/performer/handler.rs
+++ b/rio-backend/src/performer/handler.rs
@@ -95,6 +95,12 @@ pub trait Handler {
     /// OSC to set current directory.
     fn set_current_directory(&mut self, _: std::path::PathBuf) {}
 
+    /// OSC 133: mark the cursor row as a semantic prompt row.
+    fn set_semantic_prompt(&mut self, _: crate::crosswords::grid::row::SemanticPrompt) {}
+
+    /// OSC 1337 SetUserVar: record a shell-provided variable.
+    fn set_user_var(&mut self, _name: String, _value: String) {}
+
     /// Set the cursor style.
     fn set_cursor_style(&mut self, _style: Option<CursorShape>, _blinking: bool) {}
 
@@ -1061,6 +1067,13 @@ impl<U: Handler> Perform for Performer<'_, U> {
                 }
             }
 
+            // OSC 133 - semantic prompt zones (shell integration).
+            b"133" => {
+                if let Some(mark) = osc::parse_semantic_prompt(params) {
+                    self.handler.set_semantic_prompt(mark);
+                }
+            }
+
             // OSC 777 - rxvt notification.
             b"777" if params.len() >= 4 && params[1] == b"notify" => {
                 let title = std::str::from_utf8(params[2])
@@ -1132,9 +1145,11 @@ impl<U: Handler> Perform for Performer<'_, U> {
             b"111" => self.handler.reset_color(NamedColor::Background as usize),
             b"112" => self.handler.reset_color(NamedColor::Cursor as usize),
 
-            // OSC 1337 — iTerm2 inline image protocol.
+            // OSC 1337 - iTerm2 user vars and inline image protocol.
             b"1337" => {
-                if let Some(graphic) = iterm2_image_protocol::parse(params) {
+                if let Some((name, value)) = osc::parse_set_user_var(params) {
+                    self.handler.set_user_var(name, value);
+                } else if let Some(graphic) = iterm2_image_protocol::parse(params) {
                     self.handler.insert_graphic(graphic, None, None);
                 }
             }
@@ -2090,6 +2105,50 @@ fn get_termcap_capability(name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn semantic_prompt_parsing() {
+        use crate::crosswords::grid::row::SemanticPrompt;
+        use crate::performer::osc::parse_semantic_prompt as parse;
+
+        assert_eq!(parse(&[b"133", b"A"]), Some(SemanticPrompt::Prompt));
+        assert_eq!(
+            parse(&[b"133", b"A", b"aid=1"]),
+            Some(SemanticPrompt::Prompt)
+        );
+        assert_eq!(parse(&[b"133", b"P"]), Some(SemanticPrompt::Prompt));
+        assert_eq!(parse(&[b"133", b"P", b"k=i"]), Some(SemanticPrompt::Prompt));
+        assert_eq!(
+            parse(&[b"133", b"P", b"k=s"]),
+            Some(SemanticPrompt::PromptContinuation)
+        );
+        assert_eq!(
+            parse(&[b"133", b"P", b"k=c"]),
+            Some(SemanticPrompt::PromptContinuation)
+        );
+        // Accepted subcommands that set no row mark.
+        assert_eq!(parse(&[b"133", b"B"]), None);
+        assert_eq!(parse(&[b"133", b"C"]), None);
+        assert_eq!(parse(&[b"133", b"D", b"0"]), None);
+        assert_eq!(parse(&[b"133"]), None);
+        assert_eq!(parse(&[b"133", b""]), None);
+    }
+
+    #[test]
+    fn set_user_var_parsing() {
+        use crate::performer::osc::parse_set_user_var as parse;
+
+        // "hello" in base64.
+        assert_eq!(
+            parse(&[b"1337", b"SetUserVar=foo=aGVsbG8="]),
+            Some(("foo".to_string(), "hello".to_string()))
+        );
+        assert_eq!(parse(&[b"1337", b"SetUserVar=foo"]), None);
+        assert_eq!(parse(&[b"1337", b"SetUserVar==aGVsbG8="]), None);
+        assert_eq!(parse(&[b"1337", b"SetUserVar=foo=!!!"]), None);
+        assert_eq!(parse(&[b"1337", b"File=inline=1"]), None);
+        assert_eq!(parse(&[b"1337"]), None);
+    }
 
     #[test]
     fn test_hex_encoding() {

--- a/rio-backend/src/performer/osc.rs
+++ b/rio-backend/src/performer/osc.rs
@@ -42,6 +42,48 @@ pub(super) enum PaletteReset {
     Indices(Vec<u8>),
 }
 
+/// Parse an OSC 133 semantic prompt sequence into the row mark it
+/// should set, if any. `A` and `P` mark the cursor row as a prompt
+/// (`P;k=c` / `P;k=s` as a continuation); the remaining subcommands
+/// (`B`, `C`, `D`, `I`, `L`, `N`) and all `key=value` options are
+/// accepted and ignored, matching the spec's leniency.
+pub(super) fn parse_semantic_prompt(
+    params: &[&[u8]],
+) -> Option<crate::crosswords::grid::row::SemanticPrompt> {
+    use crate::crosswords::grid::row::SemanticPrompt;
+
+    let subcommand = *params.get(1)?.first()?;
+    match subcommand {
+        b'A' => Some(SemanticPrompt::Prompt),
+        b'P' => {
+            for option in &params[2..] {
+                if let Some(kind) = option.strip_prefix(b"k=") {
+                    if kind == b"c" || kind == b"s" {
+                        return Some(SemanticPrompt::PromptContinuation);
+                    }
+                }
+            }
+            Some(SemanticPrompt::Prompt)
+        }
+        _ => None,
+    }
+}
+
+/// Parse `OSC 1337 ; SetUserVar=name=<base64 value>`. The value is
+/// base64 per iTerm2's spec; anything undecodable is dropped.
+pub(super) fn parse_set_user_var(params: &[&[u8]]) -> Option<(String, String)> {
+    let payload = params.get(1)?.strip_prefix(b"SetUserVar=")?;
+    let mut parts = payload.splitn(2, |byte| *byte == b'=');
+    let name = simd_utf8::from_utf8_fast(parts.next()?).ok()?;
+    if name.is_empty() {
+        return None;
+    }
+    let encoded = parts.next()?;
+    let decoded = crate::simd_base64::decode(encoded)?;
+    let value = String::from_utf8(decoded).ok()?;
+    Some((name.to_string(), value))
+}
+
 /// Parse an `xterm`-style color value (`#rgb`, `#rrggbb`, `rgb:r/g/b`).
 pub(super) fn xparse_color(color: &[u8]) -> Option<ColorRgb> {
     if !color.is_empty() && color[0] == b'#' {


### PR DESCRIPTION
Shell integration, the two remaining items from #720.

**OSC 133 semantic prompt zones (#975).** `133;A` and `133;P` mark the cursor row as a prompt row (`P;k=c` / `P;k=s` as a continuation), following the same model ghostty and kitty use: a per-row mark that acts as an index for prompt navigation, where a run of consecutive prompt rows counts as one prompt. Marks travel with rows into scrollback and are cleared when rows are recycled. The remaining subcommands (`B`, `C`, `D`, `I`, `L`, `N`) and all `key=value` options are accepted and ignored per the spec's leniency, so shells emitting full sequences produce no unhandled warnings.

**Prompt navigation as the consumer**: two new binding actions scroll the viewport so a prompt row lands at the top.

```toml
[bindings]
keys = [
  { key = "up", with = "super | shift", action = "ScrollToPrevPrompt" },
  { key = "down", with = "super | shift", action = "ScrollToNextPrompt" },
]
```

This is most of #783 (scroll to prompt); left unbound by default to avoid clashing with existing chords.

**OSC 1337 SetUserVar (#976).** `1337;SetUserVar=name=<base64>` is decoded and stored in a per-terminal map (`Crosswords.user_vars`), available for future consumers like title templates. Previously these sequences were silently swallowed by the iTerm2 image parser; the arm now tries user vars first and falls through to images.

Tests: parse-level (both sequences incl. malformed forms), behavior-level (mark placement, scrollback survival, prompt-run collapse, navigation offsets), and a raw-byte dispatch test feeding a full bell-terminated A/B/C/D + SetUserVar stream through the parser.

Closes #975, closes #976. Refs #720 #783