### PR TITLE
escape shell characters in dropped file paths

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1978,7 +1978,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     return;
                 }
 
-                let path: String = path.to_string_lossy().into();
+                let path = crate::platform::shell_escape(&path.to_string_lossy());
                 route.window.screen.paste(&(path + " "), true);
             }
 

--- a/frontends/rioterm/src/platform/mod.rs
+++ b/frontends/rioterm/src/platform/mod.rs
@@ -1,2 +1,83 @@
 #[cfg(target_os = "macos")]
 pub mod macos;
+
+/// Escape shell-sensitive characters in a string by prefixing each
+/// with a backslash. Suitable for inserting paths into a live
+/// terminal buffer, e.g. on file drag and drop.
+pub fn shell_escape(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(
+            c,
+            '\\' | ' '
+                | '('
+                | ')'
+                | '['
+                | ']'
+                | '{'
+                | '}'
+                | '<'
+                | '>'
+                | '"'
+                | '\''
+                | '`'
+                | '!'
+                | '#'
+                | '$'
+                | '&'
+                | ';'
+                | '|'
+                | '*'
+                | '?'
+                | '\t'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shell_escape;
+
+    #[test]
+    fn plain_path_is_unchanged() {
+        assert_eq!(shell_escape("/usr/local/bin/rio"), "/usr/local/bin/rio");
+    }
+
+    #[test]
+    fn spaces_and_parens_are_escaped() {
+        assert_eq!(
+            shell_escape("/Users/me/My File (1).txt"),
+            "/Users/me/My\\ File\\ \\(1\\).txt"
+        );
+    }
+
+    #[test]
+    fn shell_metacharacters_are_escaped() {
+        assert_eq!(
+            shell_escape("a$b`c\"d'e;f&g|h*i?j!k#l"),
+            "a\\$b\\`c\\\"d\\'e\\;f\\&g\\|h\\*i\\?j\\!k\\#l"
+        );
+    }
+
+    #[test]
+    fn backslash_is_escaped_without_double_escaping() {
+        assert_eq!(shell_escape("a\\ b"), "a\\\\\\ b");
+    }
+
+    #[test]
+    fn brackets_braces_and_redirects_are_escaped() {
+        assert_eq!(
+            shell_escape("x[1]{2}<3>4\t5"),
+            "x\\[1\\]\\{2\\}\\<3\\>4\\\t5"
+        );
+    }
+
+    #[test]
+    fn unicode_passes_through() {
+        assert_eq!(shell_escape("/tmp/café 図.png"), "/tmp/café\\ 図.png");
+    }
+}

--- a/frontends/rioterm/src/platform/mod.rs
+++ b/frontends/rioterm/src/platform/mod.rs
@@ -4,6 +4,7 @@ pub mod macos;
 /// Escape shell-sensitive characters in a string by prefixing each
 /// with a backslash. Suitable for inserting paths into a live
 /// terminal buffer, e.g. on file drag and drop.
+#[inline]
 pub fn shell_escape(s: &str) -> String {
     let mut escaped = String::with_capacity(s.len());
     for c in s.chars() {


### PR DESCRIPTION
Dropped file paths were pasted raw, so paths containing spaces, parentheses, quotes, `$`, `;` and other shell metacharacters would word split or execute as separate commands. Each sensitive character is now prefixed with a backslash before the path is written to the terminal, in a single pass so inserted backslashes are never double escaped.

Escaped set: `\` `space` `tab` `( ) [ ] { } < >` `" ' `` ` `` `! # $ & ; | * ?`

Closes #1730