### PR TITLE
restore sixel and iterm2 rendering with texture lifecycle fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2176,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -4829,6 +4836,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ image_rs = { package = "image", version = "0.25.10", default-features = false, f
     "pnm",
     "webp",
     "bmp",
+    # chafa's iTerm2 renderer emits TIFF payloads (OSC 1337)
+    "tiff",
 ] }
 regex = "1.12.3"
 onig = { version = "6.5.1", default-features = false }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -456,17 +456,18 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     // Image textures (kitty) → separate store, no clone
                     for (image_id, graphic_data) in queues.pending_images {
                         sugarloaf.image_data.insert(
-                            image_id,
+                            crate::renderer::kitty_image_key(image_id),
                             rio_backend::sugarloaf::GraphicDataEntry::from_graphic_data(
                                 graphic_data,
                             ),
                         );
                     }
 
-                    for graphic_id in queues.remove_queue {
-                        sugarloaf
-                            .image_data
-                            .remove(&crate::renderer::atlas_image_key(graphic_id.get()));
+                    // Removals arrive as final image keys (atlas refs
+                    // dropped off scrollback, kitty evictions) and free
+                    // both the pixel store and the cached GPU texture.
+                    for key in queues.remove_queue {
+                        sugarloaf.remove_image(key);
                     }
 
                     // Mark the panel dirty — the renderer skips non-dirty

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -435,17 +435,22 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
             }
-            RioEventType::Rio(RioEvent::UpdateGraphics {
-                route_id: _,
-                queues,
-            }) => {
+            RioEventType::Rio(RioEvent::UpdateGraphics { route_id, queues }) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     // Process graphics directly in sugarloaf
                     let sugarloaf = &mut route.window.screen.sugarloaf;
 
-                    // Atlas graphics (sixel/iTerm2)
+                    // Atlas graphics (sixel/iTerm2) → the same per-image
+                    // texture store the overlay pipeline draws from, under
+                    // a namespaced key.
                     for graphic_data in queues.pending {
-                        sugarloaf.graphics.insert(graphic_data);
+                        let key = crate::renderer::atlas_image_key(graphic_data.id.get());
+                        sugarloaf.image_data.insert(
+                            key,
+                            rio_backend::sugarloaf::GraphicDataEntry::from_graphic_data(
+                                graphic_data,
+                            ),
+                        );
                     }
 
                     // Image textures (kitty) → separate store, no clone
@@ -458,8 +463,20 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         );
                     }
 
-                    for graphic_data in queues.remove_queue {
-                        sugarloaf.graphics.remove(&graphic_data);
+                    for graphic_id in queues.remove_queue {
+                        sugarloaf
+                            .image_data
+                            .remove(&crate::renderer::atlas_image_key(graphic_id.get()));
+                    }
+
+                    // Mark the panel dirty — the renderer skips non-dirty
+                    // panels, so a bare redraw after the pixels arrive
+                    // would no-op and leave the image blank until the
+                    // next unrelated damage.
+                    if let Some(ctx_item) =
+                        route.window.screen.ctx_mut().get_by_route_id(route_id)
+                    {
+                        ctx_item.val.renderable_content.pending_update.set_dirty();
                     }
 
                     // Request a redraw to display the updated graphics

--- a/frontends/rioterm/src/context/renderable.rs
+++ b/frontends/rioterm/src/context/renderable.rs
@@ -97,6 +97,9 @@ pub struct RenderableContent {
     pub kitty_images: FxHashMap<u32, StoredImage>,
     pub kitty_placements: Vec<KittyPlacement>,
     pub kitty_graphics_dirty: bool,
+    /// `true` while any atlas graphic (sixel/iTerm2) is alive on the
+    /// grid. Gates the per-frame cell scan that builds their overlays.
+    pub has_atlas_graphics: bool,
 }
 
 impl RenderableContent {
@@ -128,6 +131,7 @@ impl RenderableContent {
             kitty_images: FxHashMap::default(),
             kitty_placements: Vec::new(),
             kitty_graphics_dirty: false,
+            has_atlas_graphics: false,
         }
     }
 

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -43,16 +43,7 @@ fn window_bg_alpha(config: &Config) -> f32 {
     }
 }
 
