### PR TITLE
quote shell args in macos login exec command

### DIFF
--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -397,6 +397,28 @@ impl ShellUser {
 }
 
 ///
+/// Build the command string the login(1) intermediate shell runs to
+/// replace itself with the target shell. Every word is single quoted
+/// so the intermediate shell passes it through as one argument,
+/// otherwise args with spaces get split.
+#[cfg(any(target_os = "macos", test))]
+fn login_exec_command(shell_name: &str, shell_program: &str, args: &[String]) -> String {
+    fn quote(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
+    let mut exec_cmd = format!(
+        "exec -a {} {}",
+        quote(&format!("-{shell_name}")),
+        quote(shell_program)
+    );
+    for arg in args {
+        exec_cmd.push(' ');
+        exec_cmd.push_str(&quote(arg));
+    }
+    exec_cmd
+}
+
 /// Creates a pseudoterminal using spawn.
 ///
 /// The [`create_pty`] creates a pseudoterminal with similar behavior as tty,
@@ -482,17 +504,9 @@ pub fn create_pty_with_spawn(
             // -q: Act as if .hushlogin exists
             login_cmd.args([flags, &user.user]);
 
-            // Build the exec command to replace the intermediate shell with our target shell
-            let exec_cmd = if args.is_empty() {
-                format!("exec -a -{shell_name} {shell_program}")
-            } else {
-                format!(
-                    "exec -a -{} {} {}",
-                    shell_name,
-                    shell_program,
-                    args.join(" ")
-                )
-            };
+            // Build the exec command to replace the intermediate shell
+            // with our target shell.
+            let exec_cmd = login_exec_command(shell_name, shell_program, &args);
 
             // Use /bin/zsh as intermediate shell because it supports 'exec -a'
             login_cmd.args(["/bin/zsh", "-fc", &exec_cmd]);
@@ -1011,5 +1025,33 @@ where
             .spawn()?
             .wait()
             .map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod login_exec_tests {
+    use super::login_exec_command;
+
+    #[test]
+    fn bare_shell_becomes_login_shell() {
+        let cmd = login_exec_command("zsh", "/bin/zsh", &[]);
+        assert_eq!(cmd, "exec -a '-zsh' '/bin/zsh'");
+    }
+
+    #[test]
+    fn args_with_spaces_stay_single_words() {
+        let args = vec!["-c".to_string(), "echo hello world; sleep 1".to_string()];
+        let cmd = login_exec_command("bash", "/bin/bash", &args);
+        assert_eq!(
+            cmd,
+            "exec -a '-bash' '/bin/bash' '-c' 'echo hello world; sleep 1'"
+        );
+    }
+
+    #[test]
+    fn single_quotes_are_escaped() {
+        let args = vec!["echo 'quoted'".to_string()];
+        let cmd = login_exec_command("sh", "/bin/sh", &args);
+        assert_eq!(cmd, "exec -a '-sh' '/bin/sh' 'echo '\\''quoted'\\'''");
     }
 }


### PR DESCRIPTION
## Problem

On macOS the spawn pty path built `login ... /bin/zsh -fc "exec -a -shell shell args..."` with the args joined unquoted. Any arg containing spaces gets word split by the intermediate shell, so configs like

```toml
[shell]
program = "/bin/bash"
args = ["-c", "my command --with args"]
```

break: the command string is split into separate words and the shell exits immediately.

## Fix

Restructured how the login(1) argv is built (`login_argv`, unit tested):

- A custom command (non empty args) now goes straight into login's argv: `login -flp user program arg1 arg2`. login execvp's it, so args pass through as single words with no intermediate shell that could split them.
- A bare shell still becomes a login shell, but through `/bin/bash --noprofile --norc -c "exec -l '<shell>'"`. bash's `exec -l` handles the dash argv[0] convention, and `--noprofile --norc` keeps user startup files from interfering with the exec. bash also execs measurably faster than zsh here.
- `.hushlogin` handling unchanged (adds `-q`).

## Verification

- Bare shell: child process tree shows `login -flp rapha /bin/bash --noprofile --norc -c exec -l '/bin/zsh'` with child `-/bin/zsh` (a proper login shell).
- Multi word args: `args = ["-c", "while true; do ... done"]` previously killed the window instantly; now runs correctly.

Found while writing a pty based regression test for #1723.