### PR TITLE
fix atlas limit and stale grid position panics

### DIFF
--- a/rio-backend/src/crosswords/grid/mod.rs
+++ b/rio-backend/src/crosswords/grid/mod.rs
@@ -754,6 +754,20 @@ impl<'a, T> Iterator for GridIterator<'a, T> {
             _ => self.current.col += Column(1),
         }
 
+        // Guard both axes before indexing (#1713): positions can be
+        // stale relative to the live grid (resize between capture and
+        // use), and history rows keep their old length across column
+        // growth. Ending the iteration beats panicking.
+        let screen_lines = self.grid.screen_lines() as i32;
+        let history = (self.grid.total_lines() - self.grid.screen_lines()) as i32;
+        if self.current.row.0 >= screen_lines || self.current.row.0 < -history {
+            return None;
+        }
+        let row = &self.grid[self.current.row];
+        if self.current.col.0 >= row.len() {
+            return None;
+        }
+
         Some(Indexed {
             square: &self.grid[self.current],
             pos: self.current,

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -4722,6 +4722,25 @@ mod tests {
     }
 
     #[test]
+    fn grid_iterator_survives_narrow_rows() {
+        let mut cw = make_crosswords();
+        for _ in 0..6 {
+            cw.linefeed();
+        }
+        // History rows keep their old length across column growth;
+        // simulate one narrower than the grid (#1713).
+        cw.grid[Line(-2)].inner.truncate(2);
+        let start = Pos::new(Line(-3), Column(0));
+        // Must not panic; may end early at the narrow row.
+        let _ = cw.grid.iter_from(start).count();
+
+        // A stale position beyond the grid's history must end the
+        // iteration instead of panicking.
+        let stale = Pos::new(Line(-40), Column(0));
+        assert_eq!(cw.grid.iter_from(stale).count(), 0);
+    }
+
+    #[test]
     fn user_vars_are_stored() {
         let mut cw = make_crosswords();
         assert!(cw.user_vars.is_empty());

--- a/sugarloaf/src/renderer/image_cache/cache.rs
+++ b/sugarloaf/src/renderer/image_cache/cache.rs
@@ -130,8 +130,10 @@ impl ImageCache {
                 let mask_texture = device.create_texture(&wgpu::TextureDescriptor {
                     label: Some("rich_text mask atlas"),
                     size: wgpu::Extent3d {
-                        width: SIZE as u32,
-                        height: SIZE as u32,
+                        // Clamped to the device limit: downlevel GPUs
+                        // (GLES 3.1 class) report 2048 and reject 4096.
+                        width: max_texture_size as u32,
+                        height: max_texture_size as u32,
                         depth_or_array_layers: 1,
                     },
                     view_formats: &[],
@@ -149,8 +151,8 @@ impl ImageCache {
                 let color_texture = device.create_texture(&wgpu::TextureDescriptor {
                     label: Some("rich_text color atlas 0"),
                     size: wgpu::Extent3d {
-                        width: SIZE as u32,
-                        height: SIZE as u32,
+                        width: max_texture_size as u32,
+                        height: max_texture_size as u32,
                         depth_or_array_layers: 1,
                     },
                     view_formats: &[],


### PR DESCRIPTION
Two crash fixes from the stability triage:

**Atlas exceeds device limits (#1641).** The rich text image cache clamps its CPU-side atlas to `min(4096, max_texture_dimension_2d)`, but the initial mask and color GPU textures were created at the hardcoded 4096 regardless. On downlevel GPUs (Raspberry Pi class, GLES 3.1 limits of 2048) `create_texture` panics at startup. The initial textures now use the clamped size, matching what the additional-color-atlas path already did.

**Grid iterator panics on stale positions (#1713).** `GridIterator::next` indexed the grid without bounds checks, so a position stale relative to the live grid (captured before a resize, like the komorebi tiling resize in the report: "len is 67 but index is 73") panicked in the row storage. The iterator now ends instead of panicking when the position is outside the grid's line range or past a row's width (history rows keep their old length across column growth). Regression test covers both the narrow-row and stale-position cases.

Closes #1641, closes #1713