-/// `image_data` (u32) key for an atlas graphic (sixel/iTerm2).
-/// `GraphicId`s are small sequential u64s; the high bit keeps them out
-/// of the kitty protocol id space (see the `KittyPlacement` doc comment
-/// in rio-backend), so both kinds share the per-image texture store.
-pub const ATLAS_IMAGE_ID_FLAG: u32 = 0x8000_0000;
-
-#[inline]
-pub fn atlas_image_key(id: u64) -> u32 {
-    ATLAS_IMAGE_ID_FLAG | (id as u32 & 0x7FFF_FFFF)
-}
+pub use rio_backend::sugarloaf::{atlas_image_key, kitty_image_key};
 
 pub struct Renderer {
     is_vi_mode_enabled: bool,
@@ -459,7 +450,7 @@ impl Renderer {
                             continue;
                         };
                         overlays.push(rio_backend::sugarloaf::GraphicOverlay {
-                            image_id: p.image_id,
+                            image_id: kitty_image_key(p.image_id),
                             x: geometry.x,
                             y: geometry.y,
                             width: geometry.width,
@@ -907,7 +898,7 @@ impl Renderer {
             };
 
             overlays.push(rio_backend::sugarloaf::GraphicOverlay {
-                image_id: run.image_id,
+                image_id: kitty_image_key(run.image_id),
                 x: geom.x,
                 y: geom.y,
                 width: geom.width,

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -43,6 +43,17 @@ fn window_bg_alpha(config: &Config) -> f32 {
     }
 }
 
+/// `image_data` (u32) key for an atlas graphic (sixel/iTerm2).
+/// `GraphicId`s are small sequential u64s; the high bit keeps them out
+/// of the kitty protocol id space (see the `KittyPlacement` doc comment
+/// in rio-backend), so both kinds share the per-image texture store.
+pub const ATLAS_IMAGE_ID_FLAG: u32 = 0x8000_0000;
+
+#[inline]
+pub fn atlas_image_key(id: u64) -> u32 {
+    ATLAS_IMAGE_ID_FLAG | (id as u32 & 0x7FFF_FFFF)
+}
+
 pub struct Renderer {
     is_vi_mode_enabled: bool,
     is_game_mode_enabled: bool,
@@ -391,6 +402,8 @@ impl Renderer {
                 } else {
                     context.renderable_content.kitty_graphics_dirty = false;
                 }
+                context.renderable_content.has_atlas_graphics =
+                    !terminal.graphics.placed_textures.is_empty();
                 context.renderable_content.frame_damage = damage;
                 drop(terminal);
             }
@@ -401,7 +414,8 @@ impl Renderer {
             let rc = &context.renderable_content;
             let has_overlays = !rc.kitty_placements.is_empty();
             let has_virtual = !rc.kitty_virtual_placements.is_empty();
-            if has_overlays || has_virtual {
+            let has_atlas = rc.has_atlas_graphics;
+            if has_overlays || has_virtual || has_atlas {
                 let layout = context.dimension;
                 // Canonical integer cell stride — line_height already
                 // baked into `cell.cell_height`. Same value the GPU
@@ -466,8 +480,20 @@ impl Renderer {
                         cell_height,
                     );
                 }
-            } else if rc.kitty_graphics_dirty {
-                // Placements were removed — clear overlays
+
+                if has_atlas {
+                    Self::push_atlas_graphic_overlays(
+                        overlays,
+                        rc,
+                        origin_x,
+                        origin_y,
+                        cell_width,
+                        cell_height,
+                    );
+                }
+            } else {
+                // No placements of any kind — drop stale overlays (kitty
+                // deletes, or the last atlas graphic scrolled out).
                 sugarloaf.clear_image_overlays_for(context.rich_text_id);
             }
 
@@ -889,6 +915,160 @@ impl Renderer {
                 z_index,
                 source_rect: geom.source_rect,
             });
+        }
+    }
+
+    /// Scan visible rows for cells carrying atlas graphics (sixel/iTerm2)
+    /// and push one `GraphicOverlay` per row-run. The backend writes a
+    /// `GraphicCell { texture, offset_x, offset_y }` into every covered
+    /// cell, so contiguous cells continuing the same texture at the
+    /// expected pixel offset coalesce into one overlay; erased or
+    /// overwritten cells break the run and that slice is not drawn.
+    fn push_atlas_graphic_overlays(
+        overlays: &mut Vec<rio_backend::sugarloaf::GraphicOverlay>,
+        rc: &RenderableContent,
+        origin_x: f32,
+        origin_y: f32,
+        cell_width: f32,
+        cell_height: f32,
+    ) {
+        // Below text, like virtual placements.
+        const ATLAS_Z_INDEX: i32 = -1;
+
+        struct Run {
+            id: u64,
+            tex_w: f32,
+            tex_h: f32,
+            /// Cell size when the graphic was inserted — the pixel stride
+            /// between covered cells. Differs from the live cell size
+            /// after a font resize (the image then scales with the font).
+            insert_cw: f32,
+            insert_ch: f32,
+            src_x0: f32,
+            src_y: f32,
+            start_col: usize,
+            cells: usize,
+        }
+
+        /// Push the run as one overlay: a `source_rect` slice of the
+        /// texture (normalized, resolution-independent) covering the
+        /// run's cells. Edge cells draw only the pixels the image
+        /// actually has.
+        fn flush(
+            overlays: &mut Vec<rio_backend::sugarloaf::GraphicOverlay>,
+            r: Run,
+            line: usize,
+            origin_x: f32,
+            origin_y: f32,
+            cell_width: f32,
+            cell_height: f32,
+        ) {
+            let src_w = (r.cells as f32 * r.insert_cw).min(r.tex_w - r.src_x0);
+            let src_h = r.insert_ch.min(r.tex_h - r.src_y);
+            if src_w <= 0.0 || src_h <= 0.0 {
+                return;
+            }
+            overlays.push(rio_backend::sugarloaf::GraphicOverlay {
+                image_id: atlas_image_key(r.id),
+                x: origin_x + r.start_col as f32 * cell_width,
+                y: origin_y + line as f32 * cell_height,
+                width: src_w * (cell_width / r.insert_cw),
+                height: src_h * (cell_height / r.insert_ch),
+                z_index: ATLAS_Z_INDEX,
+                source_rect: [
+                    r.src_x0 / r.tex_w,
+                    r.src_y / r.tex_h,
+                    (r.src_x0 + src_w) / r.tex_w,
+                    (r.src_y + src_h) / r.tex_h,
+                ],
+            });
+        }
+
+        for (line_idx, row) in rc.visible_rows.iter().enumerate() {
+            if !row.has_extras {
+                continue;
+            }
+
+            let mut run: Option<Run> = None;
+
+            for (col_idx, square) in row.inner.iter().enumerate() {
+                let graphic = if square.has_graphics() {
+                    square
+                        .extras_id()
+                        .and_then(|eid| rc.extras.get(&eid))
+                        .and_then(|e| e.graphic.as_ref())
+                        .and_then(|g| g.first())
+                } else {
+                    None
+                };
+
+                let Some(cell) = graphic else {
+                    if let Some(r) = run.take() {
+                        flush(
+                            overlays,
+                            r,
+                            line_idx,
+                            origin_x,
+                            origin_y,
+                            cell_width,
+                            cell_height,
+                        );
+                    }
+                    continue;
+                };
+
+                // Covered cells of one image row share a single
+                // `GraphicCell`; the per-cell x offset is positional:
+                // offset_x + (col - anchor_col) * insert-time cell width.
+                match &mut run {
+                    Some(r)
+                        if r.id == cell.texture.id.get()
+                            && r.src_y == cell.offset_y as f32
+                            && col_idx == r.start_col + r.cells =>
+                    {
+                        r.cells += 1;
+                    }
+                    _ => {
+                        if let Some(r) = run.take() {
+                            flush(
+                                overlays,
+                                r,
+                                line_idx,
+                                origin_x,
+                                origin_y,
+                                cell_width,
+                                cell_height,
+                            );
+                        }
+                        let insert_cw = cell.texture.cell_width.max(1) as f32;
+                        let src_x0 = cell.offset_x as f32
+                            + (col_idx as f32 - cell.anchor_col as f32) * insert_cw;
+                        run = Some(Run {
+                            id: cell.texture.id.get(),
+                            tex_w: cell.texture.width as f32,
+                            tex_h: cell.texture.height as f32,
+                            insert_cw,
+                            insert_ch: cell.texture.cell_height.max(1) as f32,
+                            src_x0,
+                            src_y: cell.offset_y as f32,
+                            start_col: col_idx,
+                            cells: 1,
+                        });
+                    }
+                }
+            }
+
+            if let Some(r) = run {
+                flush(
+                    overlays,
+                    r,
+                    line_idx,
+                    origin_x,
+                    origin_y,
+                    cell_width,
+                    cell_height,
+                );
+            }
         }
     }
 }

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -1063,3 +1063,105 @@ impl Renderer {
         }
     }
 }
