### PR TITLE
fix kitty source crop handling and test overlay geometry

### DIFF
--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -414,31 +414,40 @@ impl Renderer {
                 overlays.clear();
 
                 if has_overlays {
-                    let history_size = rc.history_size as i64;
-                    let display_offset = rc.display_offset as i64;
-                    let screen_lines = rc.screen_lines as i64;
+                    let viewport = rio_backend::ansi::graphics::OverlayViewport {
+                        cell_width,
+                        cell_height,
+                        origin_x,
+                        origin_y,
+                        history_size: rc.history_size as i64,
+                        display_offset: rc.display_offset as i64,
+                        screen_lines: rc.screen_lines as i64,
+                    };
 
                     for p in &rc.kitty_placements {
-                        let screen_row = p.dest_row - (history_size - display_offset);
-                        let image_bottom_row = screen_row + p.rows as i64;
-                        // Cull only if fully off-screen (like )
-                        if image_bottom_row <= 0 || screen_row >= screen_lines {
+                        let (image_width, image_height) = rc
+                            .kitty_images
+                            .get(&p.image_id)
+                            .map(|stored| (stored.data.width, stored.data.height))
+                            .unwrap_or((0, 0));
+                        let Some(geometry) =
+                            rio_backend::ansi::graphics::kitty_overlay_geometry(
+                                p,
+                                image_width,
+                                image_height,
+                                &viewport,
+                            )
+                        else {
                             continue;
-                        }
+                        };
                         overlays.push(rio_backend::sugarloaf::GraphicOverlay {
                             image_id: p.image_id,
-                            // kitty X=/Y= offset, supports sub-cell positioning
-                            x: origin_x
-                                + p.dest_col as f32 * cell_width
-                                + p.cell_x_offset as f32,
-                            y: origin_y
-                                + screen_row as f32 * cell_height
-                                + p.cell_y_offset as f32,
-                            width: p.pixel_width as f32,
-                            height: p.pixel_height as f32,
+                            x: geometry.x,
+                            y: geometry.y,
+                            width: geometry.width,
+                            height: geometry.height,
                             z_index: p.z_index,
-                            source_rect:
-                                rio_backend::sugarloaf::GraphicOverlay::FULL_SOURCE_RECT,
+                            source_rect: geometry.source_rect,
                         });
                     }
                 }

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -868,6 +868,7 @@ impl Renderer {
                 vp.rows,
                 img.data.width as u32,
                 img.data.height as u32,
+                (vp.x, vp.y, vp.width, vp.height),
                 cell_width,
                 cell_height,
                 origin_x,

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -379,7 +379,11 @@ impl Renderer {
                             })
                             .cloned()
                             .collect();
-                        placements.sort_by_key(|p| p.z_index);
+                        // Tie-break on the unique key so equal
+                        // z-indexes keep a stable paint order across
+                        // frames (map iteration order is not).
+                        placements
+                            .sort_by_key(|p| (p.z_index, p.image_id, p.placement_id));
                         placements
                     };
                     context.renderable_content.kitty_graphics_dirty = true;

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -101,7 +101,11 @@ pub struct KittyPlacement {
     pub image_id: u32,
     /// Kitty protocol placement ID (p= parameter).
     pub placement_id: u32,
-    /// Source rectangle within the image (pixels).
+    /// Source rectangle within the image, exactly as requested
+    /// (`x=`/`y=`/`w=`/`h=`; zero width/height means "to the image
+    /// edge"). Stored raw and resolved against the image's current
+    /// dimensions at read time, so a retransmit that changes the
+    /// image size re-clamps instead of showing a stale crop.
     pub source_x: u32,
     pub source_y: u32,
     pub source_width: u32,
@@ -129,6 +133,39 @@ pub struct KittyPlacement {
     pub z_index: i32,
     /// Transmission timestamp for cache invalidation.
     pub transmit_time: std::time::Instant,
+}
+
+/// Resolve a raw kitty source rectangle against the image's current
+/// dimensions: origin clamped to the edges, zero width/height meaning
+/// "to the edge". Returns `None` when nothing of the crop lies inside
+/// the image (or the image is empty).
+pub fn resolve_source_rect(
+    source_x: u32,
+    source_y: u32,
+    source_width: u32,
+    source_height: u32,
+    image_width: usize,
+    image_height: usize,
+) -> Option<(usize, usize, usize, usize)> {
+    if image_width == 0 || image_height == 0 {
+        return None;
+    }
+    let x = (source_x as usize).min(image_width);
+    let y = (source_y as usize).min(image_height);
+    let width = if source_width > 0 {
+        (source_width as usize).min(image_width - x)
+    } else {
+        image_width - x
+    };
+    let height = if source_height > 0 {
+        (source_height as usize).min(image_height - y)
+    } else {
+        image_height - y
+    };
+    if width == 0 || height == 0 {
+        return None;
+    }
+    Some((x, y, width, height))
 }
 
 /// Display pixel size for a kitty placement: the source rectangle
@@ -164,17 +201,40 @@ pub fn kitty_display_size(
 }
 
 impl KittyPlacement {
-    /// Recompute display size, cell span, and offset clamps for a new
-    /// cell size. Cell-sized placements track the grid; native-size
-    /// ones keep their pixel dimensions but re-derive how many cells
-    /// they cover.
-    pub fn rescale(&mut self, cell_width: usize, cell_height: usize) {
+    /// Recompute display size and cell span against the image's
+    /// current dimensions and a cell size. Cell-sized placements
+    /// track the grid; native-size ones keep their pixel dimensions
+    /// but re-derive how many cells they cover. Called on resize and
+    /// retransmission.
+    pub fn rescale(
+        &mut self,
+        image_width: usize,
+        image_height: usize,
+        cell_width: usize,
+        cell_height: usize,
+    ) {
         if cell_width == 0 || cell_height == 0 {
             return;
         }
+        let Some((_, _, source_width, source_height)) = resolve_source_rect(
+            self.source_x,
+            self.source_y,
+            self.source_width,
+            self.source_height,
+            image_width,
+            image_height,
+        ) else {
+            // Nothing of the crop is inside the image: invisible, no
+            // cell footprint.
+            self.pixel_width = 0;
+            self.pixel_height = 0;
+            self.columns = 0;
+            self.rows = 0;
+            return;
+        };
         let (w, h) = kitty_display_size(
-            self.source_width as usize,
-            self.source_height as usize,
+            source_width,
+            source_height,
             self.requested_columns,
             self.requested_rows,
             cell_width,
@@ -229,9 +289,13 @@ pub struct OverlayViewport {
 
 /// Compute where a direct kitty placement lands on screen.
 ///
-/// The viewport cell stride must be the same one the grid paints
-/// with, so image position and text stay in lockstep. Returns `None`
-/// when the placement is fully outside the viewport; a partially
+/// The crop and display size are resolved here, per frame, against
+/// the image's current dimensions and the viewport's cell stride —
+/// nothing baked at place time can go stale when the image is
+/// retransmitted or the cell size changes. The viewport cell stride
+/// must be the same one the grid paints with, so image position and
+/// text stay in lockstep. Returns `None` when the placement is fully
+/// outside the viewport or resolves to nothing visible; a partially
 /// visible placement keeps its full quad and the GPU clips it.
 pub fn kitty_overlay_geometry(
     placement: &KittyPlacement,
@@ -249,24 +313,42 @@ pub fn kitty_overlay_geometry(
         return None;
     }
 
+    let (source_x, source_y, source_width, source_height) = resolve_source_rect(
+        placement.source_x,
+        placement.source_y,
+        placement.source_width,
+        placement.source_height,
+        image_width,
+        image_height,
+    )?;
+
+    let cell_width_px = viewport.cell_width.round() as usize;
+    let cell_height_px = viewport.cell_height.round() as usize;
+    if cell_width_px == 0 || cell_height_px == 0 {
+        return None;
+    }
+    let (display_width, display_height) = kitty_display_size(
+        source_width,
+        source_height,
+        placement.requested_columns,
+        placement.requested_rows,
+        cell_width_px,
+        cell_height_px,
+    );
+    if display_width == 0 || display_height == 0 {
+        return None;
+    }
+
     // Normalized `[u0, v0, u1, v1]` (origin, end), the convention all
     // three image shaders share.
-    let source_rect = if image_width > 0
-        && image_height > 0
-        && placement.source_width > 0
-        && placement.source_height > 0
-    {
-        let image_width = image_width as f32;
-        let image_height = image_height as f32;
-        [
-            placement.source_x as f32 / image_width,
-            placement.source_y as f32 / image_height,
-            (placement.source_x + placement.source_width) as f32 / image_width,
-            (placement.source_y + placement.source_height) as f32 / image_height,
-        ]
-    } else {
-        [0.0, 0.0, 1.0, 1.0]
-    };
+    let image_width = image_width as f32;
+    let image_height = image_height as f32;
+    let source_rect = [
+        source_x as f32 / image_width,
+        source_y as f32 / image_height,
+        (source_x + source_width) as f32 / image_width,
+        (source_y + source_height) as f32 / image_height,
+    ];
 
     // Per the kitty spec the sub-cell offset stays inside the cell
     // box; stored values are raw, so clamp against the current cell
@@ -277,8 +359,8 @@ pub fn kitty_overlay_geometry(
     Some(KittyOverlayGeometry {
         x: viewport.origin_x + placement.dest_col as f32 * viewport.cell_width + x_offset,
         y: viewport.origin_y + screen_row as f32 * viewport.cell_height + y_offset,
-        width: placement.pixel_width as f32,
-        height: placement.pixel_height as f32,
+        width: display_width as f32,
+        height: display_height as f32,
         source_rect,
     })
 }
@@ -291,8 +373,13 @@ pub struct VirtualPlacement {
     pub placement_id: u32,
     pub columns: u32,
     pub rows: u32,
+    /// Raw source rectangle (`x=`/`y=`/`w=`/`h=`), resolved against
+    /// the image's current dimensions at render time like direct
+    /// placements.
     pub x: u32,
     pub y: u32,
+    pub width: u32,
+    pub height: u32,
 }
 
 /// Per-screen Kitty graphics state.

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -172,16 +172,20 @@ pub fn kitty_overlay_geometry(
         return None;
     }
 
+    // Normalized `[u0, v0, u1, v1]` (origin, end), the convention all
+    // three image shaders share.
     let source_rect = if image_width > 0
         && image_height > 0
         && placement.source_width > 0
         && placement.source_height > 0
     {
+        let image_width = image_width as f32;
+        let image_height = image_height as f32;
         [
-            placement.source_x as f32 / image_width as f32,
-            placement.source_y as f32 / image_height as f32,
-            placement.source_width as f32 / image_width as f32,
-            placement.source_height as f32 / image_height as f32,
+            placement.source_x as f32 / image_width,
+            placement.source_y as f32 / image_height,
+            (placement.source_x + placement.source_width) as f32 / image_width,
+            (placement.source_y + placement.source_height) as f32 / image_height,
         ]
     } else {
         [0.0, 0.0, 1.0, 1.0]

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -125,6 +125,81 @@ pub struct KittyPlacement {
     pub transmit_time: std::time::Instant,
 }
 
+/// On-screen quad for a direct kitty placement, in physical pixels.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KittyOverlayGeometry {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    /// Normalized source rectangle within the image texture.
+    pub source_rect: [f32; 4],
+}
+
+/// Viewport parameters for placement geometry: the panel content
+/// origin in physical pixels, the canonical cell stride the grid
+/// paints with, and the scroll state.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OverlayViewport {
+    pub cell_width: f32,
+    pub cell_height: f32,
+    pub origin_x: f32,
+    pub origin_y: f32,
+    pub history_size: i64,
+    pub display_offset: i64,
+    pub screen_lines: i64,
+}
+
+/// Compute where a direct kitty placement lands on screen.
+///
+/// The viewport cell stride must be the same one the grid paints
+/// with, so image position and text stay in lockstep. Returns `None`
+/// when the placement is fully outside the viewport; a partially
+/// visible placement keeps its full quad and the GPU clips it.
+pub fn kitty_overlay_geometry(
+    placement: &KittyPlacement,
+    image_width: usize,
+    image_height: usize,
+    viewport: &OverlayViewport,
+) -> Option<KittyOverlayGeometry> {
+    // dest_row is absolute (scrollback aware); the viewport top sits
+    // at history_size - display_offset, so scrolling up moves the
+    // placement down relative to the viewport.
+    let screen_row =
+        placement.dest_row - (viewport.history_size - viewport.display_offset);
+    let bottom_row = screen_row + placement.rows as i64;
+    if bottom_row <= 0 || screen_row >= viewport.screen_lines {
+        return None;
+    }
+
+    let source_rect = if image_width > 0
+        && image_height > 0
+        && placement.source_width > 0
+        && placement.source_height > 0
+    {
+        [
+            placement.source_x as f32 / image_width as f32,
+            placement.source_y as f32 / image_height as f32,
+            placement.source_width as f32 / image_width as f32,
+            placement.source_height as f32 / image_height as f32,
+        ]
+    } else {
+        [0.0, 0.0, 1.0, 1.0]
+    };
+
+    Some(KittyOverlayGeometry {
+        x: viewport.origin_x
+            + placement.dest_col as f32 * viewport.cell_width
+            + placement.cell_x_offset as f32,
+        y: viewport.origin_y
+            + screen_row as f32 * viewport.cell_height
+            + placement.cell_y_offset as f32,
+        width: placement.pixel_width as f32,
+        height: placement.pixel_height as f32,
+        source_rect,
+    })
+}
+
 /// Virtual placement metadata for Kitty graphics protocol
 /// Stored separately from direct graphics in cells
 #[derive(Debug, Clone, PartialEq)]

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -185,17 +185,19 @@ impl KittyPlacement {
         }
         self.pixel_width = w as u32;
         self.pixel_height = h as u32;
-        self.cell_x_offset = self.cell_x_offset.min(cell_width as u32 - 1);
-        self.cell_y_offset = self.cell_y_offset.min(cell_height as u32 - 1);
+        // Offsets are stored raw and clamped where they're read, so a
+        // shrink-then-grow of the cell size can't lose the original.
+        let x_offset = (self.cell_x_offset as usize).min(cell_width - 1);
+        let y_offset = (self.cell_y_offset as usize).min(cell_height - 1);
         self.columns = if self.requested_columns > 0 {
             self.requested_columns
         } else {
-            (w + self.cell_x_offset as usize).div_ceil(cell_width) as u32
+            (w + x_offset).div_ceil(cell_width) as u32
         };
         self.rows = if self.requested_rows > 0 {
             self.requested_rows
         } else {
-            (h + self.cell_y_offset as usize).div_ceil(cell_height) as u32
+            (h + y_offset).div_ceil(cell_height) as u32
         };
     }
 }
@@ -266,13 +268,15 @@ pub fn kitty_overlay_geometry(
         [0.0, 0.0, 1.0, 1.0]
     };
 
+    // Per the kitty spec the sub-cell offset stays inside the cell
+    // box; stored values are raw, so clamp against the current cell
+    // size here.
+    let x_offset = (placement.cell_x_offset as f32).min(viewport.cell_width - 1.0);
+    let y_offset = (placement.cell_y_offset as f32).min(viewport.cell_height - 1.0);
+
     Some(KittyOverlayGeometry {
-        x: viewport.origin_x
-            + placement.dest_col as f32 * viewport.cell_width
-            + placement.cell_x_offset as f32,
-        y: viewport.origin_y
-            + screen_row as f32 * viewport.cell_height
-            + placement.cell_y_offset as f32,
+        x: viewport.origin_x + placement.dest_col as f32 * viewport.cell_width + x_offset,
+        y: viewport.origin_y + screen_row as f32 * viewport.cell_height + y_offset,
         width: placement.pixel_width as f32,
         height: placement.pixel_height as f32,
         source_rect,

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -113,6 +113,12 @@ pub struct KittyPlacement {
     /// Display size in cells.
     pub columns: u32,
     pub rows: u32,
+    /// The `c=`/`r=` span the client requested (0 = derived). Kept
+    /// separate from `columns`/`rows` so a cell size change can tell
+    /// cell-sized placements (which track the grid) apart from
+    /// native-size ones (which keep their pixel size).
+    pub requested_columns: u32,
+    pub requested_rows: u32,
     /// Actual display pixel dimensions.
     pub pixel_width: u32,
     pub pixel_height: u32,
@@ -123,6 +129,75 @@ pub struct KittyPlacement {
     pub z_index: i32,
     /// Transmission timestamp for cache invalidation.
     pub transmit_time: std::time::Instant,
+}
+
+/// Display pixel size for a kitty placement: the source rectangle
+/// scaled to the requested cell span, keeping aspect when only one
+/// axis is given, or shown at native size when no span is requested.
+pub fn kitty_display_size(
+    source_width: usize,
+    source_height: usize,
+    requested_columns: u32,
+    requested_rows: u32,
+    cell_width: usize,
+    cell_height: usize,
+) -> (usize, usize) {
+    if source_width == 0 || source_height == 0 {
+        return (0, 0);
+    }
+    match (requested_columns, requested_rows) {
+        (0, 0) => (source_width, source_height),
+        (c, 0) => {
+            let w = c as usize * cell_width;
+            let h =
+                (source_height as f64 * w as f64 / source_width as f64).round() as usize;
+            (w, h)
+        }
+        (0, r) => {
+            let h = r as usize * cell_height;
+            let w =
+                (source_width as f64 * h as f64 / source_height as f64).round() as usize;
+            (w, h)
+        }
+        (c, r) => (c as usize * cell_width, r as usize * cell_height),
+    }
+}
+
+impl KittyPlacement {
+    /// Recompute display size, cell span, and offset clamps for a new
+    /// cell size. Cell-sized placements track the grid; native-size
+    /// ones keep their pixel dimensions but re-derive how many cells
+    /// they cover.
+    pub fn rescale(&mut self, cell_width: usize, cell_height: usize) {
+        if cell_width == 0 || cell_height == 0 {
+            return;
+        }
+        let (w, h) = kitty_display_size(
+            self.source_width as usize,
+            self.source_height as usize,
+            self.requested_columns,
+            self.requested_rows,
+            cell_width,
+            cell_height,
+        );
+        if w == 0 || h == 0 {
+            return;
+        }
+        self.pixel_width = w as u32;
+        self.pixel_height = h as u32;
+        self.cell_x_offset = self.cell_x_offset.min(cell_width as u32 - 1);
+        self.cell_y_offset = self.cell_y_offset.min(cell_height as u32 - 1);
+        self.columns = if self.requested_columns > 0 {
+            self.requested_columns
+        } else {
+            (w + self.cell_x_offset as usize).div_ceil(cell_width) as u32
+        };
+        self.rows = if self.requested_rows > 0 {
+            self.requested_rows
+        } else {
+            (h + self.cell_y_offset as usize).div_ceil(cell_height) as u32
+        };
+    }
 }
 
 /// On-screen quad for a direct kitty placement, in physical pixels.

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -123,7 +123,8 @@ pub struct KittyPlacement {
     /// native-size ones (which keep their pixel size).
     pub requested_columns: u32,
     pub requested_rows: u32,
-    /// Actual display pixel dimensions.
+    /// Cached display pixel size for grid footprint bookkeeping. The
+    /// render path resolves size per frame and never reads these.
     pub pixel_width: u32,
     pub pixel_height: u32,
     /// Sub-cell pixel offset.

--- a/rio-backend/src/ansi/kitty_virtual.rs
+++ b/rio-backend/src/ansi/kitty_virtual.rs
@@ -560,6 +560,7 @@ pub fn compute_run_geometry(
     placement_rows: u32,
     image_width_px: u32,
     image_height_px: u32,
+    source_rect_px: (u32, u32, u32, u32),
     cell_width: f32,
     cell_height: f32,
     origin_x: f32,
@@ -569,18 +570,32 @@ pub fn compute_run_geometry(
 ) -> Option<RunGeometry> {
     let img_w = image_width_px as f32;
     let img_h = image_height_px as f32;
-    if img_w <= 0.0 || img_h <= 0.0 {
-        return None;
-    }
+
+    // Resolve the placement's raw source rectangle against the
+    // image's current dimensions; what gets fitted into the
+    // placement box is the crop, not the whole image. A full-image
+    // crop (the common case) leaves the math identical.
+    let (crop_x, crop_y, crop_w, crop_h) = crate::ansi::graphics::resolve_source_rect(
+        source_rect_px.0,
+        source_rect_px.1,
+        source_rect_px.2,
+        source_rect_px.3,
+        image_width_px as usize,
+        image_height_px as usize,
+    )?;
+    let crop_x = crop_x as f32;
+    let crop_y = crop_y as f32;
+    let crop_w = crop_w as f32;
+    let crop_h = crop_h as f32;
 
     // 1. Placement box in pixels.
     let p_cols_px = placement_cols.max(1) as f32 * cell_width;
     let p_rows_px = placement_rows.max(1) as f32 * cell_height;
 
     // 2. Aspect-fit + centering.
-    let scale = (p_cols_px / img_w).min(p_rows_px / img_h);
-    let fit_w = img_w * scale;
-    let fit_h = img_h * scale;
+    let scale = (p_cols_px / crop_w).min(p_rows_px / crop_h);
+    let fit_w = crop_w * scale;
+    let fit_h = crop_h * scale;
     let pad_x = (p_cols_px - fit_w) * 0.5;
     let pad_y = (p_rows_px - fit_h) * 0.5;
 
@@ -604,11 +619,13 @@ pub fn compute_run_geometry(
         return None;
     }
 
-    // 5. Source rect (normalised) and screen position.
-    let src_u0 = (vis_x0 - img_box_x0) / fit_w;
-    let src_v0 = (vis_y0 - img_box_y0) / fit_h;
-    let src_u1 = (vis_x1 - img_box_x0) / fit_w;
-    let src_v1 = (vis_y1 - img_box_y0) / fit_h;
+    // 5. Source rect (normalised) and screen position. The fitted
+    // fractions live in crop space; map them into full-image texture
+    // coordinates.
+    let src_u0 = (crop_x + (vis_x0 - img_box_x0) / fit_w * crop_w) / img_w;
+    let src_v0 = (crop_y + (vis_y0 - img_box_y0) / fit_h * crop_h) / img_h;
+    let src_u1 = (crop_x + (vis_x1 - img_box_x0) / fit_w * crop_w) / img_w;
+    let src_v1 = (crop_y + (vis_y1 - img_box_y0) / fit_h * crop_h) / img_h;
 
     let intra_x = vis_x0 - run_box_x;
     let intra_y = vis_y0 - run_box_y;
@@ -864,6 +881,7 @@ mod tests {
             5,
             100,
             50,
+            (0, 0, 0, 0),
             10.0,
             10.0,
             0.0,
@@ -897,6 +915,7 @@ mod tests {
             10,
             50,
             100,
+            (0, 0, 0, 0),
             10.0,
             10.0,
             0.0,
@@ -915,6 +934,7 @@ mod tests {
             10,
             50,
             100,
+            (0, 0, 0, 0),
             10.0,
             10.0,
             0.0,
@@ -952,6 +972,7 @@ mod tests {
             10,
             200,
             50,
+            (0, 0, 0, 0),
             10.0,
             10.0,
             0.0,
@@ -968,6 +989,7 @@ mod tests {
             10,
             200,
             50,
+            (0, 0, 0, 0),
             10.0,
             10.0,
             0.0,
@@ -1004,6 +1026,7 @@ mod tests {
             10,
             100,
             100,
+            (0, 0, 0, 0),
             10.0,
             10.0,
             0.0,
@@ -1031,6 +1054,7 @@ mod tests {
             5,
             100,
             50,
+            (0, 0, 0, 0),
             10.0,
             10.0,
             100.0,
@@ -1055,6 +1079,7 @@ mod tests {
             5,
             100,
             50,
+            (0, 0, 0, 0),
             10.0,
             10.0,
             0.0,
@@ -1069,8 +1094,20 @@ mod tests {
 
     #[test]
     fn geom_returns_none_when_image_zero_sized() {
-        let none =
-            compute_run_geometry(&run(0, 0, 1), 10, 5, 0, 50, 10.0, 10.0, 0.0, 0.0, 0, 0);
+        let none = compute_run_geometry(
+            &run(0, 0, 1),
+            10,
+            5,
+            0,
+            50,
+            (0, 0, 0, 0),
+            10.0,
+            10.0,
+            0.0,
+            0.0,
+            0,
+            0,
+        );
         assert!(none.is_none());
     }
 

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -732,8 +732,8 @@ impl<U: EventListener> Crosswords<U> {
                 || self.graphics.cell_height != size.square_height()
             {
                 self.graphics.resize(&size);
-                let cell_w = self.graphics.cell_width as usize;
-                let cell_h = self.graphics.cell_height as usize;
+                let cell_w = self.graphics.cell_width.round() as usize;
+                let cell_h = self.graphics.cell_height.round() as usize;
                 if cell_w > 0 && cell_h > 0 {
                     for p in self.graphics.kitty_placements.values_mut() {
                         let (iw, ih) = self
@@ -846,8 +846,8 @@ impl<U: EventListener> Crosswords<U> {
         // dimensions), and shift dest_row to follow the text. Active
         // and inactive screens both get the treatment so alt-screen
         // images aren't stale on swap-back.
-        let cell_w = self.graphics.cell_width as usize;
-        let cell_h = self.graphics.cell_height as usize;
+        let cell_w = self.graphics.cell_width.round() as usize;
+        let cell_h = self.graphics.cell_height.round() as usize;
         let mut overlay_changed = false;
         if cell_w > 0 && cell_h > 0 {
             for p in self.graphics.kitty_placements.values_mut() {
@@ -3911,13 +3911,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
         self.graphics.store_kitty_image(image_id, None, graphic);
 
         if let Some(pixel_data) = pixel_data {
-            let cell_w = self.graphics.cell_width as usize;
-            let cell_h = self.graphics.cell_height as usize;
-            for ((id, _), p) in self.graphics.kitty_placements.iter_mut() {
-                if *id == image_id {
-                    p.rescale(image_width, image_height, cell_w, cell_h);
-                }
-            }
+            self.refresh_placements_for_image(image_id, image_width, image_height);
             self.graphics.pending_images.push((image_id, pixel_data));
             self.graphics.kitty_graphics_dirty = true;
             self.send_graphics_updates();
@@ -3943,10 +3937,17 @@ impl<U: EventListener> Handler for Crosswords<U> {
         // `pending_images`, so we have to do that here — otherwise the
         // GPU never sees the pixel data and the placeholder cells render
         // as blank space.
+        // Like the a=t path, a retransmission with live direct
+        // placements of this id must refresh their grid footprint
+        // against the new dimensions.
+        let image_width = graphic_data.width;
+        let image_height = graphic_data.height;
+
         if placement.virtual_placement {
             let pixel_data = graphic_data.clone();
             self.graphics
                 .store_kitty_image(image_id, None, graphic_data);
+            self.refresh_placements_for_image(image_id, image_width, image_height);
             self.graphics.pending_images.push((image_id, pixel_data));
             self.graphics.kitty_graphics_dirty = true;
             self.send_graphics_updates();
@@ -3957,6 +3958,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
         // Store takes ownership and sets transmit_time.
         self.graphics
             .store_kitty_image(image_id, None, graphic_data);
+        self.refresh_placements_for_image(image_id, image_width, image_height);
 
         // Place as overlay — handles GPU upload internally.
         self.place_kitty_overlay(image_id, &placement);
@@ -4470,8 +4472,8 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
 
-        let cell_width = self.graphics.cell_width as usize;
-        let cell_height = self.graphics.cell_height as usize;
+        let cell_width = self.graphics.cell_width.round() as usize;
+        let cell_height = self.graphics.cell_height.round() as usize;
 
         if cell_width == 0 || cell_height == 0 {
             return;
@@ -4636,6 +4638,23 @@ impl<U: EventListener> Crosswords<U> {
         }
     }
 
+    /// Refresh the grid footprint of every live placement of an image
+    /// after its pixel data changed dimensions.
+    pub fn refresh_placements_for_image(
+        &mut self,
+        image_id: u32,
+        image_width: usize,
+        image_height: usize,
+    ) {
+        let cell_w = self.graphics.cell_width.round() as usize;
+        let cell_h = self.graphics.cell_height.round() as usize;
+        for ((id, _), p) in self.graphics.kitty_placements.iter_mut() {
+            if *id == image_id {
+                p.rescale(image_width, image_height, cell_w, cell_h);
+            }
+        }
+    }
+
     /// Move the cursor past a placement (`C=0`): linefeed once per
     /// occupied row so the whole image scrolls into view, then land on
     /// the image's last row at the first column after it, clamped to
@@ -4658,6 +4677,10 @@ impl<U: EventListener> Crosswords<U> {
         }
         let col = (dest_col + columns as usize).min(self.grid.columns() - 1);
         self.grid.cursor.pos.col = Column(col);
+        // Any cursor repositioning discards a pending wrap, otherwise
+        // the next printed character wraps a row below the intended
+        // caption position.
+        self.grid.cursor.should_wrap = false;
     }
 
     /// Register a virtual placement (kitty graphics `a=p,U=1`).

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -736,7 +736,13 @@ impl<U: EventListener> Crosswords<U> {
                 let cell_h = self.graphics.cell_height as usize;
                 if cell_w > 0 && cell_h > 0 {
                     for p in self.graphics.kitty_placements.values_mut() {
-                        p.rescale(cell_w, cell_h);
+                        let (iw, ih) = self
+                            .graphics
+                            .kitty_images
+                            .get(&p.image_id)
+                            .map(|s| (s.data.width, s.data.height))
+                            .unwrap_or((0, 0));
+                        p.rescale(iw, ih, cell_w, cell_h);
                     }
                     for p in self
                         .graphics
@@ -744,7 +750,14 @@ impl<U: EventListener> Crosswords<U> {
                         .kitty_placements
                         .values_mut()
                     {
-                        p.rescale(cell_w, cell_h);
+                        let (iw, ih) = self
+                            .graphics
+                            .kitty_inactive_screen
+                            .kitty_images
+                            .get(&p.image_id)
+                            .map(|s| (s.data.width, s.data.height))
+                            .unwrap_or((0, 0));
+                        p.rescale(iw, ih, cell_w, cell_h);
                     }
                     if !self.graphics.kitty_placements.is_empty()
                         || !self
@@ -838,7 +851,13 @@ impl<U: EventListener> Crosswords<U> {
         let mut overlay_changed = false;
         if cell_w > 0 && cell_h > 0 {
             for p in self.graphics.kitty_placements.values_mut() {
-                p.rescale(cell_w, cell_h);
+                let (iw, ih) = self
+                    .graphics
+                    .kitty_images
+                    .get(&p.image_id)
+                    .map(|s| (s.data.width, s.data.height))
+                    .unwrap_or((0, 0));
+                p.rescale(iw, ih, cell_w, cell_h);
                 if dest_row_shift != 0 {
                     p.dest_row += dest_row_shift;
                 }
@@ -849,7 +868,14 @@ impl<U: EventListener> Crosswords<U> {
                 .kitty_placements
                 .values_mut()
             {
-                p.rescale(cell_w, cell_h);
+                let (iw, ih) = self
+                    .graphics
+                    .kitty_inactive_screen
+                    .kitty_images
+                    .get(&p.image_id)
+                    .map(|s| (s.data.width, s.data.height))
+                    .unwrap_or((0, 0));
+                p.rescale(iw, ih, cell_w, cell_h);
                 if dest_row_shift != 0 {
                     p.dest_row += dest_row_shift;
                 }
@@ -3871,7 +3897,31 @@ impl<U: EventListener> Handler for Crosswords<U> {
             "Storing kitty graphic: id={}, {}x{}",
             image_id, graphic.width, graphic.height
         );
+        // Retransmission of an id with live placements: refresh their
+        // grid footprint against the new dimensions and push the new
+        // pixels so the display updates without a re-place.
+        let has_placements = self
+            .graphics
+            .kitty_placements
+            .keys()
+            .any(|(id, _)| *id == image_id);
+        let image_width = graphic.width;
+        let image_height = graphic.height;
+        let pixel_data = has_placements.then(|| graphic.clone());
         self.graphics.store_kitty_image(image_id, None, graphic);
+
+        if let Some(pixel_data) = pixel_data {
+            let cell_w = self.graphics.cell_width as usize;
+            let cell_h = self.graphics.cell_height as usize;
+            for ((id, _), p) in self.graphics.kitty_placements.iter_mut() {
+                if *id == image_id {
+                    p.rescale(image_width, image_height, cell_w, cell_h);
+                }
+            }
+            self.graphics.pending_images.push((image_id, pixel_data));
+            self.graphics.kitty_graphics_dirty = true;
+            self.send_graphics_updates();
+        }
     }
 
     fn kitty_transmit_and_display(
@@ -4420,26 +4470,6 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
 
-        // Resolve the source rectangle (kitty `x=`/`y=`/`w=`/`h=`)
-        // against the image. Zero width/height means "to the image
-        // edge". The crop is what gets displayed; it never affects
-        // where the placement lands.
-        let source_x = (placement.x as usize).min(image_width);
-        let source_y = (placement.y as usize).min(image_height);
-        let source_width = if placement.width > 0 {
-            (placement.width as usize).min(image_width - source_x)
-        } else {
-            image_width - source_x
-        };
-        let source_height = if placement.height > 0 {
-            (placement.height as usize).min(image_height - source_y)
-        } else {
-            image_height - source_y
-        };
-        if source_width == 0 || source_height == 0 {
-            return;
-        }
-
         let cell_width = self.graphics.cell_width as usize;
         let cell_height = self.graphics.cell_height as usize;
 
@@ -4447,18 +4477,36 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
 
-        let (display_w, display_h) = crate::ansi::graphics::kitty_display_size(
-            source_width,
-            source_height,
-            placement.columns,
-            placement.rows,
-            cell_width,
-            cell_height,
-        );
+        // Resolve the source rectangle (kitty `x=`/`y=`/`w=`/`h=`)
+        // against the image. The crop is what gets displayed; it
+        // never affects where the placement lands. Both crop and
+        // display size are re-resolved at render time, so these
+        // values only drive the grid footprint (spans and cursor
+        // movement). A crop fully outside the image still stores the
+        // placement — it renders nothing and occupies no cells, and
+        // can become visible after a retransmission with larger
+        // dimensions.
+        let (display_w, display_h) = match crate::ansi::graphics::resolve_source_rect(
+            placement.x,
+            placement.y,
+            placement.width,
+            placement.height,
+            image_width,
+            image_height,
+        ) {
+            Some((_, _, source_width, source_height)) => {
+                crate::ansi::graphics::kitty_display_size(
+                    source_width,
+                    source_height,
+                    placement.columns,
+                    placement.rows,
+                    cell_width,
+                    cell_height,
+                )
+            }
+            None => (0, 0),
+        };
 
-        if display_w == 0 || display_h == 0 {
-            return;
-        }
         if display_w > MAX_GRAPHIC_DIMENSIONS[0] || display_h > MAX_GRAPHIC_DIMENSIONS[1]
         {
             return;
@@ -4498,16 +4546,22 @@ impl<U: EventListener> Crosswords<U> {
         // the trick is the sub-cell offset shifts the image
         // within its first cell, so it can spill into one extra
         // row/column. Include it so cursor movement and row occupation
-        // cover the full image.
-        let columns = if placement.columns > 0 {
-            placement.columns
+        // cover the full image. An invisible placement (degenerate
+        // crop) occupies no cells at all.
+        let (columns, rows) = if display_w == 0 || display_h == 0 {
+            (0, 0)
         } else {
-            (display_w + cell_x_offset).div_ceil(cell_width) as u32
-        };
-        let rows = if placement.rows > 0 {
-            placement.rows
-        } else {
-            (display_h + cell_y_offset).div_ceil(cell_height) as u32
+            let columns = if placement.columns > 0 {
+                placement.columns
+            } else {
+                (display_w + cell_x_offset).div_ceil(cell_width) as u32
+            };
+            let rows = if placement.rows > 0 {
+                placement.rows
+            } else {
+                (display_h + cell_y_offset).div_ceil(cell_height) as u32
+            };
+            (columns, rows)
         };
 
         // Create overlay placement.
@@ -4526,10 +4580,10 @@ impl<U: EventListener> Crosswords<U> {
         let kitty_placement = KittyPlacement {
             image_id,
             placement_id,
-            source_x: source_x as u32,
-            source_y: source_y as u32,
-            source_width: source_width as u32,
-            source_height: source_height as u32,
+            source_x: placement.x,
+            source_y: placement.y,
+            source_width: placement.width,
+            source_height: placement.height,
             dest_col,
             dest_row,
             columns,
@@ -4570,24 +4624,40 @@ impl<U: EventListener> Crosswords<U> {
         match placement.cursor_movement {
             0 => {
                 // C=0: Move cursor to after the image
-                let rows_to_advance = rows.saturating_sub(1) as usize;
-                for _ in 0..rows_to_advance {
-                    self.linefeed();
-                }
-                self.carriage_return();
+                self.advance_cursor_past_placement(dest_col, columns, rows);
             }
             1 => {
                 // C=1: Don't move cursor
             }
             _ => {
                 // Default: treat as C=0
-                let rows_to_advance = rows.saturating_sub(1) as usize;
-                for _ in 0..rows_to_advance {
-                    self.linefeed();
-                }
-                self.carriage_return();
+                self.advance_cursor_past_placement(dest_col, columns, rows);
             }
         }
+    }
+
+    /// Move the cursor past a placement (`C=0`): linefeed once per
+    /// occupied row so the whole image scrolls into view, then land on
+    /// the image's last row at the first column after it, clamped to
+    /// the grid edge. An invisible placement (zero span) leaves the
+    /// cursor untouched.
+    fn advance_cursor_past_placement(
+        &mut self,
+        dest_col: usize,
+        columns: u32,
+        rows: u32,
+    ) {
+        if rows == 0 {
+            return;
+        }
+        for _ in 0..rows {
+            self.linefeed();
+        }
+        if self.grid.cursor.pos.row.0 > 0 {
+            self.grid.cursor.pos.row -= 1;
+        }
+        let col = (dest_col + columns as usize).min(self.grid.columns() - 1);
+        self.grid.cursor.pos.col = Column(col);
     }
 
     /// Register a virtual placement (kitty graphics `a=p,U=1`).
@@ -4618,6 +4688,8 @@ impl<U: EventListener> Crosswords<U> {
             rows: placement.rows,
             x: placement.x,
             y: placement.y,
+            width: placement.width,
+            height: placement.height,
         };
         self.graphics
             .kitty_virtual_placements

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -4390,22 +4390,30 @@ impl<U: EventListener> Crosswords<U> {
         };
         let mut graphic_data = stored.data.clone();
 
-        // Apply resize from placement parameters
-        if placement.columns > 0 || placement.rows > 0 {
-            let both_specified = placement.columns > 0 && placement.rows > 0;
-            graphic_data.resize = Some(sugarloaf::ResizeCommand {
-                width: if placement.columns > 0 {
-                    sugarloaf::ResizeParameter::Cells(placement.columns)
-                } else {
-                    sugarloaf::ResizeParameter::Auto
-                },
-                height: if placement.rows > 0 {
-                    sugarloaf::ResizeParameter::Cells(placement.rows)
-                } else {
-                    sugarloaf::ResizeParameter::Auto
-                },
-                preserve_aspect_ratio: !both_specified,
-            });
+        let image_width = graphic_data.width;
+        let image_height = graphic_data.height;
+        if image_width == 0 || image_height == 0 {
+            return;
+        }
+
+        // Resolve the source rectangle (kitty `x=`/`y=`/`w=`/`h=`)
+        // against the image. Zero width/height means "to the image
+        // edge". The crop is what gets displayed; it never affects
+        // where the placement lands.
+        let source_x = (placement.x as usize).min(image_width);
+        let source_y = (placement.y as usize).min(image_height);
+        let source_width = if placement.width > 0 {
+            (placement.width as usize).min(image_width - source_x)
+        } else {
+            image_width - source_x
+        };
+        let source_height = if placement.height > 0 {
+            (placement.height as usize).min(image_height - source_y)
+        } else {
+            image_height - source_y
+        };
+        if source_width == 0 || source_height == 0 {
+            return;
         }
 
         let cell_width = self.graphics.cell_width as usize;
@@ -4415,15 +4423,25 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
 
-        // Compute display dimensions
-        let view_width = cell_width * self.grid.columns();
-        let view_height = cell_height * self.grid.screen_lines();
-        let (display_w, display_h) = graphic_data.compute_display_dimensions(
-            cell_width,
-            cell_height,
-            view_width,
-            view_height,
-        );
+        // Display size: the source rectangle scaled to the requested
+        // cell span (`c=`/`r=`), keeping aspect when only one axis is
+        // given, or shown at native size when no span is requested.
+        let (display_w, display_h) = match (placement.columns, placement.rows) {
+            (0, 0) => (source_width, source_height),
+            (c, 0) => {
+                let w = c as usize * cell_width;
+                let h = (source_height as f64 * w as f64 / source_width as f64).round()
+                    as usize;
+                (w, h)
+            }
+            (0, r) => {
+                let h = r as usize * cell_height;
+                let w = (source_width as f64 * h as f64 / source_height as f64).round()
+                    as usize;
+                (w, h)
+            }
+            (c, r) => (c as usize * cell_width, r as usize * cell_height),
+        };
 
         if display_w == 0 || display_h == 0 {
             return;
@@ -4447,17 +4465,11 @@ impl<U: EventListener> Crosswords<U> {
 
         // Memory is managed in store_kitty_image (eviction happens there)
 
-        // Compute cursor position for placement
-        let dest_col = if placement.x > 0 {
-            placement.x as usize
-        } else {
-            self.grid.cursor.pos.col.0
-        };
-        let cursor_row = if placement.y > 0 {
-            placement.y as i32
-        } else {
-            self.grid.cursor.pos.row.0
-        };
+        // Per the kitty spec a placement always renders at the cursor
+        // position; `x=`/`y=` select the source rectangle within the
+        // image, never the destination cell.
+        let dest_col = self.grid.cursor.pos.col.0;
+        let cursor_row = self.grid.cursor.pos.row.0;
         // Absolute row = history_size + screen-relative row
         let dest_row = self.history_size() as i64 + cursor_row as i64;
 
@@ -4500,10 +4512,10 @@ impl<U: EventListener> Crosswords<U> {
         let kitty_placement = KittyPlacement {
             image_id,
             placement_id,
-            source_x: placement.x,
-            source_y: placement.y,
-            source_width: placement.width,
-            source_height: placement.height,
+            source_x: source_x as u32,
+            source_y: source_y as u32,
+            source_width: source_width as u32,
+            source_height: source_height as u32,
             dest_col,
             dest_row,
             columns,

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -795,21 +795,17 @@ impl<U: EventListener> Crosswords<U> {
             self.history_size() as i64 + self.grid.cursor.pos.row.0 as i64;
         let dest_row_shift = post_resize_cursor_abs - pre_resize_cursor_abs;
 
-        // Recompute overlay placement pixel dimensions for new cell
-        // size, and shift dest_row to follow the text. Active and
-        // inactive screens both get the treatment so alt-screen
+        // Rescale overlay placements for the new cell size (cell-sized
+        // placements track the grid; native-size ones keep their pixel
+        // dimensions), and shift dest_row to follow the text. Active
+        // and inactive screens both get the treatment so alt-screen
         // images aren't stale on swap-back.
         let cell_w = self.graphics.cell_width as usize;
         let cell_h = self.graphics.cell_height as usize;
         let mut overlay_changed = false;
         if cell_w > 0 && cell_h > 0 {
             for p in self.graphics.kitty_placements.values_mut() {
-                if p.columns > 0 {
-                    p.pixel_width = (p.columns as usize * cell_w) as u32;
-                }
-                if p.rows > 0 {
-                    p.pixel_height = (p.rows as usize * cell_h) as u32;
-                }
+                p.rescale(cell_w, cell_h);
                 if dest_row_shift != 0 {
                     p.dest_row += dest_row_shift;
                 }
@@ -820,12 +816,7 @@ impl<U: EventListener> Crosswords<U> {
                 .kitty_placements
                 .values_mut()
             {
-                if p.columns > 0 {
-                    p.pixel_width = (p.columns as usize * cell_w) as u32;
-                }
-                if p.rows > 0 {
-                    p.pixel_height = (p.rows as usize * cell_h) as u32;
-                }
+                p.rescale(cell_w, cell_h);
                 if dest_row_shift != 0 {
                     p.dest_row += dest_row_shift;
                 }
@@ -4423,25 +4414,14 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
 
-        // Display size: the source rectangle scaled to the requested
-        // cell span (`c=`/`r=`), keeping aspect when only one axis is
-        // given, or shown at native size when no span is requested.
-        let (display_w, display_h) = match (placement.columns, placement.rows) {
-            (0, 0) => (source_width, source_height),
-            (c, 0) => {
-                let w = c as usize * cell_width;
-                let h = (source_height as f64 * w as f64 / source_width as f64).round()
-                    as usize;
-                (w, h)
-            }
-            (0, r) => {
-                let h = r as usize * cell_height;
-                let w = (source_width as f64 * h as f64 / source_height as f64).round()
-                    as usize;
-                (w, h)
-            }
-            (c, r) => (c as usize * cell_width, r as usize * cell_height),
-        };
+        let (display_w, display_h) = crate::ansi::graphics::kitty_display_size(
+            source_width,
+            source_height,
+            placement.columns,
+            placement.rows,
+            cell_width,
+            cell_height,
+        );
 
         if display_w == 0 || display_h == 0 {
             return;
@@ -4520,6 +4500,8 @@ impl<U: EventListener> Crosswords<U> {
             dest_row,
             columns,
             rows,
+            requested_columns: placement.columns,
+            requested_rows: placement.rows,
             pixel_width: display_w as u32,
             pixel_height: display_h as u32,
             cell_x_offset: cell_x_offset as u32,

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -724,6 +724,39 @@ impl<U: EventListener> Crosswords<U> {
         let num_lines = size.screen_lines();
 
         if old_cols == num_cols && old_lines == num_lines {
+            // Same grid, but the cell size may still have changed (a
+            // font or DPI change that kept cols/rows constant). Keep
+            // the graphics cell metrics and placements in sync so
+            // cell-sized images keep tracking the grid.
+            if self.graphics.cell_width != size.square_width()
+                || self.graphics.cell_height != size.square_height()
+            {
+                self.graphics.resize(&size);
+                let cell_w = self.graphics.cell_width as usize;
+                let cell_h = self.graphics.cell_height as usize;
+                if cell_w > 0 && cell_h > 0 {
+                    for p in self.graphics.kitty_placements.values_mut() {
+                        p.rescale(cell_w, cell_h);
+                    }
+                    for p in self
+                        .graphics
+                        .kitty_inactive_screen
+                        .kitty_placements
+                        .values_mut()
+                    {
+                        p.rescale(cell_w, cell_h);
+                    }
+                    if !self.graphics.kitty_placements.is_empty()
+                        || !self
+                            .graphics
+                            .kitty_inactive_screen
+                            .kitty_placements
+                            .is_empty()
+                    {
+                        self.graphics.kitty_graphics_dirty = true;
+                    }
+                }
+            }
             info!("Crosswords::resize dimensions unchanged");
             return;
         }
@@ -4454,8 +4487,9 @@ impl<U: EventListener> Crosswords<U> {
         let dest_row = self.history_size() as i64 + cursor_row as i64;
 
         // kitty spec the `X=`/`Y=` sub-cell offset must be smaller
-        // than the cell size; kitty clamps out-of-range values to the
-        // cell box
+        // than the cell size. The stored value stays raw (a later cell
+        // size change re-clamps at read time without losing the
+        // original); these clamped copies only drive span derivation.
         let cell_x_offset = (placement.cell_x_offset as usize).min(cell_width - 1);
         let cell_y_offset = (placement.cell_y_offset as usize).min(cell_height - 1);
 
@@ -4504,8 +4538,8 @@ impl<U: EventListener> Crosswords<U> {
             requested_rows: placement.rows,
             pixel_width: display_w as u32,
             pixel_height: display_h as u32,
-            cell_x_offset: cell_x_offset as u32,
-            cell_y_offset: cell_y_offset as u32,
+            cell_x_offset: placement.cell_x_offset,
+            cell_y_offset: placement.cell_y_offset,
             z_index: placement.z_index,
             transmit_time,
         };

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -5,6 +5,7 @@ use crate::ansi::graphics::KittyPlacement;
 use crate::ansi::kitty_graphics_protocol::{
     self, DeleteRequest, KittyGraphicsState, PlacementRequest,
 };
+use crate::crosswords::pos::Column;
 use crate::crosswords::Crosswords;
 use crate::event::{EventListener, RioEvent, WindowId};
 use crate::performer::handler::Handler;
@@ -4544,4 +4545,67 @@ fn test_virtual_run_geometry_honors_source_crop() {
     .expect("visible run");
     assert_eq!(g.source_rect[0], 0.0, "full-image left edge");
     assert_eq!(g.source_rect[1], 0.0, "crop origin maps to image top");
+}
+
+#[test]
+fn test_cursor_movement_clears_pending_wrap() {
+    let mut term = geometry_test_term();
+
+    // A character printed into the last column arms the wrap flag; a
+    // C=0 placement repositions the cursor and must disarm it, or the
+    // next printed character wraps below the intended position.
+    term.grid.cursor.pos.col = Column(79);
+    term.grid.cursor.should_wrap = true;
+
+    let mut placement = placement_request(14);
+    placement.cursor_movement = 0;
+    term.place_graphic(placement);
+
+    assert!(
+        !term.grid.cursor.should_wrap,
+        "cursor repositioning discards a pending wrap"
+    );
+}
+
+#[test]
+fn test_transmit_and_display_refreshes_sibling_placements() {
+    let mut term = geometry_test_term();
+
+    // Direct placement of the 100x100 image: 5 rows at 20px cells.
+    let mut placement = placement_request(15);
+    placement.cursor_movement = 1;
+    term.place_graphic(placement);
+    assert_eq!(
+        term.graphics.kitty_placements.get(&(1, 15)).unwrap().rows,
+        5
+    );
+
+    // a=T retransmit of the same id (new 100x200 pixels + a second
+    // placement): the first placement's footprint must follow the new
+    // dimensions like the a=t path.
+    let graphic = GraphicData {
+        id: GraphicId::new(1),
+        width: 100,
+        height: 200,
+        color_type: ColorType::Rgba,
+        pixels: vec![255u8; 100 * 200 * 4],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: std::time::Instant::now(),
+    };
+    let mut second = placement_request(16);
+    second.cursor_movement = 1;
+    term.kitty_transmit_and_display(graphic, second);
+
+    assert_eq!(
+        term.graphics.kitty_placements.get(&(1, 15)).unwrap().rows,
+        10,
+        "sibling placement footprint follows the retransmit"
+    );
+    assert_eq!(
+        term.graphics.kitty_placements.get(&(1, 16)).unwrap().rows,
+        10
+    );
 }

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -1300,6 +1300,8 @@ fn test_kitty_placement_insert_and_delete() {
         dest_row: 0,
         columns: 10,
         rows: 5,
+        requested_columns: 0,
+        requested_rows: 0,
         pixel_width: 100,
         pixel_height: 50,
         cell_x_offset: 0,
@@ -1333,6 +1335,8 @@ fn test_kitty_placement_delete_by_z_index() {
         dest_row: 0,
         columns: 1,
         rows: 1,
+        requested_columns: 0,
+        requested_rows: 0,
         pixel_width: 10,
         pixel_height: 10,
         cell_x_offset: 0,
@@ -1375,6 +1379,8 @@ fn test_collect_active_ids_includes_overlay_placements() {
         dest_row: 0,
         columns: 1,
         rows: 1,
+        requested_columns: 0,
+        requested_rows: 0,
         pixel_width: 10,
         pixel_height: 10,
         cell_x_offset: 0,
@@ -1430,6 +1436,8 @@ fn test_eviction_removes_dangling_placements() {
         dest_row: 0,
         columns: 1,
         rows: 1,
+        requested_columns: 0,
+        requested_rows: 0,
         pixel_width: 10,
         pixel_height: 10,
         cell_x_offset: 0,
@@ -1471,6 +1479,8 @@ fn make_test_placement(
         dest_row,
         columns,
         rows,
+        requested_columns: 0,
+        requested_rows: 0,
         pixel_width: columns * 10,
         pixel_height: rows * 20,
         cell_x_offset: 0,
@@ -4090,6 +4100,8 @@ fn test_overlay_geometry_scroll_and_pixel_position() {
         dest_row: 55,
         columns: 2,
         rows: 3,
+        requested_columns: 0,
+        requested_rows: 0,
         pixel_width: 25,
         pixel_height: 45,
         cell_x_offset: 3,
@@ -4148,6 +4160,8 @@ fn test_overlay_geometry_partial_visibility_and_full_source() {
         dest_row: 48,
         columns: 2,
         rows: 3,
+        requested_columns: 0,
+        requested_rows: 0,
         pixel_width: 20,
         pixel_height: 60,
         cell_x_offset: 0,
@@ -4174,4 +4188,55 @@ fn test_overlay_geometry_partial_visibility_and_full_source() {
 
     // Zero crop falls back to the full texture.
     assert_eq!(geometry.source_rect, [0.0, 0.0, 1.0, 1.0]);
+}
+
+#[test]
+fn test_rescale_keeps_native_size_and_tracks_cell_span() {
+    use crate::ansi::graphics::KittyPlacement;
+
+    // Native-size placement: 25x45 crop, 10x20 cells.
+    let mut native = KittyPlacement {
+        image_id: 1,
+        placement_id: 1,
+        source_x: 0,
+        source_y: 0,
+        source_width: 25,
+        source_height: 45,
+        dest_col: 0,
+        dest_row: 0,
+        columns: 3,
+        rows: 3,
+        requested_columns: 0,
+        requested_rows: 0,
+        pixel_width: 25,
+        pixel_height: 45,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
+        z_index: 0,
+        transmit_time: std::time::Instant::now(),
+    };
+
+    // Font grows to 12x24 cells: the image must NOT stretch to its
+    // cell box; only the derived span shrinks.
+    native.rescale(12, 24);
+    assert_eq!(native.pixel_width, 25, "native pixel size is kept");
+    assert_eq!(native.pixel_height, 45);
+    assert_eq!(native.columns, 3, "ceil(25 / 12)");
+    assert_eq!(native.rows, 2, "ceil(45 / 24)");
+
+    // Cell-sized placement (c=4, r=2) tracks the grid instead.
+    let mut cell_sized = KittyPlacement {
+        requested_columns: 4,
+        requested_rows: 2,
+        columns: 4,
+        rows: 2,
+        pixel_width: 40,
+        pixel_height: 40,
+        ..native.clone()
+    };
+    cell_sized.rescale(12, 24);
+    assert_eq!(cell_sized.pixel_width, 48);
+    assert_eq!(cell_sized.pixel_height, 48);
+    assert_eq!(cell_sized.columns, 4);
+    assert_eq!(cell_sized.rows, 2);
 }

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -4116,7 +4116,8 @@ fn test_overlay_geometry_scroll_and_pixel_position() {
     assert_eq!(geometry.y, 50.0 + 5.0 * 20.0 + 7.0);
     assert_eq!(geometry.width, 25.0);
     assert_eq!(geometry.height, 45.0);
-    assert_eq!(geometry.source_rect, [0.25, 0.25, 0.5, 0.5]);
+    // (origin, end): crop (50, 25)-(150, 75) of a 200x100 image.
+    assert_eq!(geometry.source_rect, [0.25, 0.25, 0.75, 0.75]);
 
     // At the live view (no scroll) the same placement is 25 rows above
     // the viewport and fully culled.

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -3946,3 +3946,231 @@ fn test_animation_action_surfaces_unsupported_response() {
     assert!(body.contains("EINVAL:unsupported action"));
     assert!(body.contains("i=1"));
 }
+
+// Placement geometry tests
+
+fn geometry_test_term() -> Crosswords<TestEventListener> {
+    let mut term: Crosswords<TestEventListener> = Crosswords::new(
+        crate::crosswords::CrosswordsSize::new(80, 24),
+        crate::ansi::CursorShape::Block,
+        TestEventListener,
+        unsafe { WindowId::dummy() },
+        0,
+        10_000,
+    );
+    term.graphics.cell_width = 10.0;
+    term.graphics.cell_height = 20.0;
+
+    let graphic = GraphicData {
+        id: GraphicId::new(1),
+        width: 100,
+        height: 100,
+        color_type: ColorType::Rgba,
+        pixels: vec![255u8; 100 * 100 * 4],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: std::time::Instant::now(),
+    };
+    term.store_graphic(graphic);
+    term
+}
+
+fn placement_request(placement_id: u32) -> PlacementRequest {
+    PlacementRequest {
+        image_id: 1,
+        placement_id,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        columns: 0,
+        rows: 0,
+        z_index: 0,
+        virtual_placement: false,
+        unicode_placeholder: 0,
+        cursor_movement: 1,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
+    }
+}
+
+#[test]
+fn test_source_crop_keeps_placement_at_cursor() {
+    let mut term = geometry_test_term();
+
+    // x=/y= select the source rectangle, never the destination cell.
+    let mut placement = placement_request(5);
+    placement.x = 30;
+    placement.y = 40;
+    term.place_graphic(placement);
+
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 5))
+        .expect("placement stored");
+    assert_eq!(stored.dest_col, 0, "placement lands at the cursor column");
+    assert_eq!(stored.dest_row, 0, "placement lands at the cursor row");
+    assert_eq!(stored.source_x, 30);
+    assert_eq!(stored.source_y, 40);
+    assert_eq!(stored.source_width, 70, "crop extends to the image edge");
+    assert_eq!(stored.source_height, 60);
+    assert_eq!(stored.pixel_width, 70, "native size shows only the crop");
+    assert_eq!(stored.pixel_height, 60);
+    assert_eq!(stored.columns, 7);
+    assert_eq!(stored.rows, 3);
+}
+
+#[test]
+fn test_source_crop_clamped_and_degenerate_dropped() {
+    let mut term = geometry_test_term();
+
+    // Crop wider than the image clamps to the edge.
+    let mut placement = placement_request(6);
+    placement.x = 90;
+    placement.width = 50;
+    term.place_graphic(placement);
+
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 6))
+        .expect("placement stored");
+    assert_eq!(stored.source_x, 90);
+    assert_eq!(stored.source_width, 10, "clamped to image width");
+    assert_eq!(stored.source_height, 100);
+
+    // A crop fully outside the image places nothing.
+    let mut placement = placement_request(7);
+    placement.y = 100;
+    term.place_graphic(placement);
+    assert!(
+        !term.graphics.kitty_placements.contains_key(&(1, 7)),
+        "degenerate crop must not store a placement"
+    );
+}
+
+#[test]
+fn test_crop_scaled_to_requested_columns() {
+    let mut term = geometry_test_term();
+
+    // 50x25 crop over c=10 columns: width = 10 cells * 10px, height
+    // keeps the crop aspect ratio.
+    let mut placement = placement_request(8);
+    placement.width = 50;
+    placement.height = 25;
+    placement.columns = 10;
+    term.place_graphic(placement);
+
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 8))
+        .expect("placement stored");
+    assert_eq!(stored.pixel_width, 100);
+    assert_eq!(stored.pixel_height, 50, "aspect follows the crop");
+    assert_eq!(stored.columns, 10);
+    assert_eq!(stored.rows, 3, "ceil(50 / 20)");
+}
+
+#[test]
+fn test_overlay_geometry_scroll_and_pixel_position() {
+    use crate::ansi::graphics::{kitty_overlay_geometry, OverlayViewport};
+
+    let placement = KittyPlacement {
+        image_id: 1,
+        placement_id: 1,
+        source_x: 50,
+        source_y: 25,
+        source_width: 100,
+        source_height: 50,
+        dest_col: 4,
+        dest_row: 55,
+        columns: 2,
+        rows: 3,
+        pixel_width: 25,
+        pixel_height: 45,
+        cell_x_offset: 3,
+        cell_y_offset: 7,
+        z_index: 0,
+        transmit_time: std::time::Instant::now(),
+    };
+
+    let viewport = OverlayViewport {
+        cell_width: 10.0,
+        cell_height: 20.0,
+        origin_x: 100.0,
+        origin_y: 50.0,
+        history_size: 80,
+        display_offset: 30,
+        screen_lines: 24,
+    };
+
+    // Scrolled back 30 rows into 80 rows of history: the absolute row
+    // 55 sits 5 rows below the viewport top (80 - 30).
+    let geometry = kitty_overlay_geometry(&placement, 200, 100, &viewport)
+        .expect("visible placement");
+    assert_eq!(geometry.x, 100.0 + 4.0 * 10.0 + 3.0);
+    assert_eq!(geometry.y, 50.0 + 5.0 * 20.0 + 7.0);
+    assert_eq!(geometry.width, 25.0);
+    assert_eq!(geometry.height, 45.0);
+    assert_eq!(geometry.source_rect, [0.25, 0.25, 0.5, 0.5]);
+
+    // At the live view (no scroll) the same placement is 25 rows above
+    // the viewport and fully culled.
+    let live = OverlayViewport {
+        display_offset: 0,
+        ..viewport
+    };
+    assert!(kitty_overlay_geometry(&placement, 200, 100, &live).is_none());
+
+    // One row past the bottom edge is culled too.
+    let mut below = placement.clone();
+    below.dest_row = 80 + 24;
+    assert!(kitty_overlay_geometry(&below, 200, 100, &live).is_none());
+}
+
+#[test]
+fn test_overlay_geometry_partial_visibility_and_full_source() {
+    use crate::ansi::graphics::{kitty_overlay_geometry, OverlayViewport};
+
+    let placement = KittyPlacement {
+        image_id: 1,
+        placement_id: 1,
+        source_x: 0,
+        source_y: 0,
+        source_width: 0,
+        source_height: 0,
+        dest_col: 0,
+        dest_row: 48,
+        columns: 2,
+        rows: 3,
+        pixel_width: 20,
+        pixel_height: 60,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
+        z_index: 0,
+        transmit_time: std::time::Instant::now(),
+    };
+
+    let viewport = OverlayViewport {
+        cell_width: 10.0,
+        cell_height: 20.0,
+        origin_x: 0.0,
+        origin_y: 0.0,
+        history_size: 50,
+        display_offset: 0,
+        screen_lines: 24,
+    };
+
+    // Two of three rows scrolled off the top: keep the quad with a
+    // negative y and let the GPU clip it.
+    let geometry = kitty_overlay_geometry(&placement, 20, 60, &viewport)
+        .expect("partially visible placement");
+    assert_eq!(geometry.y, -40.0);
+
+    // Zero crop falls back to the full texture.
+    assert_eq!(geometry.source_rect, [0.0, 0.0, 1.0, 1.0]);
+}

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -423,8 +423,11 @@ fn test_cursor_movement_default() {
     let final_cursor_row = term.grid.cursor.pos.row.0;
     let final_cursor_col = term.grid.cursor.pos.col.0;
 
-    // With cursor_movement=0 (Kitty default), cursor stays ON last row of image
-    // For a 2-row image starting at row 0 (occupies rows 0-1), cursor should be at row 1, col 0
+    // With cursor_movement=0 (Kitty default), the cursor ends on the
+    // image's last row at the first column after the image, so text
+    // printed next never overwrites the image. 2-row image at row 0
+    // occupies rows 0-1; r=2 with a 100x100 image in 10x20 cells gives
+    // a 40x40 display, i.e. 4 columns.
     assert_eq!(
         final_cursor_row, 1,
         "Cursor should be at row 1 (last row of image) with cursor_movement=0. Initial: {}, Final: {}",
@@ -432,8 +435,8 @@ fn test_cursor_movement_default() {
         final_cursor_row
     );
     assert_eq!(
-        final_cursor_col, 0,
-        "Cursor should be at column 0 after carriage return"
+        final_cursor_col, 4,
+        "Cursor should be at the first column after the image"
     );
 }
 
@@ -4027,21 +4030,32 @@ fn test_source_crop_keeps_placement_at_cursor() {
         .expect("placement stored");
     assert_eq!(stored.dest_col, 0, "placement lands at the cursor column");
     assert_eq!(stored.dest_row, 0, "placement lands at the cursor row");
-    assert_eq!(stored.source_x, 30);
+    assert_eq!(stored.source_x, 30, "crop is stored raw");
     assert_eq!(stored.source_y, 40);
-    assert_eq!(stored.source_width, 70, "crop extends to the image edge");
-    assert_eq!(stored.source_height, 60);
-    assert_eq!(stored.pixel_width, 70, "native size shows only the crop");
+    assert_eq!(stored.source_width, 0, "raw zero means to the edge");
+    assert_eq!(stored.source_height, 0);
+    assert_eq!(stored.pixel_width, 70, "footprint shows only the crop");
     assert_eq!(stored.pixel_height, 60);
     assert_eq!(stored.columns, 7);
     assert_eq!(stored.rows, 3);
 }
 
 #[test]
-fn test_source_crop_clamped_and_degenerate_dropped() {
-    let mut term = geometry_test_term();
+fn test_source_crop_clamped_and_degenerate_invisible() {
+    use crate::ansi::graphics::{kitty_overlay_geometry, OverlayViewport};
 
-    // Crop wider than the image clamps to the edge.
+    let mut term = geometry_test_term();
+    let viewport = OverlayViewport {
+        cell_width: 10.0,
+        cell_height: 20.0,
+        origin_x: 0.0,
+        origin_y: 0.0,
+        history_size: 0,
+        display_offset: 0,
+        screen_lines: 24,
+    };
+
+    // Crop wider than the image clamps to the edge at render time.
     let mut placement = placement_request(6);
     placement.x = 90;
     placement.width = 50;
@@ -4052,17 +4066,35 @@ fn test_source_crop_clamped_and_degenerate_dropped() {
         .kitty_placements
         .get(&(1, 6))
         .expect("placement stored");
-    assert_eq!(stored.source_x, 90);
-    assert_eq!(stored.source_width, 10, "clamped to image width");
-    assert_eq!(stored.source_height, 100);
+    assert_eq!(stored.source_x, 90, "raw request kept");
+    assert_eq!(stored.source_width, 50);
+    assert_eq!(stored.pixel_width, 10, "footprint uses the clamped crop");
+    assert_eq!(stored.pixel_height, 100);
+    let geometry = kitty_overlay_geometry(stored, 100, 100, &viewport).expect("visible");
+    assert_eq!(geometry.width, 10.0, "clamped to image width");
+    assert_eq!(geometry.source_rect, [0.9, 0.0, 1.0, 1.0]);
 
-    // A crop fully outside the image places nothing.
+    // A crop fully outside the image is stored (kitty answers OK) but
+    // renders nothing and occupies no cells.
     let mut placement = placement_request(7);
     placement.y = 100;
+    placement.cursor_movement = 0;
+    let cursor_before = term.grid.cursor.pos;
     term.place_graphic(placement);
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 7))
+        .expect("degenerate placement still stored");
+    assert_eq!(stored.columns, 0, "no cell footprint");
+    assert_eq!(stored.rows, 0);
     assert!(
-        !term.graphics.kitty_placements.contains_key(&(1, 7)),
-        "degenerate crop must not store a placement"
+        kitty_overlay_geometry(stored, 100, 100, &viewport).is_none(),
+        "degenerate crop renders nothing"
+    );
+    assert_eq!(
+        term.grid.cursor.pos, cursor_before,
+        "invisible placement leaves the cursor untouched"
     );
 }
 
@@ -4130,8 +4162,10 @@ fn test_overlay_geometry_scroll_and_pixel_position() {
         .expect("visible placement");
     assert_eq!(geometry.x, 100.0 + 4.0 * 10.0 + 3.0);
     assert_eq!(geometry.y, 50.0 + 5.0 * 20.0 + 7.0);
-    assert_eq!(geometry.width, 25.0);
-    assert_eq!(geometry.height, 45.0);
+    // Display size resolves per frame: no cell span requested, so the
+    // 100x50 crop shows at native size.
+    assert_eq!(geometry.width, 100.0);
+    assert_eq!(geometry.height, 50.0);
     // (origin, end): crop (50, 25)-(150, 75) of a 200x100 image.
     assert_eq!(geometry.source_rect, [0.25, 0.25, 0.75, 0.75]);
 
@@ -4222,7 +4256,7 @@ fn test_rescale_keeps_native_size_and_tracks_cell_span() {
 
     // Font grows to 12x24 cells: the image must NOT stretch to its
     // cell box; only the derived span shrinks.
-    native.rescale(12, 24);
+    native.rescale(25, 45, 12, 24);
     assert_eq!(native.pixel_width, 25, "native pixel size is kept");
     assert_eq!(native.pixel_height, 45);
     assert_eq!(native.columns, 3, "ceil(25 / 12)");
@@ -4238,7 +4272,7 @@ fn test_rescale_keeps_native_size_and_tracks_cell_span() {
         pixel_height: 40,
         ..native.clone()
     };
-    cell_sized.rescale(12, 24);
+    cell_sized.rescale(25, 45, 12, 24);
     assert_eq!(cell_sized.pixel_width, 48);
     assert_eq!(cell_sized.pixel_height, 48);
     assert_eq!(cell_sized.columns, 4);
@@ -4324,4 +4358,190 @@ fn test_overlay_geometry_clamps_raw_offsets() {
         kitty_overlay_geometry(&placement, 8, 8, &viewport).expect("visible placement");
     assert_eq!(geometry.x, 2.0 * 10.0 + 9.0, "offset clamped to cell box");
     assert_eq!(geometry.y, 19.0);
+}
+
+#[test]
+fn test_retransmit_reclamps_crop_and_updates_footprint() {
+    use crate::ansi::graphics::{kitty_overlay_geometry, OverlayViewport};
+
+    let mut term = geometry_test_term();
+    let viewport = OverlayViewport {
+        cell_width: 10.0,
+        cell_height: 20.0,
+        origin_x: 0.0,
+        origin_y: 0.0,
+        history_size: 0,
+        display_offset: 0,
+        screen_lines: 24,
+    };
+
+    // Crop the bottom half of the 100x100 image.
+    let mut placement = placement_request(11);
+    placement.y = 50;
+    term.place_graphic(placement);
+
+    let stored = term.graphics.kitty_placements.get(&(1, 11)).unwrap();
+    assert_eq!(stored.rows, 3, "ceil(50 / 20)");
+    let geometry = kitty_overlay_geometry(stored, 100, 100, &viewport).unwrap();
+    assert_eq!(geometry.height, 50.0);
+    assert_eq!(geometry.source_rect, [0.0, 0.5, 1.0, 1.0]);
+
+    // Retransmit the same id as 100x60: the crop re-resolves against
+    // the new dimensions instead of showing a stale region, and the
+    // grid footprint follows.
+    term.graphics.kitty_graphics_dirty = false;
+    let graphic = GraphicData {
+        id: GraphicId::new(1),
+        width: 100,
+        height: 60,
+        color_type: ColorType::Rgba,
+        pixels: vec![255u8; 100 * 60 * 4],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: std::time::Instant::now(),
+    };
+    term.store_graphic(graphic);
+
+    let stored = term.graphics.kitty_placements.get(&(1, 11)).unwrap();
+    assert_eq!(stored.pixel_height, 10, "60 - 50 remaining below the crop");
+    assert_eq!(stored.rows, 1);
+    let geometry = kitty_overlay_geometry(stored, 100, 60, &viewport).unwrap();
+    assert_eq!(geometry.height, 10.0);
+    let [_, v0, _, v1] = geometry.source_rect;
+    assert!((v0 - 50.0 / 60.0).abs() < 1e-6);
+    assert_eq!(v1, 1.0);
+
+    // The new pixels were dispatched for upload without a re-place
+    // (send_graphics_updates drains the queue into an event, so the
+    // dirty flag is the observable side).
+    assert!(term.graphics.kitty_graphics_dirty);
+}
+
+#[test]
+fn test_retransmit_can_make_degenerate_placement_visible() {
+    let mut term = geometry_test_term();
+
+    // Fully outside the 100x100 image: invisible, zero footprint.
+    let mut placement = placement_request(12);
+    placement.y = 100;
+    term.place_graphic(placement);
+    assert_eq!(
+        term.graphics.kitty_placements.get(&(1, 12)).unwrap().rows,
+        0
+    );
+
+    // Retransmit taller: the placement comes alive.
+    let graphic = GraphicData {
+        id: GraphicId::new(1),
+        width: 100,
+        height: 200,
+        color_type: ColorType::Rgba,
+        pixels: vec![255u8; 100 * 200 * 4],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: std::time::Instant::now(),
+    };
+    term.store_graphic(graphic);
+
+    let stored = term.graphics.kitty_placements.get(&(1, 12)).unwrap();
+    assert_eq!(stored.pixel_height, 100, "rows 100..200 of the new image");
+    assert_eq!(stored.rows, 5, "ceil(100 / 20)");
+}
+
+#[test]
+fn test_cursor_movement_scrolls_at_screen_bottom() {
+    let mut term = geometry_test_term();
+
+    // Park the cursor on the bottom row.
+    for _ in 0..23 {
+        term.linefeed();
+    }
+    assert_eq!(term.grid.cursor.pos.row.0, 23);
+
+    // 100x100 image in 10x20 cells: 5 rows, 10 columns.
+    let mut placement = placement_request(13);
+    placement.cursor_movement = 0;
+    term.place_graphic(placement);
+
+    // The image scrolled into view (5 linefeeds at the bottom) and the
+    // cursor sits on its last row, first column after it.
+    assert_eq!(term.grid.cursor.pos.row.0, 22);
+    assert_eq!(term.grid.cursor.pos.col.0, 10);
+    assert_eq!(term.history_size(), 5, "five rows scrolled into history");
+}
+
+#[test]
+fn test_virtual_run_geometry_honors_source_crop() {
+    use crate::ansi::kitty_virtual::{compute_run_geometry, PlaceholderRun};
+
+    let run = PlaceholderRun {
+        image_id: 1,
+        placement_id: 1,
+        row: 0,
+        col: 0,
+        width: 5,
+    };
+
+    // Right half of a 100x50 image (crop 50x50) into a 5x5 cell
+    // placement at 10x10 cells: the crop fits the 50x50 box exactly.
+    let g = compute_run_geometry(
+        &run,
+        5,
+        5,
+        100,
+        50,
+        (50, 0, 50, 50),
+        10.0,
+        10.0,
+        0.0,
+        0.0,
+        0,
+        0,
+    )
+    .expect("visible run");
+    assert_eq!(g.width, 50.0);
+    assert_eq!(g.height, 10.0, "one cell row");
+    // u spans the right half of the image; v the top fifth of the crop.
+    assert_eq!(g.source_rect, [0.5, 0.0, 1.0, 0.2]);
+
+    // Without a crop the full image aspect-fits with letterboxing;
+    // the top run sits entirely in the padding, while the second row
+    // maps to the full-image left edge.
+    assert!(compute_run_geometry(
+        &run,
+        5,
+        5,
+        100,
+        50,
+        (0, 0, 0, 0),
+        10.0,
+        10.0,
+        0.0,
+        0.0,
+        0,
+        0,
+    )
+    .is_none());
+    let second_row = PlaceholderRun { row: 1, ..run };
+    let g = compute_run_geometry(
+        &second_row,
+        5,
+        5,
+        100,
+        50,
+        (0, 0, 0, 0),
+        10.0,
+        10.0,
+        0.0,
+        0.0,
+        1,
+        0,
+    )
+    .expect("visible run");
+    assert_eq!(g.source_rect[0], 0.0, "full-image left edge");
+    assert_eq!(g.source_rect[1], 0.0, "crop origin maps to image top");
 }

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -676,8 +676,9 @@ fn test_subcell_offset_forwarded_and_clamped() {
     assert_eq!(stored.cell_x_offset, 7);
     assert_eq!(stored.cell_y_offset, 9);
 
-    // Per kitty spec the offset must be smaller than the cell size;
-    // out-of-range values are clamped to the cell box.
+    // Per kitty spec the offset must be smaller than the cell size.
+    // The stored value stays raw (re-clamped at read time so cell
+    // size changes don't lose it); span derivation uses the clamp.
     let placement = kitty_graphics_protocol::PlacementRequest {
         image_id: 1,
         placement_id: 8,
@@ -701,8 +702,11 @@ fn test_subcell_offset_forwarded_and_clamped() {
         .kitty_placements
         .get(&(1, 8))
         .expect("placement stored");
-    assert_eq!(stored.cell_x_offset, 9, "clamped to cell_width - 1");
-    assert_eq!(stored.cell_y_offset, 19, "clamped to cell_height - 1");
+    assert_eq!(stored.cell_x_offset, 999, "raw offset is kept");
+    assert_eq!(stored.cell_y_offset, 999);
+    // 40x40 image, 10x20 cells, offsets clamped to 9/19 for spans.
+    assert_eq!(stored.columns, 5, "ceil((40 + 9) / 10)");
+    assert_eq!(stored.rows, 3, "ceil((40 + 19) / 20)");
 }
 
 #[test]
@@ -4239,4 +4243,85 @@ fn test_rescale_keeps_native_size_and_tracks_cell_span() {
     assert_eq!(cell_sized.pixel_height, 48);
     assert_eq!(cell_sized.columns, 4);
     assert_eq!(cell_sized.rows, 2);
+}
+
+#[test]
+fn test_crop_scaled_to_requested_rows_and_both_axes() {
+    let mut term = geometry_test_term();
+
+    // r= only: height = 2 cells * 20px, width keeps the crop aspect.
+    let mut placement = placement_request(9);
+    placement.width = 50;
+    placement.height = 25;
+    placement.rows = 2;
+    term.place_graphic(placement);
+
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 9))
+        .expect("placement stored");
+    assert_eq!(stored.pixel_height, 40);
+    assert_eq!(stored.pixel_width, 80, "aspect follows the crop");
+    assert_eq!(stored.rows, 2);
+    assert_eq!(stored.columns, 8, "ceil(80 / 10)");
+
+    // c= and r= both: exact fit, aspect not preserved.
+    let mut placement = placement_request(10);
+    placement.width = 50;
+    placement.height = 25;
+    placement.columns = 3;
+    placement.rows = 4;
+    term.place_graphic(placement);
+
+    let stored = term
+        .graphics
+        .kitty_placements
+        .get(&(1, 10))
+        .expect("placement stored");
+    assert_eq!(stored.pixel_width, 30);
+    assert_eq!(stored.pixel_height, 80, "stretched to the exact span");
+    assert_eq!(stored.columns, 3);
+    assert_eq!(stored.rows, 4);
+}
+
+#[test]
+fn test_overlay_geometry_clamps_raw_offsets() {
+    use crate::ansi::graphics::{kitty_overlay_geometry, OverlayViewport};
+
+    // Raw offsets larger than the current cell box clamp at read
+    // time; the stored value survives cell size changes.
+    let placement = KittyPlacement {
+        image_id: 1,
+        placement_id: 1,
+        source_x: 0,
+        source_y: 0,
+        source_width: 0,
+        source_height: 0,
+        dest_col: 2,
+        dest_row: 0,
+        columns: 1,
+        rows: 1,
+        requested_columns: 0,
+        requested_rows: 0,
+        pixel_width: 8,
+        pixel_height: 8,
+        cell_x_offset: 999,
+        cell_y_offset: 999,
+        z_index: 0,
+        transmit_time: std::time::Instant::now(),
+    };
+    let viewport = OverlayViewport {
+        cell_width: 10.0,
+        cell_height: 20.0,
+        origin_x: 0.0,
+        origin_y: 0.0,
+        history_size: 0,
+        display_offset: 0,
+        screen_lines: 24,
+    };
+    let geometry =
+        kitty_overlay_geometry(&placement, 8, 8, &viewport).expect("visible placement");
+    assert_eq!(geometry.x, 2.0 * 10.0 + 9.0, "offset clamped to cell box");
+    assert_eq!(geometry.y, 19.0);
 }

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -303,12 +303,14 @@ pub fn render_cpu(
     text: &crate::text::Text,
     images: &ImageLayers,
 ) {
-    // Flatten and z-sort image overlays once; ties broken by image id
-    // and position so the paint order (and the frame hash) stays
-    // deterministic across frames.
+    // Flatten and z-sort image overlays once. The sort is stable and
+    // each panel's vec arrives ordered (z, image_id, placement_id)
+    // from the frontend, so equal keys keep their per-panel paint
+    // order. Never key on screen position: it changes with scroll,
+    // and f32 bit patterns don't order correctly once negative.
     let mut image_overlays: Vec<&GraphicOverlay> =
         images.overlays.values().flatten().collect();
-    image_overlays.sort_by_key(|o| (o.z_index, o.image_id, o.x.to_bits(), o.y.to_bits()));
+    image_overlays.sort_by_key(|o| (o.z_index, o.image_id));
 
     let vertices = renderer.vertices();
     let quad_instances = renderer.instances();

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -304,10 +304,11 @@ pub fn render_cpu(
     images: &ImageLayers,
 ) {
     // Flatten and z-sort image overlays once; ties broken by image id
-    // so the paint order (and the frame hash) stays deterministic.
+    // and position so the paint order (and the frame hash) stays
+    // deterministic across frames.
     let mut image_overlays: Vec<&GraphicOverlay> =
         images.overlays.values().flatten().collect();
-    image_overlays.sort_by_key(|o| (o.z_index, o.image_id));
+    image_overlays.sort_by_key(|o| (o.z_index, o.image_id, o.x.to_bits(), o.y.to_bits()));
 
     let vertices = renderer.vertices();
     let quad_instances = renderer.instances();
@@ -576,9 +577,11 @@ fn draw_image_overlays(
 /// Nearest-neighbor, alpha-blended blit of one image overlay.
 ///
 /// `source_rect` follows the shared shader convention: normalized
-/// `[u0, v0, u1, v1]` (origin, end) within the source image. Sampling
-/// happens at destination pixel centers, matching what the GPU
-/// backends rasterize for an axis-aligned quad.
+/// `[u0, v0, u1, v1]` (origin, end) within the source image. Sample
+/// positions sit at destination pixel centers like the GPU quad
+/// rasterization; the filter is nearest rather than the GPU sampler's
+/// bilinear, so scaled images are blockier here but land on exactly
+/// the same pixels (and identical ones at 1:1).
 #[allow(clippy::too_many_arguments)]
 pub fn draw_image_overlay(
     buf: &mut [u32],

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -5,16 +5,24 @@
 // Writes directly into softbuffer's `&mut [u32]` (0x00RRGGBB) — no
 // intermediate pixmap, no pixel format conversion at present time.
 //
-// v1 limitations: monochrome glyphs only (color-atlas glyphs / images
-// not implemented), no per-corner radii / borders / advanced underlines.
+// v1 limitations: monochrome glyphs only (color-atlas glyphs not
+// implemented), no per-corner radii / borders / advanced underlines.
+// Kitty image overlays composite via `draw_image_overlay`.
 
 use crate::context::cpu::CpuContext;
 use crate::renderer::compositor::Vertex;
 use crate::renderer::image_cache::ImageCache;
 use crate::renderer::Renderer;
+use crate::sugarloaf::graphics::{GraphicDataEntry, GraphicOverlay};
 use rustc_hash::FxHashMap;
 use std::hash::Hasher;
 use wide::{u32x4, u32x8};
+
+/// Image overlays and their pixel stores for a CPU frame.
+pub struct ImageLayers<'a> {
+    pub overlays: &'a FxHashMap<usize, Vec<GraphicOverlay>>,
+    pub data: &'a FxHashMap<u32, GraphicDataEntry>,
+}
 
 #[derive(Default)]
 pub struct CpuCache {
@@ -293,7 +301,14 @@ pub fn render_cpu(
     background: Option<crate::sugarloaf::Color>,
     grids: &mut [(&mut crate::grid::GridRenderer, crate::grid::GridUniforms)],
     text: &crate::text::Text,
+    images: &ImageLayers,
 ) {
+    // Flatten and z-sort image overlays once; ties broken by image id
+    // so the paint order (and the frame hash) stays deterministic.
+    let mut image_overlays: Vec<&GraphicOverlay> =
+        images.overlays.values().flatten().collect();
+    image_overlays.sort_by_key(|o| (o.z_index, o.image_id));
+
     let vertices = renderer.vertices();
     let quad_instances = renderer.instances();
     let text_instances = text.instances();
@@ -326,6 +341,23 @@ pub fn render_cpu(
             h.write(bytemuck::bytes_of(uniforms));
             if let crate::grid::GridRenderer::Cpu(cpu_grid) = &**grid {
                 cpu_grid.hash_state(&mut h);
+            }
+        }
+        // Image overlays: geometry plus the pixel store identity (a
+        // retransmitted image gets a fresh handle id).
+        h.write_usize(image_overlays.len());
+        for overlay in &image_overlays {
+            h.write_u32(overlay.image_id);
+            h.write_u32(overlay.x.to_bits());
+            h.write_u32(overlay.y.to_bits());
+            h.write_u32(overlay.width.to_bits());
+            h.write_u32(overlay.height.to_bits());
+            h.write_i32(overlay.z_index);
+            for v in overlay.source_rect {
+                h.write_u32(v.to_bits());
+            }
+            if let Some(entry) = images.data.get(&overlay.image_id) {
+                h.write_u64(entry.handle.id());
             }
         }
         // Text instances change per frame for any UI overlay
@@ -379,15 +411,28 @@ pub fn render_cpu(
 
     // Grid passes: paint each panel's terminal cells (bg + glyphs)
     // into the buffer before overlay vertices, so UI overlays
-    // composite on top. CPU backend doesn't handle kitty image layers
-    // (no image-overlay support on softbuffer), so the bg/text split
-    // here just runs back-to-back per panel.
+    // composite on top. Image overlays interleave with the passes the
+    // same way the GPU backends layer them: below-bg images first,
+    // then cell backgrounds, below-text images, glyphs, above-text
+    // images.
     {
+        use crate::renderer::IMAGE_BG_LIMIT;
         let buf_slice: &mut [u32] = &mut buffer;
+        let split_below_bg =
+            image_overlays.partition_point(|o| o.z_index < IMAGE_BG_LIMIT);
+        let split_below_text = image_overlays.partition_point(|o| o.z_index < 0);
+        let (below_bg, rest) = image_overlays.split_at(split_below_bg);
+        let (below_text, above_text) = rest.split_at(split_below_text - split_below_bg);
+
+        draw_image_overlays(buf_slice, buf_w, buf_h, below_bg, images.data);
         for (grid, uniforms) in grids.iter() {
             grid.render_bg_cpu(buf_slice, ctx.width_px, ctx.height_px, uniforms);
+        }
+        draw_image_overlays(buf_slice, buf_w, buf_h, below_text, images.data);
+        for (grid, uniforms) in grids.iter() {
             grid.render_text_cpu(buf_slice, ctx.width_px, ctx.height_px, uniforms);
         }
+        draw_image_overlays(buf_slice, buf_w, buf_h, above_text, images.data);
     }
 
     // QuadInstance pass: split borders, panel rects, scrollbar, dim
@@ -500,6 +545,109 @@ pub fn render_cpu(
 
     if let Err(e) = buffer.present() {
         tracing::error!("softbuffer present failed: {e}");
+    }
+}
+
+/// Draw a batch of image overlays into the buffer.
+fn draw_image_overlays(
+    buf: &mut [u32],
+    buf_w: i32,
+    buf_h: i32,
+    overlays: &[&GraphicOverlay],
+    data: &FxHashMap<u32, GraphicDataEntry>,
+) {
+    for overlay in overlays {
+        let entry = match data.get(&overlay.image_id) {
+            Some(e) => e,
+            None => continue,
+        };
+        let (width, height, pixels) = match &entry.handle.data {
+            crate::components::core::image::Data::Rgba {
+                width,
+                height,
+                pixels,
+            } => (*width, *height, pixels.as_ref()),
+            _ => continue,
+        };
+        draw_image_overlay(buf, buf_w, buf_h, overlay, width, height, pixels);
+    }
+}
+
+/// Nearest-neighbor, alpha-blended blit of one image overlay.
+///
+/// `source_rect` follows the shared shader convention: normalized
+/// `[u0, v0, u1, v1]` (origin, end) within the source image. Sampling
+/// happens at destination pixel centers, matching what the GPU
+/// backends rasterize for an axis-aligned quad.
+#[allow(clippy::too_many_arguments)]
+pub fn draw_image_overlay(
+    buf: &mut [u32],
+    buf_w: i32,
+    buf_h: i32,
+    overlay: &GraphicOverlay,
+    image_width: u32,
+    image_height: u32,
+    rgba: &[u8],
+) {
+    if image_width == 0 || image_height == 0 {
+        return;
+    }
+    if rgba.len() < (image_width as usize) * (image_height as usize) * 4 {
+        return;
+    }
+    if overlay.width <= 0.0 || overlay.height <= 0.0 {
+        return;
+    }
+
+    let x0 = overlay.x.round() as i32;
+    let y0 = overlay.y.round() as i32;
+    let x1 = (overlay.x + overlay.width).round() as i32;
+    let y1 = (overlay.y + overlay.height).round() as i32;
+    let span_x = (x1 - x0) as f32;
+    let span_y = (y1 - y0) as f32;
+    if span_x <= 0.0 || span_y <= 0.0 {
+        return;
+    }
+
+    let cx0 = x0.max(0);
+    let cy0 = y0.max(0);
+    let cx1 = x1.min(buf_w);
+    let cy1 = y1.min(buf_h);
+    if cx1 <= cx0 || cy1 <= cy0 {
+        return;
+    }
+
+    let [u0, v0, u1, v1] = overlay.source_rect;
+    let iw = image_width as f32;
+    let ih = image_height as f32;
+    let max_sx = image_width as i32 - 1;
+    let max_sy = image_height as i32 - 1;
+
+    for py in cy0..cy1 {
+        let t_y = ((py - y0) as f32 + 0.5) / span_y;
+        let v = v0 + (v1 - v0) * t_y;
+        let sy = ((v * ih) as i32).clamp(0, max_sy) as usize;
+        let src_row = sy * image_width as usize;
+        let dst_row = (py * buf_w) as usize;
+        for px in cx0..cx1 {
+            let t_x = ((px - x0) as f32 + 0.5) / span_x;
+            let u = u0 + (u1 - u0) * t_x;
+            let sx = ((u * iw) as i32).clamp(0, max_sx) as usize;
+            let idx = (src_row + sx) * 4;
+            let a = rgba[idx + 3];
+            if a == 0 {
+                continue;
+            }
+            let premul = |c: u8| ((c as u32 * a as u32 + 127) / 255) as u8;
+            let src = pack_premul(
+                premul(rgba[idx]),
+                premul(rgba[idx + 1]),
+                premul(rgba[idx + 2]),
+                a,
+            );
+            let dst = &mut buf[dst_row + px as usize];
+            *dst = blend_over_swar(src, *dst);
+        }
     }
 }
 
@@ -841,5 +989,115 @@ fn draw_quad_instance(
             let idx = (y as usize) * stride + (x as usize);
             buf[idx] = blend_over_swar(src_premul, buf[idx]);
         }
+    }
+}
+
+#[cfg(test)]
+mod image_overlay_tests {
+    use super::*;
+
+    const RED: [u8; 4] = [255, 0, 0, 255];
+    const BLUE: [u8; 4] = [0, 0, 255, 255];
+
+    fn overlay(x: f32, y: f32, width: f32, height: f32) -> GraphicOverlay {
+        GraphicOverlay {
+            image_id: 1,
+            x,
+            y,
+            width,
+            height,
+            z_index: 0,
+            source_rect: [0.0, 0.0, 1.0, 1.0],
+        }
+    }
+
+    /// 2x2 image: left column red, right column blue.
+    fn red_blue_image() -> Vec<u8> {
+        [RED, BLUE, RED, BLUE].concat()
+    }
+
+    fn buffer(w: usize, h: usize) -> Vec<u32> {
+        vec![0u32; w * h]
+    }
+
+    const RED_PX: u32 = 0x00ff_0000;
+    const BLUE_PX: u32 = 0x0000_00ff;
+
+    #[test]
+    fn one_to_one_blit_lands_on_exact_pixels() {
+        let mut buf = buffer(6, 6);
+        let image = red_blue_image();
+        draw_image_overlay(&mut buf, 6, 6, &overlay(1.0, 2.0, 2.0, 2.0), 2, 2, &image);
+
+        for y in 0..6usize {
+            for x in 0..6usize {
+                let expected = match (x, y) {
+                    (1, 2) | (1, 3) => RED_PX,
+                    (2, 2) | (2, 3) => BLUE_PX,
+                    _ => 0,
+                };
+                assert_eq!(buf[y * 6 + x], expected, "pixel ({x}, {y})");
+            }
+        }
+    }
+
+    #[test]
+    fn source_rect_selects_the_crop() {
+        let mut buf = buffer(4, 4);
+        let image = red_blue_image();
+        // Right half only: everything drawn must be blue.
+        let mut o = overlay(0.0, 0.0, 1.0, 2.0);
+        o.source_rect = [0.5, 0.0, 1.0, 1.0];
+        draw_image_overlay(&mut buf, 4, 4, &o, 2, 2, &image);
+
+        assert_eq!(buf[0], BLUE_PX);
+        assert_eq!(buf[4], BLUE_PX);
+        assert_eq!(buf[1], 0, "outside the quad stays untouched");
+    }
+
+    #[test]
+    fn nearest_neighbor_upscale() {
+        let mut buf = buffer(4, 2);
+        let image = red_blue_image();
+        // 2x2 image scaled to 4x2: two red columns then two blue.
+        draw_image_overlay(&mut buf, 4, 2, &overlay(0.0, 0.0, 4.0, 2.0), 2, 2, &image);
+
+        assert_eq!(&buf[0..4], &[RED_PX, RED_PX, BLUE_PX, BLUE_PX]);
+        assert_eq!(&buf[4..8], &[RED_PX, RED_PX, BLUE_PX, BLUE_PX]);
+    }
+
+    #[test]
+    fn alpha_blends_over_background() {
+        let mut buf = vec![0x0000_00ff_u32; 1]; // blue background
+                                                // Single half-transparent red pixel.
+        let image = vec![255, 0, 0, 128];
+        draw_image_overlay(&mut buf, 1, 1, &overlay(0.0, 0.0, 1.0, 1.0), 1, 1, &image);
+
+        let r = (buf[0] >> 16) & 0xff;
+        let b = buf[0] & 0xff;
+        assert!((127..=129).contains(&r), "red ~50%: {r}");
+        assert!((126..=128).contains(&b), "blue ~50%: {b}");
+    }
+
+    #[test]
+    fn clips_at_buffer_edges() {
+        let mut buf = buffer(2, 2);
+        let image = red_blue_image();
+        // Overlay hangs off the top-left corner; only the bottom-right
+        // quarter (blue column, bottom row) is inside the buffer.
+        draw_image_overlay(&mut buf, 2, 2, &overlay(-1.0, -1.0, 2.0, 2.0), 2, 2, &image);
+
+        assert_eq!(buf[0], BLUE_PX, "visible slice of the image");
+        assert_eq!(buf[1], 0);
+        assert_eq!(buf[2], 0);
+        assert_eq!(buf[3], 0);
+    }
+
+    #[test]
+    fn fully_transparent_pixels_leave_dst_untouched() {
+        let mut buf = vec![0x0012_3456_u32; 4];
+        let image = vec![0u8; 2 * 2 * 4]; // all alpha 0
+        draw_image_overlay(&mut buf, 2, 2, &overlay(0.0, 0.0, 2.0, 2.0), 2, 2, &image);
+        assert!(buf.iter().all(|&px| px == 0x0012_3456));
     }
 }

--- a/sugarloaf/src/renderer/image.metal
+++ b/sugarloaf/src/renderer/image.metal
@@ -15,7 +15,7 @@ struct ImageInstanceInput {
     float2 dest_pos [[attribute(0)]];
  // Size of the image on screen (physical pixels).
     float2 dest_size [[attribute(1)]];
- // Source rectangle: xy = origin, zw = size (normalized 0..1).
+ // Source rectangle: xy = origin, zw = end (normalized 0..1).
     float4 source_rect [[attribute(2)]];
 };
 

--- a/sugarloaf/src/renderer/image.wgsl
+++ b/sugarloaf/src/renderer/image.wgsl
@@ -15,7 +15,8 @@ struct InstanceInput {
     @location(0) dest_pos: vec2<f32>,
     // Size of the image on screen (physical pixels).
     @location(1) dest_size: vec2<f32>,
-    // Source rectangle in the texture: xy = origin, zw = size (normalized 0..1).
+    // Source rectangle in the texture: xy = origin, zw = end
+    // (normalized 0..1), matching the Metal and Vulkan shaders.
     @location(2) source_rect: vec4<f32>,
 }
 
@@ -37,8 +38,9 @@ fn vs_main(
     corner.x = f32(vid == 1u || vid == 3u);
     corner.y = f32(vid == 2u || vid == 3u);
 
-    // Texture coordinates from source rect
-    var tex_coord = instance.source_rect.xy + instance.source_rect.zw * corner;
+    // Texture coordinates from source rect (origin at corner 0,
+    // end at corner 1)
+    var tex_coord = mix(instance.source_rect.xy, instance.source_rect.zw, corner);
 
     // Screen position
     var image_pos = instance.dest_pos + instance.dest_size * corner;

--- a/sugarloaf/src/renderer/mod.rs
+++ b/sugarloaf/src/renderer/mod.rs
@@ -783,7 +783,7 @@ enum ImageLayer {
 /// Threshold separating `BelowBg` from `BelowText`. Matches ghostty's
 /// `bg_limit = std.math.minInt(i32) / 2` at
 /// `renderer/image.zig:377`.
-const IMAGE_BG_LIMIT: i32 = i32::MIN / 2;
+pub(crate) const IMAGE_BG_LIMIT: i32 = i32::MIN / 2;
 
 /// A single image draw command for the image pipeline.
 struct ImageDraw {
@@ -1184,7 +1184,9 @@ impl Renderer {
                 continue;
             }
 
-            // CPU backend: image overlays not supported in v1, skip.
+            // CPU backend composites overlays directly from
+            // `image_data` in `cpu::render_cpu`; no GPU texture to
+            // upload here.
             if matches!(&context.inner, crate::context::ContextType::Cpu(_)) {
                 continue;
             }

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -983,6 +983,10 @@ impl Sugarloaf<'_> {
             bg,
             grids,
             &self.text,
+            &crate::renderer::cpu::ImageLayers {
+                overlays: &self.image_overlays,
+                data: &self.image_data,
+            },
         );
 
         self.reset();


### PR DESCRIPTION
First PR from the image placement audit (#1293/#1314/#1276/#1441 investigation). Six placement fixes, per frame crop resolution, CPU compositing, and the test harness they all run under.

## Bug 1: kitty `x=`/`y=` moved the placement instead of cropping the image

Per the kitty graphics spec a placement always renders at the cursor; `x=`/`y=`/`w=`/`h=` select the source rectangle within the image. Rio used `x=`/`y=` as the destination column/row, and the stored source rectangle was never consumed by the render path. Any client that tiles or crops images got both a teleported placement and an uncropped image.

## Bug 2: wgpu sampled wrong texture coordinates for sliced placements

The image shaders disagreed on `source_rect` semantics: Metal and Vulkan treat it as `[u0, v0, u1, v1]` (origin, end) but the wgsl shader computed `xy + zw * corner` (origin, size), so on wgpu any placeholder run past an image's first row sampled the wrong region. All three backends now share the origin/end convention.

## Bug 3: native-size images stretched to their cell box on resize

The resize path recomputed every placement's pixel size as `columns * cell_width`, guarded by `columns > 0` — always true for derived spans. Any font or window change inflated native images by up to a full cell (the "incorrect sizes" signature from #1314/#1441). Placements now record the requested `c=`/`r=` separately; native ones keep their pixel size.

## Bug 4: font/DPI change with unchanged cols/rows never rescaled anything

`Crosswords::resize` early-returns before `graphics.resize` when grid dims are unchanged, leaving cell metrics stale after DPI-only changes. The early-return path now syncs cell size and rescales placements.

## Bug 5: sub-cell offsets were destroyed by shrinking the cell size

Offsets were clamped destructively at place/rescale time. They're now stored raw and clamped where read, so repeated resizes are lossless.

## Bug 6: unstable paint order for equal z-indexes

Placements were sorted by z alone with ties in hash map iteration order (frame to frame flicker potential). The frontend tie-breaks on `(image_id, placement_id)`; the CPU flatten relies on that order via a stable sort.

## Per frame crop and size resolution

The crop and display size are no longer baked into the placement at place time. `KittyPlacement` stores the raw request (`x=`/`y=`/`w=`/`h=`, zero meaning "to the edge", plus the requested cell span) and the render path resolves everything against the image's current dimensions and cell size every frame. Consequences, each covered by a test:

- A retransmission (`a=t`) that changes an image's dimensions re-clamps existing placements instead of showing a stale crop, refreshes their grid footprint, and pushes the new pixels so the display updates without a re-place.
- A crop fully outside the image stores the placement (kitty answers OK), renders nothing, occupies no cells, and leaves the cursor untouched — and becomes visible if a later retransmit makes the image large enough.
- Virtual (Unicode placeholder) placements honor the source crop too: the crop, not the whole image, is aspect-fitted into the placement grid, and per run slices map into full image texture coordinates. No crop degenerates to the exact previous math.

## Cursor movement matches kitty

`C=0` used to leave the cursor at column 0 of the image's last row, so the next prompt overwrote the image's bottom row. It now linefeeds once per occupied row (scrolling the image fully into view) and lands on the image's last row at the first column after it, clamped to the grid edge — kitty's behavior. Invisible placements don't move the cursor.

## Feature: CPU backend composites kitty images

The CPU (softbuffer) backend skipped image overlays entirely. It now composites them with the same three layer z ordering as the GPU backends via a nearest neighbor, alpha blended blit honoring the normalized source rectangle, with overlays folded into the frame skip hash. This is also what makes image rendering testable without a GPU.

## Tests

- Placement geometry (rio-backend, 20+ new): crop at cursor, raw storage with read time clamping, span derivation, one axis and both axes scaling, scrollback positioning, culling, partial visibility, native vs cell-sized rescale, retransmit re-clamping and degenerate-to-visible transitions, cursor movement at the screen bottom with scrollback, virtual run crops with letterbox culling.
- Pixel goldens (sugarloaf, pure CPU): exact pixel 1:1 blit, crop selection, nearest neighbor upscale, alpha blend, edge clipping, transparent passthrough.

579 rio-backend, 152 sugarloaf, 162 rioterm tests pass.