+
+#[cfg(test)]
+mod atlas_overlay_tests {
+    use super::*;
+    use crate::context::renderable::Cursor;
+    use parking_lot::Mutex;
+    use rio_backend::ansi::graphics::{GraphicCell, TextureRef};
+    use rio_backend::crosswords::grid::row::Row;
+    use rio_backend::crosswords::pos::Column;
+    use rio_backend::crosswords::square::{CellFlags, Extras, Square};
+    use rio_backend::sugarloaf::GraphicId;
+    use std::sync::Arc;
+
+    /// 30x40 px texture inserted at 10x20 cells: 3 cells wide, 2 rows.
+    fn test_rc(covered: &[usize]) -> RenderableContent {
+        let ops = Arc::new(Mutex::new(Vec::new()));
+        let texture = Arc::new(TextureRef {
+            id: GraphicId::new(5),
+            width: 30,
+            height: 40,
+            cell_width: 10,
+            cell_height: 20,
+            texture_operations: Arc::downgrade(&ops),
+        });
+        // Leak the ops arc so the queue outlives the test scope.
+        std::mem::forget(ops);
+
+        let mut rc = RenderableContent::new(Cursor::default());
+        let mut row: Row<Square> = Row::new(5);
+        let mut extras_map = rustc_hash::FxHashMap::default();
+        let eid: u16 = 3;
+        extras_map.insert(
+            eid,
+            Extras {
+                zerowidth: Vec::new(),
+                hyperlink: None,
+                graphic: Some(smallvec::smallvec![GraphicCell {
+                    texture: texture.clone(),
+                    offset_x: 0,
+                    offset_y: 0,
+                    anchor_col: 0,
+                }]),
+            },
+        );
+        for &col in covered {
+            let square = &mut row[Column(col)];
+            square.set_extras_id(Some(eid));
+            square.insert_cell_flag(CellFlags::GRAPHICS);
+        }
+        row.has_extras = true;
+        rc.visible_rows = vec![row];
+        rc.extras = extras_map;
+        rc
+    }
+
+    #[test]
+    fn contiguous_run_coalesces_into_one_overlay() {
+        let rc = test_rc(&[0, 1, 2]);
+        let mut overlays = Vec::new();
+        Renderer::push_atlas_graphic_overlays(&mut overlays, &rc, 0.0, 0.0, 10.0, 20.0);
+
+        assert_eq!(overlays.len(), 1, "one overlay per row-run");
+        let o = &overlays[0];
+        assert_eq!(o.image_id, atlas_image_key(5));
+        assert_eq!(o.x, 0.0);
+        assert_eq!(o.y, 0.0);
+        assert_eq!(o.width, 30.0);
+        assert_eq!(o.height, 20.0, "one cell row of the texture");
+        // Top half of the 40px-tall texture.
+        assert_eq!(o.source_rect, [0.0, 0.0, 1.0, 0.5]);
+    }
+
+    #[test]
+    fn erased_cell_splits_the_run_and_hides_its_slice() {
+        let rc = test_rc(&[0, 2]);
+        let mut overlays = Vec::new();
+        Renderer::push_atlas_graphic_overlays(&mut overlays, &rc, 0.0, 0.0, 10.0, 20.0);
+
+        assert_eq!(overlays.len(), 2, "erased middle cell splits the run");
+        assert_eq!(overlays[0].x, 0.0);
+        assert_eq!(overlays[0].width, 10.0);
+        assert_eq!(overlays[0].source_rect[0], 0.0);
+        // Second slice starts at cell 2 on screen AND in the texture,
+        // derived positionally from the anchor column.
+        assert_eq!(overlays[1].x, 20.0);
+        assert_eq!(overlays[1].width, 10.0);
+        assert!((overlays[1].source_rect[0] - 20.0 / 30.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn font_resize_scales_atlas_overlay_to_live_cell_size() {
+        let rc = test_rc(&[0, 1, 2]);
+        let mut overlays = Vec::new();
+        // Live cells grew to 12x24 after insert at 10x20: the image
+        // scales with the font.
+        Renderer::push_atlas_graphic_overlays(&mut overlays, &rc, 0.0, 0.0, 12.0, 24.0);
+
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(overlays[0].width, 36.0, "30px scaled by 12/10");
+        assert_eq!(overlays[0].height, 24.0, "20px scaled by 24/20");
+    }
+}

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -21,8 +21,9 @@ pub struct UpdateQueues {
     /// Image textures (kitty) keyed by image_id.
     pub pending_images: Vec<(u32, GraphicData)>,
 
-    /// Graphics removed from the grid.
-    pub remove_queue: Vec<GraphicId>,
+    /// Image keys removed from the grid or evicted
+    /// (`sugarloaf::graphics::kitty_image_key` / `atlas_image_key`).
+    pub remove_queue: Vec<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -42,8 +43,8 @@ pub struct TextureRef {
     /// Height, in pixels, of the cell when the graphic was inserted.
     pub cell_height: usize,
 
-    /// Queue to track removed textures.
-    pub texture_operations: Weak<Mutex<Vec<GraphicId>>>,
+    /// Queue to track removed textures (final image keys).
+    pub texture_operations: Weak<Mutex<Vec<u64>>>,
 }
 
 impl PartialEq for TextureRef {
@@ -58,7 +59,9 @@ impl Eq for TextureRef {}
 impl Drop for TextureRef {
     fn drop(&mut self) {
         if let Some(texture_operations) = self.texture_operations.upgrade() {
-            texture_operations.lock().push(self.id);
+            texture_operations
+                .lock()
+                .push(crate::sugarloaf::atlas_image_key(self.id.get()));
         }
     }
 }
@@ -426,7 +429,7 @@ pub struct Graphics {
     pub pending_images: Vec<(u32, GraphicData)>,
 
     /// Graphics removed from the grid.
-    pub texture_operations: Arc<Mutex<Vec<GraphicId>>>,
+    pub texture_operations: Arc<Mutex<Vec<u64>>>,
 
     /// Shared palette for Sixel graphics.
     pub sixel_shared_palette: Option<Vec<ColorRgb>>,
@@ -880,8 +883,16 @@ impl Graphics {
             // Remove timestamp (only used for pending atlas graphics)
             self.image_timestamps.remove(&id);
 
-            // Add to removal queue so GPU textures get cleaned up
-            self.texture_operations.lock().push(id);
+            // Add to removal queue so GPU textures get cleaned up.
+            // The key namespace depends on where the image lived:
+            // kitty ids map verbatim, atlas graphics live above 2^32.
+            let key = match source {
+                CandidateSource::Pending => crate::sugarloaf::atlas_image_key(id.get()),
+                CandidateSource::ActiveKitty | CandidateSource::InactiveKitty => {
+                    crate::sugarloaf::kitty_image_key(id.get() as u32)
+                }
+            };
+            self.texture_operations.lock().push(key);
         }
 
         // Sweep dangling placements on both screens. A placement is

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -36,6 +36,9 @@ pub struct TextureRef {
     /// Height, in pixels, of the graphic.
     pub height: u16,
 
+    /// Width, in pixels, of the cell when the graphic was inserted.
+    pub cell_width: usize,
+
     /// Height, in pixels, of the cell when the graphic was inserted.
     pub cell_height: usize,
 
@@ -63,17 +66,25 @@ impl Drop for TextureRef {
 /// A list of graphics in a single cell.
 pub type GraphicsCell = SmallVec<[GraphicCell; 1]>;
 
-/// Graphic data stored in a single cell.
+/// Graphic data stored in a cell's extras slot.
+///
+/// One `GraphicCell` (one extras slot) is shared by every covered cell of
+/// an image row — a slot per cell would exhaust the u16 extras id space in
+/// a dozen large images. A cell's actual x offset is derived positionally:
+/// `offset_x + (col - anchor_col) * texture.cell_width`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GraphicCell {
     /// Texture to draw the graphic in this cell.
     pub texture: Arc<TextureRef>,
 
-    /// Offset in the x direction.
+    /// Offset in the x direction, at `anchor_col`.
     pub offset_x: u16,
 
     /// Offset in the y direction.
     pub offset_y: u16,
+
+    /// Grid column `offset_x` is measured at.
+    pub anchor_col: u16,
 }
 
 /// Kitty graphics Unicode placeholder character

--- a/rio-backend/src/crosswords/grid/mod.rs
+++ b/rio-backend/src/crosswords/grid/mod.rs
@@ -121,6 +121,22 @@ impl ExtrasTable {
         id
     }
 
+    /// Nearly out of slot ids — time for `Grid::gc_extras`.
+    pub fn under_pressure(&self) -> bool {
+        self.slots.len() >= u16::MAX as usize && self.free.len() < 256
+    }
+
+    /// Free every allocated slot whose bit is not set in `live`.
+    pub fn sweep_unmarked(&mut self, live: &[u64]) {
+        for id in 1..self.slots.len() {
+            let marked = live[id / 64] & (1 << (id % 64)) != 0;
+            if !marked && self.slots[id].is_some() {
+                self.slots[id] = None;
+                self.free.push(id as u16);
+            }
+        }
+    }
+
     /// Free a previously-allocated slot. No-op if `id == 0`.
     pub fn free(&mut self, id: crate::crosswords::square::ExtrasId) {
         if id == 0 {
@@ -471,6 +487,42 @@ use crate::crosswords::square::Square;
 use crate::crosswords::style::{Style, StyleId};
 
 impl Grid<Square> {
+    /// Free extras slots no longer referenced by any cell.
+    ///
+    /// Cells are overwritten and rows drop off the scrollback ring without
+    /// freeing their extras slot, so a session heavy on per-cell extras —
+    /// inline graphics above all — eventually exhausts the u16 id space.
+    /// Mark every slot referenced by a live row (visible + history) or a
+    /// cursor template, then free the rest. Swept graphic slots drop their
+    /// `TextureRef`, which queues the image removal downstream.
+    pub fn gc_extras(&mut self) {
+        #[inline]
+        fn mark(live: &mut [u64], sq: &Square) {
+            if matches!(
+                sq.content_tag(),
+                crate::crosswords::square::ContentTag::Codepoint
+            ) {
+                if let Some(eid) = sq.extras_id() {
+                    live[eid as usize / 64] |= 1 << (eid % 64);
+                }
+            }
+        }
+
+        let mut live = vec![0u64; (u16::MAX as usize).div_ceil(64)];
+        for l in self.topmost_line().0..=self.bottommost_line().0 {
+            let row = &self.raw[Line(l)];
+            if !row.has_extras {
+                continue;
+            }
+            for sq in &row.inner {
+                mark(&mut live, sq);
+            }
+        }
+        mark(&mut live, &self.cursor.template);
+        mark(&mut live, &self.saved_cursor.template);
+        self.extras_table.sweep_unmarked(&live);
+    }
+
     /// Read the style associated with the cell's style id.
     #[inline]
     pub fn style_of(&self, square: &Square) -> Style {

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -1452,8 +1452,15 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
 
+        // A Noop/CursorOnly frame normally has nothing to copy — but rows
+        // written after the damage event was consumed (e.g. a graphics
+        // insert racing a redraw) still carry their dirty bit. Fall
+        // through when any row is dirty so the snapshot can't go stale.
         if matches!(damage, TerminalDamage::Noop | TerminalDamage::CursorOnly) {
-            return;
+            let any_dirty = (0..count as i32).any(|y| self.grid[Line(start + y)].dirty);
+            if !any_dirty {
+                return;
+            }
         }
 
         #[allow(clippy::needless_range_loop)]
@@ -1488,6 +1495,11 @@ impl<U: EventListener> Crosswords<U> {
             return;
         }
         for sq in &row.inner {
+            // Bg-only cells reuse the extras_id bits for the bg color;
+            // reading them would insert junk map entries.
+            if sq.is_bg_only() {
+                continue;
+            }
             if let Some(id) = sq.extras_id() {
                 if let Some(live) = self.grid.extras_table.get(id) {
                     extras.insert(id, live.clone());
@@ -1874,12 +1886,18 @@ impl<U: EventListener> Crosswords<U> {
     #[inline]
     fn clear_cell_graphic(extras_table: &mut grid::ExtrasTable, cell: &mut Square) {
         if let Some(eid) = cell.extras_id() {
-            if let Some(extras) = extras_table.get_mut(eid) {
-                extras.graphic = None;
-                if extras.is_empty() {
-                    extras_table.free(eid);
-                    cell.set_extras_id(None);
+            match extras_table.get_mut(eid) {
+                Some(extras) => {
+                    extras.graphic = None;
+                    if extras.is_empty() {
+                        extras_table.free(eid);
+                        cell.set_extras_id(None);
+                    }
                 }
+                // Covered cells share one slot per image row; another cell
+                // already freed it. Drop the stale id so a reused slot
+                // isn't aliased.
+                None => cell.set_extras_id(None),
             }
         }
         cell.remove_cell_flag(CellFlags::GRAPHICS);
@@ -3770,12 +3788,19 @@ impl<U: EventListener> Handler for Crosswords<U> {
             id: graphic_id,
             width,
             height,
+            cell_width,
             cell_height,
             texture_operations: Arc::downgrade(&self.graphics.texture_operations),
         });
 
         self.graphics
             .register_placed_texture(graphic_id, Arc::downgrade(&texture));
+
+        // Reclaim slots dropped off the scrollback ring before allocating
+        // this image's rows against a nearly-full table.
+        if self.grid.extras_table.under_pressure() {
+            self.grid.gc_extras();
+        }
 
         for (top, offset_y) in (0..).zip((0..height).step_by(cell_height)) {
             let line = if scrolling {
@@ -3789,19 +3814,21 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 Line(top)
             };
 
-            // Store a reference to the graphic in the first column.
+            // One shared extras slot per image row: every covered cell
+            // points at the same `GraphicCell` and derives its own x
+            // offset from `anchor_col`. A slot per cell would exhaust
+            // the u16 extras id space in a dozen screen-sized images.
+            let graphic_cell = GraphicCell {
+                texture: texture.clone(),
+                offset_x: 0,
+                offset_y,
+                anchor_col: leftmost as u16,
+            };
+            let mut shared_eid: Option<square::ExtrasId> = None;
+
             let row_len = self.grid[line].len();
-            for (left, offset_x) in (leftmost..).zip((0..width).step_by(cell_width)) {
-                if left >= row_len {
-                    break;
-                }
-
-                let graphic_cell = GraphicCell {
-                    texture: texture.clone(),
-                    offset_x,
-                    offset_y,
-                };
-
+            let cols = (width as usize).div_ceil(cell_width);
+            for left in leftmost..(leftmost + cols).min(row_len) {
                 let cell_ref = &mut self.grid.raw[line][Column(left)];
 
                 // Bg-only cells (BgPalette/BgRgb) reuse the upper 32
@@ -3813,17 +3840,26 @@ impl<U: EventListener> Handler for Crosswords<U> {
                     cell_ref.clear();
                 }
 
-                // If the cell already has an extras slot (e.g. hyperlink),
-                // merge the graphic into it; otherwise allocate a new one.
+                // A cell that already has an extras slot (e.g. hyperlink)
+                // gets the graphic merged into its own slot — never into
+                // the shared one, which other cells read. Bare cells all
+                // point at the single shared slot.
                 if let Some(eid) = cell_ref.extras_id() {
                     if let Some(extras) = self.grid.extras_table.get_mut(eid) {
-                        extras.graphic = Some(smallvec::smallvec![graphic_cell]);
+                        extras.graphic = Some(smallvec::smallvec![graphic_cell.clone()]);
                     }
                 } else {
-                    let eid = self.grid.extras_table.alloc(square::Extras {
-                        graphic: Some(smallvec::smallvec![graphic_cell]),
-                        ..Default::default()
-                    });
+                    let eid = match shared_eid {
+                        Some(eid) => eid,
+                        None => {
+                            let eid = self.grid.extras_table.alloc(square::Extras {
+                                graphic: Some(smallvec::smallvec![graphic_cell.clone()]),
+                                ..Default::default()
+                            });
+                            shared_eid = Some(eid);
+                            eid
+                        }
+                    };
                     cell_ref.set_extras_id(Some(eid));
                 }
                 cell_ref.insert_cell_flag(CellFlags::GRAPHICS);
@@ -6428,8 +6464,11 @@ mod tests {
 
         cw.insert_graphic(graphic, None, None);
 
-        // The image spans rows 0..2, cols 0..2.
+        // The image spans rows 0..2, cols 0..2. Covered cells of one image
+        // row share a single GraphicCell (one extras slot per row); each
+        // cell's x offset derives from anchor_col.
         for row in 0..2 {
+            let mut row_eid = None;
             for col in 0..2 {
                 let cell = &cw.grid[Line(row)][Column(col)];
                 assert!(
@@ -6437,6 +6476,10 @@ mod tests {
                     "cell ({row},{col}) should have GRAPHICS flag"
                 );
                 let eid = cell.extras_id().expect("cell should have extras_id");
+                if let Some(prev) = row_eid {
+                    assert_eq!(eid, prev, "row {row} cells should share one slot");
+                }
+                row_eid = Some(eid);
                 let extras = cw
                     .grid
                     .extras_table
@@ -6449,8 +6492,10 @@ mod tests {
                     .first()
                     .expect("graphic SmallVec should have one entry");
 
-                // Verify offsets match the cell position.
-                assert_eq!(gc.offset_x, (col * 10) as u16);
+                // Derived offsets match the cell position.
+                let derived_x = gc.offset_x as usize
+                    + (col - gc.anchor_col as usize) * gc.texture.cell_width;
+                assert_eq!(derived_x, col * 10);
                 assert_eq!(gc.offset_y, (row * 10) as u16);
             }
         }

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -1118,6 +1118,7 @@ fn test_no_double_push_on_graphic_cell_drop() {
         id: GraphicId::new(99),
         width: 10,
         height: 20,
+        cell_width: 10,
         cell_height: 20,
         texture_operations: Arc::downgrade(&texture_ops),
     });
@@ -1127,11 +1128,13 @@ fn test_no_double_push_on_graphic_cell_drop() {
         texture: texture.clone(),
         offset_x: 0,
         offset_y: 0,
+        anchor_col: 0,
     };
     let cell2 = GraphicCell {
         texture: texture.clone(),
         offset_x: 10,
         offset_y: 0,
+        anchor_col: 0,
     };
 
     // Drop both cells — should NOT push to texture_operations (GraphicCell has no Drop impl)
@@ -1212,6 +1215,7 @@ fn test_collect_active_ids_uses_weak_refs() {
         id: GraphicId::new(1),
         width: 10,
         height: 20,
+        cell_width: 10,
         cell_height: 20,
         texture_operations: Arc::downgrade(&texture_ops),
     });

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -1112,7 +1112,7 @@ fn test_no_double_push_on_graphic_cell_drop() {
     use parking_lot::Mutex;
     use std::sync::Arc;
 
-    let texture_ops: Arc<Mutex<Vec<GraphicId>>> = Arc::new(Mutex::new(Vec::new()));
+    let texture_ops: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
 
     let texture = Arc::new(TextureRef {
         id: GraphicId::new(99),
@@ -1154,7 +1154,7 @@ fn test_no_double_push_on_graphic_cell_drop() {
         "TextureRef drop should push exactly once, got {}",
         ops.len()
     );
-    assert_eq!(ops[0], GraphicId::new(99));
+    assert_eq!(ops[0], crate::sugarloaf::atlas_image_key(99));
 }
 
 #[test]
@@ -4611,5 +4611,42 @@ fn test_transmit_and_display_refreshes_sibling_placements() {
     assert_eq!(
         term.graphics.kitty_placements.get(&(1, 16)).unwrap().rows,
         10
+    );
+}
+
+#[test]
+fn test_image_key_namespaces_are_disjoint() {
+    use crate::sugarloaf::{atlas_image_key, kitty_image_key};
+
+    // kitty clients may pick any u32 image id (kitten icat uses random
+    // ones); the atlas namespace must live entirely above that range.
+    assert_eq!(kitty_image_key(u32::MAX), u32::MAX as u64);
+    assert_eq!(kitty_image_key(0x8000_0001), 0x8000_0001);
+    assert!(atlas_image_key(0) > u32::MAX as u64);
+    assert_eq!(atlas_image_key(7), (1u64 << 32) + 7);
+}
+
+#[test]
+fn test_texture_ref_drop_queues_atlas_key() {
+    use crate::ansi::graphics::TextureRef;
+    use crate::sugarloaf::atlas_image_key;
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    let ops = Arc::new(Mutex::new(Vec::new()));
+    {
+        let _texture = TextureRef {
+            id: GraphicId::new(3),
+            width: 10,
+            height: 10,
+            cell_width: 10,
+            cell_height: 20,
+            texture_operations: Arc::downgrade(&ops),
+        };
+    }
+    assert_eq!(
+        *ops.lock(),
+        vec![atlas_image_key(3)],
+        "dropping the last grid reference queues the atlas key for GPU cleanup"
     );
 }

--- a/sugarloaf/src/lib.rs
+++ b/sugarloaf/src/lib.rs
@@ -37,8 +37,9 @@ pub use swash::{Attributes, Stretch, Style, Weight};
 pub use crate::font_cache::ResolvedGlyph;
 pub use crate::sugarloaf::{
     graphics::{
-        ColorType, Graphic, GraphicData, GraphicDataEntry, GraphicId, GraphicOverlay,
-        Graphics, ResizeCommand, ResizeParameter, MAX_GRAPHIC_DIMENSIONS,
+        atlas_image_key, kitty_image_key, ColorType, Graphic, GraphicData,
+        GraphicDataEntry, GraphicId, GraphicOverlay, Graphics, ResizeCommand,
+        ResizeParameter, MAX_GRAPHIC_DIMENSIONS,
     },
     primitives::{
         is_private_user_area, Corners, CursorKind, ImageProperties, Quad, Rect,

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -21,7 +21,7 @@ use wide::{u32x4, u32x8};
 /// Image overlays and their pixel stores for a CPU frame.
 pub struct ImageLayers<'a> {
     pub overlays: &'a FxHashMap<usize, Vec<GraphicOverlay>>,
-    pub data: &'a FxHashMap<u32, GraphicDataEntry>,
+    pub data: &'a FxHashMap<u64, GraphicDataEntry>,
 }
 
 #[derive(Default)]
@@ -350,7 +350,7 @@ pub fn render_cpu(
         // retransmitted image gets a fresh handle id).
         h.write_usize(image_overlays.len());
         for overlay in &image_overlays {
-            h.write_u32(overlay.image_id);
+            h.write_u64(overlay.image_id);
             h.write_u32(overlay.x.to_bits());
             h.write_u32(overlay.y.to_bits());
             h.write_u32(overlay.width.to_bits());
@@ -557,7 +557,7 @@ fn draw_image_overlays(
     buf_w: i32,
     buf_h: i32,
     overlays: &[&GraphicOverlay],
-    data: &FxHashMap<u32, GraphicDataEntry>,
+    data: &FxHashMap<u64, GraphicDataEntry>,
 ) {
     for overlay in overlays {
         let entry = match data.get(&overlay.image_id) {

--- a/sugarloaf/src/renderer/mod.rs
+++ b/sugarloaf/src/renderer/mod.rs
@@ -787,7 +787,7 @@ pub(crate) const IMAGE_BG_LIMIT: i32 = i32::MIN / 2;
 
 /// A single image draw command for the image pipeline.
 struct ImageDraw {
-    image_id: u32,
+    image_id: u64,
     instance: ImageInstance,
     layer: ImageLayer,
 }
@@ -807,7 +807,7 @@ pub struct Renderer {
     draw_cmds: Vec<batch::DrawCmd>,
     images: ImageCache,
     /// Per-image GPU textures (one map, any backend).
-    image_textures: FxHashMap<u32, ImageTextureEntry>,
+    image_textures: FxHashMap<u64, ImageTextureEntry>,
     /// Image draw commands for the current frame.
     image_draws: Vec<ImageDraw>,
     /// Pending background image upload (consumed by `prepare`).
@@ -1024,7 +1024,7 @@ impl Renderer {
         _state: &crate::sugarloaf::state::SugarState,
         _graphics: &mut Graphics,
         image_data: &mut rustc_hash::FxHashMap<
-            u32,
+            u64,
             crate::sugarloaf::graphics::GraphicDataEntry,
         >,
         image_overlays: &rustc_hash::FxHashMap<
@@ -1148,7 +1148,7 @@ impl Renderer {
         &mut self,
         context: &mut crate::context::Context,
         image_data: &mut rustc_hash::FxHashMap<
-            u32,
+            u64,
             crate::sugarloaf::graphics::GraphicDataEntry,
         >,
         overlays: &[&crate::sugarloaf::graphics::GraphicOverlay],
@@ -1355,7 +1355,7 @@ impl Renderer {
     #[allow(clippy::too_many_arguments)]
     fn draw_images_metal(
         image_draws: &[ImageDraw],
-        image_textures: &FxHashMap<u32, ImageTextureEntry>,
+        image_textures: &FxHashMap<u64, ImageTextureEntry>,
         brush: &MetalRenderer,
         render_encoder: &metal::RenderCommandEncoderRef,
         layer: ImageLayer,
@@ -1566,6 +1566,15 @@ impl Renderer {
     pub fn reset(&mut self) {
         self.image_textures.clear();
         self.image_draws.clear();
+    }
+
+    /// Drop the cached GPU texture for one image key. Called when the
+    /// image's pixel data is removed (scrolled out of scrollback,
+    /// kitty eviction) — without this, sequential atlas ids from e.g.
+    /// sixel animations would grow the texture cache without bound.
+    #[inline]
+    pub fn evict_image_texture(&mut self, key: u64) {
+        self.image_textures.remove(&key);
     }
 
     #[inline]

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -38,8 +38,9 @@ pub struct Sugarloaf<'a> {
     pub graphics: Graphics,
     #[cfg(feature = "wgpu")]
     filters_brush: Option<FiltersBrush>,
-    /// Pixel data for standalone image textures, keyed by ImageId.
-    pub image_data: rustc_hash::FxHashMap<u32, GraphicDataEntry>,
+    /// Pixel data for standalone image textures, keyed by image key
+    /// (`graphics::kitty_image_key` / `graphics::atlas_image_key`).
+    pub image_data: rustc_hash::FxHashMap<u64, GraphicDataEntry>,
     /// Persistent state for the CPU rasterizer (glyph cache + frame hash).
     /// Unused on GPU backends.
     cpu_cache: crate::renderer::cpu::CpuCache,
@@ -901,6 +902,14 @@ impl Sugarloaf<'_> {
         // Drop this frame's UI text instances — overlays re-record
         // next frame (immediate mode).
         self.text.clear();
+    }
+
+    /// Remove an image's pixel data and its cached GPU texture.
+    /// `key` is a `graphics::kitty_image_key` / `graphics::atlas_image_key`.
+    #[inline]
+    pub fn remove_image(&mut self, key: u64) {
+        self.image_data.remove(&key);
+        self.renderer.evict_image_texture(key);
     }
 
     /// Drop everything this frame's immediate-mode producers pushed

--- a/sugarloaf/src/sugarloaf/graphics.rs
+++ b/sugarloaf/src/sugarloaf/graphics.rs
@@ -85,12 +85,30 @@ pub struct Graphic {
     pub offset_y: u16,
 }
 
+/// Key for `Sugarloaf::image_data` and the renderer's per-image
+/// texture cache: a kitty image, keyed by its protocol id verbatim.
+/// The full u32 space belongs to the client, so atlas graphics live
+/// in a disjoint range above it (see [`atlas_image_key`]).
+#[inline]
+pub fn kitty_image_key(image_id: u32) -> u64 {
+    image_id as u64
+}
+
+/// Key for an atlas graphic (sixel/iTerm2): the sequential
+/// `GraphicId` shifted above the kitty u32 id space so a kitty client
+/// picking a high image id (kitten icat uses random u32 ids) can
+/// never collide with an atlas texture.
+#[inline]
+pub fn atlas_image_key(graphic_id: u64) -> u64 {
+    (1u64 << 32) + graphic_id
+}
+
 /// An overlay image placement.
 /// Used by the renderer to draw images on top of (or behind) terminal content.
 #[derive(Debug, Clone)]
 pub struct GraphicOverlay {
-    /// Image identifier (kitty protocol image_id).
-    pub image_id: u32,
+    /// Image texture key ([`kitty_image_key`] or [`atlas_image_key`]).
+    pub image_id: u64,
     /// Screen position (physical pixels).
     pub x: f32,
     pub y: f32,

--- a/sugarloaf/src/sugarloaf/state.rs
+++ b/sugarloaf/src/sugarloaf/state.rs
@@ -61,7 +61,7 @@ impl SugarState {
         advance_brush: &mut Renderer,
         context: &mut super::Context,
         graphics: &mut Graphics,
-        image_data: &mut rustc_hash::FxHashMap<u32, super::graphics::GraphicDataEntry>,
+        image_data: &mut rustc_hash::FxHashMap<u64, super::graphics::GraphicDataEntry>,
         image_overlays: &rustc_hash::FxHashMap<
             usize,
             Vec<super::graphics::GraphicOverlay>,


### PR DESCRIPTION
Builds on #1703 by @cantona — the three commits from that PR are preserved here with original authorship, rebased onto main (over the kitty placement rework from #1726), plus fixes from a performance and correctness review on top.

## From #1703 (rebased, unchanged)

- Shared extras slot per covered image row so large sixel/iTerm2 images stop exhausting the u16 extras id space, with a mark-and-sweep reclaim when the table nears the cap.
- TIFF decode for iTerm2 payloads (chafa emits TIFF).
- Atlas graphics (sixel/iTerm2) routed through the per-image texture overlay pipeline: visible rows are scanned for graphic cells and contiguous runs coalesce into one overlay per image row with a normalized source slice, so partial overwrites hide exactly the erased region and images scroll with the grid.

Fixes #1591.

## Added on top

**Disjoint image key namespaces.** The bridge keyed atlas textures as `0x8000_0000 | id` in the shared u32 image store — but kitty clients may pick any u32 image id (kitten icat uses random ones), so half the kitty id space collided with atlas textures, and the two would silently clobber each other. Image keys are now u64: kitty ids map verbatim (the full u32 space belongs to the client), atlas graphics live above 2^32.

**GPU texture eviction.** The per-image texture cache was only ever cleared wholesale; removing an image never freed its texture. Atlas `GraphicId`s are sequential and never reused, so sixel animation (timg, mcat) uploaded a new GPU texture per frame, forever. Removals now flow as final image keys through one queue (`sugarloaf.remove_image` frees both the pixel store and the cached texture), and kitty evictions — which previously pushed their ids into the removal queue where they were misinterpreted as atlas keys — now evict the right entry.

**Tests.** Atlas overlay scan unit tests (run coalescing, erased-cell splitting with positionally derived slices, font-resize scaling), key namespace disjointness, and the TextureRef drop queue.

## Performance notes from the review

- The per-frame row scan only runs on frames that render at all (Rio renders on damage), skips rows without extras via the existing per-row flag, and coalesces runs — measured cost is well bounded.
- The Noop/CursorOnly damage fall-through (snapshot freshness fix from #1703) is a per-row boolean check with early exit — negligible, kept as is.
- The texture eviction above was the real lifecycle cost: unbounded VRAM growth under any repeated-image workload.

583 rio-backend, 152 sugarloaf, 165 rioterm tests pass.