### PR TITLE
shift sixel placements with reflowed text on resize

### DIFF
--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -774,18 +774,38 @@ impl Graphics {
     /// pixel store and the GPU texture. The vec is tiny, so a full
     /// recount beats distributed per-child bookkeeping.
     pub fn recount_atlas_keys(&mut self) {
+        Self::recount_atlas_keys_for(
+            &self.atlas_placements,
+            &mut self.atlas_key_refs,
+            &self.texture_operations,
+        );
+    }
+
+    pub fn recount_inactive_atlas_keys(&mut self) {
+        Self::recount_atlas_keys_for(
+            &self.kitty_inactive_screen.atlas_placements,
+            &mut self.kitty_inactive_screen.atlas_key_refs,
+            &self.texture_operations,
+        );
+    }
+
+    fn recount_atlas_keys_for(
+        placements: &[AtlasPlacement],
+        key_refs: &mut FxHashMap<u64, u32>,
+        texture_operations: &std::sync::Arc<parking_lot::Mutex<Vec<u64>>>,
+    ) {
         let mut refs: FxHashMap<u64, u32> = FxHashMap::default();
-        for placement in &self.atlas_placements {
+        for placement in placements {
             *refs.entry(placement.image_key).or_insert(0) += 1;
         }
-        let mut removals = self.texture_operations.lock();
-        for key in self.atlas_key_refs.keys() {
+        let mut removals = texture_operations.lock();
+        for key in key_refs.keys() {
             if !refs.contains_key(key) {
                 removals.push(*key);
             }
         }
         drop(removals);
-        self.atlas_key_refs = refs;
+        *key_refs = refs;
     }
 
     pub fn swap_kitty_screen_state(&mut self) {

--- a/rio-backend/src/crosswords/grid/mod.rs
+++ b/rio-backend/src/crosswords/grid/mod.rs
@@ -76,6 +76,47 @@ pub struct Grid<T> {
     /// Per-grid storage for the rare per-cell data that used to live inside
     /// `CellExtra` (zero-width chars, hyperlinks, sixel/iterm graphics).
     pub extras_table: ExtrasTable,
+
+    /// When set before `resize`, the column reflow records an exact
+    /// old-row to new-row mapping into `reflow_remap` so the caller
+    /// can re-anchor image placements to wherever their rows landed.
+    /// Costs one Vec sized to the ring, so it is only requested when
+    /// placements exist.
+    pub track_reflow_remap: bool,
+
+    /// Output of the last tracked column reflow; `None` when tracking
+    /// was off or the column count did not change.
+    pub reflow_remap: Option<ReflowRemap>,
+}
+
+/// Exact row mapping recorded during a column reflow, in oldest-first
+/// ring positions. A row's absolute index is `base_abs + position`;
+/// this holds on both sides of the reflow because cap truncation drops
+/// oldest rows and advances the eviction base by the same amount.
+#[derive(Debug, Clone)]
+pub struct ReflowRemap {
+    /// Absolute index of ring position 0 when the reflow started.
+    pub base_abs: u64,
+    /// For each old position, the position where that row's first
+    /// cell landed, or `-1` if the row's content was dropped.
+    pub new_pos: Vec<i64>,
+}
+
+impl ReflowRemap {
+    /// Remap an absolute row through the reflow. `None` means the row
+    /// was dropped. Rows already off the ring pass through unchanged;
+    /// scrollback expiry owns those.
+    pub fn remap_abs(&self, abs: i64) -> Option<i64> {
+        let pos = abs - self.base_abs as i64;
+        if pos < 0 {
+            return Some(abs);
+        }
+        let new = *self.new_pos.get(pos as usize)?;
+        if new < 0 {
+            return None;
+        }
+        Some(self.base_abs as i64 + new)
+    }
 }
 
 /// Slot table for `square::Extras`. Index `0` is reserved as the "no extras"
@@ -195,6 +236,8 @@ impl<T: GridSquare + Default + PartialEq + Clone> Grid<T> {
             raw: Storage::with_capacity(lines, columns),
             max_scroll_limit,
             total_lines_scrolled: 0,
+            track_reflow_remap: false,
+            reflow_remap: None,
             display_offset: 0,
             saved_cursor: Cursor::default(),
             cursor: Cursor::default(),

--- a/rio-backend/src/crosswords/grid/resize.rs
+++ b/rio-backend/src/crosswords/grid/resize.rs
@@ -121,23 +121,18 @@ impl Grid<Square> {
         });
 
         for (i, mut row) in rows.drain(..).enumerate().rev() {
-            if let Some(r) = remap.as_mut() {
-                // The row's first cell lands either appended to the
-                // previous row (unwrap) or in its own pushed row.
-                let merges = reversed.last().is_some_and(&should_reflow);
-                let dest = if merges {
-                    reversed.len() - 1
-                } else {
-                    reversed.len()
-                };
-                r.new_pos[old_len - 1 - i] = dest as i64;
-            }
+            // Index of the merge target while `last_row` holds the
+            // mutable borrow below.
+            let merge_target = reversed.len().wrapping_sub(1);
 
             // Check if reflowing should be performed.
             let last_row = match reversed.last_mut() {
                 Some(last_row) if should_reflow(last_row) => last_row,
                 _ => {
                     reversed.push(row);
+                    if let Some(r) = remap.as_mut() {
+                        r.new_pos[old_len - 1 - i] = (reversed.len() - 1) as i64;
+                    }
                     continue;
                 }
             };
@@ -161,8 +156,13 @@ impl Grid<Square> {
             let len = min(row.len(), num_wrapped);
 
             // Insert leading spacer when there's not enough room for reflowing wide char.
+            let mut first_cell_moved = true;
             let mut cells = if matches!(row[Column(len - 1)].wide(), Wide::Wide) {
                 num_wrapped -= 1;
+
+                // With a single free column, only the spacer is
+                // appended and the wide char stays on this row.
+                first_cell_moved = len > 1;
 
                 let mut cells = row.front_split_off(len - 1);
 
@@ -177,6 +177,17 @@ impl Grid<Square> {
 
             // Add removed cells to previous row and reflow content.
             last_row.append(&mut cells);
+
+            // The old row's first cell just landed at the end of the
+            // merge target, unless the wide-char spacer case kept it
+            // on this row; then it lands with the push below (the
+            // dropped-as-clear paths are unreachable while the row
+            // still holds the wide char).
+            if first_cell_moved {
+                if let Some(r) = remap.as_mut() {
+                    r.new_pos[old_len - 1 - i] = merge_target as i64;
+                }
+            }
 
             let cursor_buffer_line = self.lines - self.cursor.pos.row.0 as usize - 1;
 
@@ -221,6 +232,11 @@ impl Grid<Square> {
             }
 
             reversed.push(row);
+            if !first_cell_moved {
+                if let Some(r) = remap.as_mut() {
+                    r.new_pos[old_len - 1 - i] = (reversed.len() - 1) as i64;
+                }
+            }
         }
 
         // Make sure we have at least the viewport filled.
@@ -280,19 +296,18 @@ impl Grid<Square> {
             new_pos: vec![-1; old_len],
         });
 
+        // Each old row's first cell, as (old position, offset from the
+        // head of the not-yet-pushed cell stream). Recorded at the
+        // push that consumes the cell. Offsets survive across old-row
+        // iterations because a displaced wide char can travel in the
+        // buffered tail into the next iteration's first push.
+        let mut trackers: Vec<(usize, i64)> = Vec::new();
+
         for (i, mut row) in rows.drain(..).enumerate().rev() {
-            // Where this old row's first cell lands: the first push of
-            // this iteration (splitting only adds rows after it).
-            let mut recorded = false;
-            let mut record =
-                |new_raw: &Vec<Row<Square>>, remap: &mut Option<ReflowRemap>| {
-                    if !recorded {
-                        if let Some(r) = remap.as_mut() {
-                            r.new_pos[old_len - 1 - i] = (new_raw.len() - 1) as i64;
-                        }
-                        recorded = true;
-                    }
-                };
+            if remap.is_some() {
+                let own_first = buffered.as_ref().map_or(0, |b| b.len()) as i64;
+                trackers.push((old_len - 1 - i, own_first));
+            }
 
             // Append lines left over from the previous row.
             if let Some(buffered) = buffered.take() {
@@ -323,13 +338,18 @@ impl Grid<Square> {
                         } else {
                             // Since it fits, just push the existing line without any reflow.
                             new_raw.push(row);
-                            record(&new_raw, &mut remap);
+                            if let Some(r) = remap.as_mut() {
+                                for (p, _) in trackers.drain(..) {
+                                    r.new_pos[p] = (new_raw.len() - 1) as i64;
+                                }
+                            }
                             break;
                         }
                     }
                 };
 
                 // Insert spacer if a wide char would be wrapped into the last column.
+                let mut displaced = 0i64;
                 if row.len() >= columns
                     && matches!(row[Column(columns - 1)].wide(), Wide::Wide)
                 {
@@ -338,6 +358,7 @@ impl Grid<Square> {
 
                     let wide_char = mem::replace(&mut row[Column(columns - 1)], spacer);
                     wrapped.insert(0, wide_char);
+                    displaced = 1;
                 }
 
                 // Remove wide char spacer before shrinking.
@@ -346,7 +367,11 @@ impl Grid<Square> {
                     if len == 1 {
                         row[Column(columns - 1)].set_wrapline(true);
                         new_raw.push(row);
-                        record(&new_raw, &mut remap);
+                        if let Some(r) = remap.as_mut() {
+                            for (p, _) in trackers.drain(..) {
+                                r.new_pos[p] = (new_raw.len() - 1) as i64;
+                            }
+                        }
                         break;
                     } else {
                         // Remove the leading spacer from the end of the wrapped row.
@@ -356,7 +381,23 @@ impl Grid<Square> {
                 }
 
                 new_raw.push(row);
-                record(&new_raw, &mut remap);
+                if let Some(r) = remap.as_mut() {
+                    // This push consumed `columns` cells of the
+                    // stream, minus a wide char the spacer displaced
+                    // into the next row.
+                    let consumed = columns as i64 - displaced;
+                    trackers.retain(|&(p, off)| {
+                        if off < consumed {
+                            r.new_pos[p] = (new_raw.len() - 1) as i64;
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                    for t in trackers.iter_mut() {
+                        t.1 -= consumed;
+                    }
+                }
 
                 // Set line as wrapped if cells got removed.
                 if let Some(cell) = new_raw.last_mut().and_then(|r| r.last_mut()) {

--- a/rio-backend/src/crosswords/grid/resize.rs
+++ b/rio-backend/src/crosswords/grid/resize.rs
@@ -2,7 +2,7 @@
 // https://github.com/alacritty/alacritty/blob/e35e5ad14fce8456afdd89f2b392b9924bb27471/alacritty_terminal/src/grid/resize.rs
 // which is licensed under Apache 2.0 license.
 
-use crate::crosswords::grid::{Dimensions, Grid};
+use crate::crosswords::grid::{Dimensions, Grid, ReflowRemap};
 use crate::crosswords::pos::{Boundary, Column, Line};
 use crate::crosswords::square::{Square, Wide};
 use crate::crosswords::Row;
@@ -14,6 +14,10 @@ impl Grid<Square> {
     pub fn resize(&mut self, reflow: bool, lines: usize, columns: usize) {
         // Use empty template cell for resetting cells due to resize.
         let template = mem::take(&mut self.cursor.template);
+
+        // Only the column passes below produce a row remap; a stale
+        // one from an earlier resize must not leak through.
+        self.reflow_remap = None;
 
         match self.lines.cmp(&lines) {
             Ordering::Less => self.grow_lines(lines),
@@ -107,8 +111,28 @@ impl Grid<Square> {
         }
 
         let mut rows = self.raw.take_all();
+        let old_len = rows.len();
+        // Exact row tracking for image placements: rows are walked
+        // oldest-first, and a row's absolute index is `base_abs +
+        // oldest-first position` on both sides of the reflow.
+        let mut remap = self.track_reflow_remap.then(|| ReflowRemap {
+            base_abs: self.lines_evicted(),
+            new_pos: vec![-1; old_len],
+        });
 
         for (i, mut row) in rows.drain(..).enumerate().rev() {
+            if let Some(r) = remap.as_mut() {
+                // The row's first cell lands either appended to the
+                // previous row (unwrap) or in its own pushed row.
+                let merges = reversed.last().is_some_and(&should_reflow);
+                let dest = if merges {
+                    reversed.len() - 1
+                } else {
+                    reversed.len()
+                };
+                r.new_pos[old_len - 1 - i] = dest as i64;
+            }
+
             // Check if reflowing should be performed.
             let last_row = match reversed.last_mut() {
                 Some(last_row) if should_reflow(last_row) => last_row,
@@ -229,6 +253,8 @@ impl Grid<Square> {
 
         // Clamp display offset in case lines above it got merged.
         self.display_offset = min(self.display_offset, self.history_size());
+
+        self.reflow_remap = remap;
     }
 
     /// Shrink number of columns in each row, reflowing if necessary.
@@ -245,7 +271,29 @@ impl Grid<Square> {
         let mut buffered: Option<Vec<Square>> = None;
 
         let mut rows = self.raw.take_all();
+        let old_len = rows.len();
+        // See `grow_columns`; `base_abs + position` also survives the
+        // cap truncation below because dropping the N oldest rows
+        // advances the eviction base by the same N.
+        let mut remap = self.track_reflow_remap.then(|| ReflowRemap {
+            base_abs: self.lines_evicted(),
+            new_pos: vec![-1; old_len],
+        });
+
         for (i, mut row) in rows.drain(..).enumerate().rev() {
+            // Where this old row's first cell lands: the first push of
+            // this iteration (splitting only adds rows after it).
+            let mut recorded = false;
+            let mut record =
+                |new_raw: &Vec<Row<Square>>, remap: &mut Option<ReflowRemap>| {
+                    if !recorded {
+                        if let Some(r) = remap.as_mut() {
+                            r.new_pos[old_len - 1 - i] = (new_raw.len() - 1) as i64;
+                        }
+                        recorded = true;
+                    }
+                };
+
             // Append lines left over from the previous row.
             if let Some(buffered) = buffered.take() {
                 // Add a column for every cell added before the cursor, if it goes beyond the new
@@ -275,6 +323,7 @@ impl Grid<Square> {
                         } else {
                             // Since it fits, just push the existing line without any reflow.
                             new_raw.push(row);
+                            record(&new_raw, &mut remap);
                             break;
                         }
                     }
@@ -297,6 +346,7 @@ impl Grid<Square> {
                     if len == 1 {
                         row[Column(columns - 1)].set_wrapline(true);
                         new_raw.push(row);
+                        record(&new_raw, &mut remap);
                         break;
                     } else {
                         // Remove the leading spacer from the end of the wrapped row.
@@ -306,6 +356,7 @@ impl Grid<Square> {
                 }
 
                 new_raw.push(row);
+                record(&new_raw, &mut remap);
 
                 // Set line as wrapped if cells got removed.
                 if let Some(cell) = new_raw.last_mut().and_then(|r| r.last_mut()) {
@@ -386,5 +437,7 @@ impl Grid<Square> {
 
         // Clamp the saved cursor to the grid.
         self.saved_cursor.pos.col = min(self.saved_cursor.pos.col, Column(columns - 1));
+
+        self.reflow_remap = remap;
     }
 }

--- a/rio-backend/src/crosswords/grid/tests.rs
+++ b/rio-backend/src/crosswords/grid/tests.rs
@@ -358,3 +358,72 @@ fn wrap_cell(c: char) -> Square {
     cell.set_wrapline(true);
     cell
 }
+
+fn wide_cell(c: char) -> Square {
+    let mut cell = cell(c);
+    cell.set_wide(crate::crosswords::square::Wide::Wide);
+    cell
+}
+
+fn spacer_cell() -> Square {
+    let mut cell = Square::default();
+    cell.set_wide(crate::crosswords::square::Wide::Spacer);
+    cell
+}
+
+#[test]
+fn shrink_reflow_remap_tracks_displaced_wide_char() {
+    // A wrapped tail of exactly `columns - 1` cells is buffered into
+    // the next row, whose first cell is a wide char. The spacer logic
+    // displaces that wide char into the following push, so the remap
+    // must record the row after the one receiving the buffered tail.
+    let mut grid = Grid::<Square>::new(3, 8, 4);
+    for (n, c) in "1234567".chars().enumerate() {
+        grid[Line(0)][Column(n)] = cell(c);
+    }
+    grid[Line(0)][Column(6)] = wrap_cell('7');
+    grid[Line(1)][Column(0)] = wide_cell('W');
+    grid[Line(1)][Column(1)] = spacer_cell();
+    grid[Line(1)][Column(2)] = cell('x');
+
+    grid.track_reflow_remap = true;
+    grid.resize(true, 3, 4);
+    grid.track_reflow_remap = false;
+
+    let remap = grid.reflow_remap.take().expect("remap must be recorded");
+    assert_eq!(remap.base_abs, 0);
+    // Old row 0 lands at 0; the wide-char row's first cell lands at 2
+    // (position 1 holds the buffered "567" tail plus the spacer); the
+    // trailing blank row lands at 3.
+    assert_eq!(remap.new_pos, vec![0, 2, 3]);
+
+    // Cross-check against where the wide char actually sits.
+    let total = grid.total_lines() as i32;
+    let screen = grid.screen_lines() as i32;
+    let wide_line = Line(2 - (total - screen));
+    assert_eq!(grid[wide_line][Column(0)], wide_cell('W'));
+}
+
+#[test]
+fn grow_reflow_remap_tracks_unmerged_wide_char() {
+    // The merge target has exactly one free column, so only a leading
+    // spacer is appended and the wide char stays on its own row. The
+    // remap must record the pushed remainder row, not the merge
+    // target.
+    let mut grid = Grid::<Square>::new(2, 4, 2);
+    for (n, c) in "1234".chars().enumerate() {
+        grid[Line(0)][Column(n)] = cell(c);
+    }
+    grid[Line(0)][Column(3)] = wrap_cell('4');
+    grid[Line(1)][Column(0)] = wide_cell('W');
+    grid[Line(1)][Column(1)] = spacer_cell();
+
+    grid.track_reflow_remap = true;
+    grid.resize(true, 2, 5);
+    grid.track_reflow_remap = false;
+
+    let remap = grid.reflow_remap.take().expect("remap must be recorded");
+    assert_eq!(remap.base_abs, 0);
+    assert_eq!(remap.new_pos, vec![0, 1]);
+    assert_eq!(grid[Line(1)][Column(0)], wide_cell('W'));
+}

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -894,9 +894,38 @@ impl<U: EventListener> Crosswords<U> {
                     .kitty_placements
                     .is_empty();
         }
+
+        // Sixel/iTerm2 placements live in the same absolute row space
+        // and must follow the reflowed text just like kitty ones. The
+        // dirty flag is required even when the shift is zero: the
+        // renderer only refreshes its placement snapshot when it sees
+        // the flag, and resize invalidates positions regardless.
+        if !self.graphics.atlas_placements.is_empty()
+            || !self
+                .graphics
+                .kitty_inactive_screen
+                .atlas_placements
+                .is_empty()
+        {
+            if dest_row_shift != 0 {
+                for p in self.graphics.atlas_placements.iter_mut() {
+                    p.abs_row += dest_row_shift;
+                }
+                for p in self
+                    .graphics
+                    .kitty_inactive_screen
+                    .atlas_placements
+                    .iter_mut()
+                {
+                    p.abs_row += dest_row_shift;
+                }
+            }
+            overlay_changed = true;
+        }
         if overlay_changed {
             self.graphics.kitty_graphics_dirty = true;
         }
+        self.expire_atlas_placements();
     }
 
     /// Toggle the vi mode.

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -787,26 +787,35 @@ impl<U: EventListener> Crosswords<U> {
         delta = std::cmp::min(std::cmp::max(delta, min_delta), history_size as i32);
         self.vi_mode_cursor.pos.row += delta;
 
-        // Snapshot the cursor's *absolute* row (history + screen row)
-        // before the grid is reflowed. Kitty placements live in the
-        // same absolute coordinate space, and we use the cursor as a
-        // proxy for "where the surrounding text is". When reflow
-        // unwraps a row above the cursor (e.g. a long prompt fits on
-        // one line after the window widens), the cursor moves up to
-        // follow its content; we shift placements by the same amount
-        // so the image moves with the text. For grow_lines pulling
-        // from history the cursor's *absolute* row is invariant
-        // (history shrinks by N, cursor.row grows by N), so the
-        // delta naturally falls out to zero and placements stay put
-        // — which is what we want, since neither the cursor nor the
-        // image actually moved relative to the buffer.
-        let pre_resize_cursor_abs = self.grid.lines_evicted() as i64
-            + history_size as i64
-            + self.grid.cursor.pos.row.0 as i64;
+        // Image placements (kitty and sixel/iTerm2) anchor at absolute
+        // rows. A column reflow moves content to different rows, so ask
+        // each grid to record an exact old-row to new-row mapping while
+        // it reflows, but only when that grid's screen actually has
+        // placements; tracking costs a Vec sized to the ring. Vertical
+        // resizes never move content in absolute row space and produce
+        // no remap.
+        let active_has_placements = !self.graphics.kitty_placements.is_empty()
+            || !self.graphics.atlas_placements.is_empty();
+        let inactive_has_placements = !self
+            .graphics
+            .kitty_inactive_screen
+            .kitty_placements
+            .is_empty()
+            || !self
+                .graphics
+                .kitty_inactive_screen
+                .atlas_placements
+                .is_empty();
 
         let is_alt = self.mode.contains(Mode::ALT_SCREEN);
+        self.grid.track_reflow_remap = active_has_placements;
+        self.inactive_grid.track_reflow_remap = inactive_has_placements;
         self.grid.resize(!is_alt, num_lines, num_cols);
         self.inactive_grid.resize(is_alt, num_lines, num_cols);
+        self.grid.track_reflow_remap = false;
+        self.inactive_grid.track_reflow_remap = false;
+        let active_remap = self.grid.reflow_remap.take();
+        let inactive_remap = self.inactive_grid.reflow_remap.take();
 
         // Invalidate selection and tabs only when necessary.
         if old_cols != num_cols {
@@ -838,24 +847,12 @@ impl<U: EventListener> Crosswords<U> {
         // Update size information for graphics.
         self.graphics.resize(&size);
 
-        // Compute the placement dest_row shift. See the comment above
-        // where we captured `pre_resize_cursor_abs`. Note: we use the
-        // *absolute* cursor row (history + cursor.row), not screen
-        // row, so vertical resizes (which move cursor.row but keep
-        // the absolute row constant) don't shift placements.
-        let post_resize_cursor_abs = self.grid.lines_evicted() as i64
-            + self.history_size() as i64
-            + self.grid.cursor.pos.row.0 as i64;
-        let dest_row_shift = post_resize_cursor_abs - pre_resize_cursor_abs;
-
         // Rescale overlay placements for the new cell size (cell-sized
         // placements track the grid; native-size ones keep their pixel
-        // dimensions), and shift dest_row to follow the text. Active
-        // and inactive screens both get the treatment so alt-screen
-        // images aren't stale on swap-back.
+        // dimensions). Active and inactive screens both get the
+        // treatment so alt-screen images aren't stale on swap-back.
         let cell_w = self.graphics.cell_width.round() as usize;
         let cell_h = self.graphics.cell_height.round() as usize;
-        let mut overlay_changed = false;
         if cell_w > 0 && cell_h > 0 {
             for p in self.graphics.kitty_placements.values_mut() {
                 let (iw, ih) = self
@@ -865,9 +862,6 @@ impl<U: EventListener> Crosswords<U> {
                     .map(|s| (s.data.width, s.data.height))
                     .unwrap_or((0, 0));
                 p.rescale(iw, ih, cell_w, cell_h);
-                if dest_row_shift != 0 {
-                    p.dest_row += dest_row_shift;
-                }
             }
             for p in self
                 .graphics
@@ -883,46 +877,67 @@ impl<U: EventListener> Crosswords<U> {
                     .map(|s| (s.data.width, s.data.height))
                     .unwrap_or((0, 0));
                 p.rescale(iw, ih, cell_w, cell_h);
-                if dest_row_shift != 0 {
-                    p.dest_row += dest_row_shift;
-                }
             }
-            overlay_changed = !self.graphics.kitty_placements.is_empty()
-                || !self
-                    .graphics
-                    .kitty_inactive_screen
-                    .kitty_placements
-                    .is_empty();
         }
 
-        // Sixel/iTerm2 placements live in the same absolute row space
-        // and must follow the reflowed text just like kitty ones. The
-        // dirty flag is required even when the shift is zero: the
-        // renderer only refreshes its placement snapshot when it sees
-        // the flag, and resize invalidates positions regardless.
-        if !self.graphics.atlas_placements.is_empty()
-            || !self
-                .graphics
-                .kitty_inactive_screen
-                .atlas_placements
-                .is_empty()
-        {
-            if dest_row_shift != 0 {
-                for p in self.graphics.atlas_placements.iter_mut() {
-                    p.abs_row += dest_row_shift;
-                }
-                for p in self
-                    .graphics
-                    .kitty_inactive_screen
-                    .atlas_placements
-                    .iter_mut()
-                {
-                    p.abs_row += dest_row_shift;
+        // Re-anchor placements through the exact reflow row mapping:
+        // each one moves to wherever its anchor row's content landed.
+        // Kitty placements on a dropped row stay put (they float and
+        // get culled off screen); sixel/iTerm2 placements are grid
+        // content and are destroyed, along with any that a truncation
+        // pushed past the ring end.
+        if let Some(remap) = &active_remap {
+            let max_abs =
+                self.grid.lines_evicted() as i64 + self.grid.total_lines() as i64;
+            for p in self.graphics.kitty_placements.values_mut() {
+                if let Some(abs) = remap.remap_abs(p.dest_row) {
+                    p.dest_row = abs;
                 }
             }
-            overlay_changed = true;
+            let before = self.graphics.atlas_placements.len();
+            self.graphics.atlas_placements.retain_mut(|p| {
+                match remap.remap_abs(p.abs_row) {
+                    Some(abs) if abs < max_abs => {
+                        p.abs_row = abs;
+                        true
+                    }
+                    _ => false,
+                }
+            });
+            if self.graphics.atlas_placements.len() != before {
+                self.graphics.recount_atlas_keys();
+                self.send_graphics_updates();
+            }
         }
-        if overlay_changed {
+        if let Some(remap) = &inactive_remap {
+            let max_abs = self.inactive_grid.lines_evicted() as i64
+                + self.inactive_grid.total_lines() as i64;
+            let inactive = &mut self.graphics.kitty_inactive_screen;
+            for p in inactive.kitty_placements.values_mut() {
+                if let Some(abs) = remap.remap_abs(p.dest_row) {
+                    p.dest_row = abs;
+                }
+            }
+            let before = inactive.atlas_placements.len();
+            inactive
+                .atlas_placements
+                .retain_mut(|p| match remap.remap_abs(p.abs_row) {
+                    Some(abs) if abs < max_abs => {
+                        p.abs_row = abs;
+                        true
+                    }
+                    _ => false,
+                });
+            if inactive.atlas_placements.len() != before {
+                self.graphics.recount_inactive_atlas_keys();
+                self.send_graphics_updates();
+            }
+        }
+
+        // The renderer only refreshes its placement snapshot when it
+        // sees the dirty flag, and resize invalidates positions even
+        // when no placement field changed (history and viewport moved).
+        if active_has_placements || inactive_has_placements {
             self.graphics.kitty_graphics_dirty = true;
         }
         self.expire_atlas_placements();

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -3895,6 +3895,93 @@ fn test_resize_narrow_with_prompt_after_image() {
     );
 }
 
+#[test]
+fn test_resize_widen_unwraps_sixel_follows() {
+    // Sixel analog of the kitty widen test: a wrapped command above a
+    // sixel unwraps when the window widens, so the placement must move
+    // up by one row with the text, and the resize must mark the
+    // overlay dirty so the renderer refreshes its placement snapshot.
+    use crate::performer::handler::Handler;
+    let event_listener = TestEventListener;
+    let window_id = unsafe { WindowId::dummy() };
+    let mut term: Crosswords<TestEventListener> = Crosswords::new(
+        crate::crosswords::CrosswordsSize::new(20, 10),
+        crate::ansi::CursorShape::Block,
+        event_listener,
+        window_id,
+        0,
+        10_000,
+    );
+    term.graphics.cell_width = 10.0;
+    term.graphics.cell_height = 20.0;
+
+    // 32 chars wrap onto 2 rows at columns=20, fit on 1 at columns=50.
+    type_text(&mut term, "$ convert image.png sixel:- 1234");
+    term.linefeed();
+    term.carriage_return();
+
+    term.insert_graphic(atlas_graphic(), None, None);
+    let initial_abs_row = term.graphics.atlas_placements[0].abs_row;
+    term.graphics.kitty_graphics_dirty = false;
+
+    term.resize(ReflowDim {
+        columns: 50,
+        lines: 10,
+    });
+
+    let final_abs_row = term.graphics.atlas_placements[0].abs_row;
+    assert_eq!(
+        final_abs_row,
+        initial_abs_row - 1,
+        "widening should shift the sixel up with the unwrapped command"
+    );
+    assert!(
+        term.graphics.kitty_graphics_dirty,
+        "resize with sixel placements must mark the overlay dirty, or \
+         the renderer keeps painting from a stale placement snapshot"
+    );
+}
+
+#[test]
+fn test_resize_narrow_wraps_sixel_follows() {
+    // Mirror case: the command above the sixel wraps when the window
+    // narrows, so the placement must move down by one row.
+    use crate::performer::handler::Handler;
+    let event_listener = TestEventListener;
+    let window_id = unsafe { WindowId::dummy() };
+    let mut term: Crosswords<TestEventListener> = Crosswords::new(
+        crate::crosswords::CrosswordsSize::new(50, 10),
+        crate::ansi::CursorShape::Block,
+        event_listener,
+        window_id,
+        0,
+        10_000,
+    );
+    term.graphics.cell_width = 10.0;
+    term.graphics.cell_height = 20.0;
+
+    type_text(&mut term, "$ convert image.png sixel:- 1234");
+    term.linefeed();
+    term.carriage_return();
+
+    term.insert_graphic(atlas_graphic(), None, None);
+    let initial_abs_row = term.graphics.atlas_placements[0].abs_row;
+    term.graphics.kitty_graphics_dirty = false;
+
+    term.resize(ReflowDim {
+        columns: 20,
+        lines: 10,
+    });
+
+    let final_abs_row = term.graphics.atlas_placements[0].abs_row;
+    assert_eq!(
+        final_abs_row,
+        initial_abs_row + 1,
+        "narrowing should shift the sixel down with the wrapped command"
+    );
+    assert!(term.graphics.kitty_graphics_dirty);
+}
+
 // Animation actions surface EINVAL (regression).
 
 #[test]

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -3982,6 +3982,131 @@ fn test_resize_narrow_wraps_sixel_follows() {
     assert!(term.graphics.kitty_graphics_dirty);
 }
 
+#[test]
+fn test_resize_widen_sixel_above_wrap_change_stays_put() {
+    // A wrapped line BETWEEN the image and the cursor unwraps when the
+    // window widens. Only content below the image moved, so the image
+    // must stay anchored. A global cursor-derived shift gets this
+    // wrong (the cursor moves up, the image does not); the exact
+    // reflow row remap keeps it in place.
+    use crate::performer::handler::Handler;
+    let event_listener = TestEventListener;
+    let window_id = unsafe { WindowId::dummy() };
+    let mut term: Crosswords<TestEventListener> = Crosswords::new(
+        crate::crosswords::CrosswordsSize::new(20, 10),
+        crate::ansi::CursorShape::Block,
+        event_listener,
+        window_id,
+        0,
+        10_000,
+    );
+    term.graphics.cell_width = 10.0;
+    term.graphics.cell_height = 20.0;
+
+    // Row 0: short label, no wrap. Rows 1-2: the sixel.
+    type_text(&mut term, "img");
+    term.linefeed();
+    term.carriage_return();
+    term.insert_graphic(atlas_graphic(), None, None);
+    term.linefeed();
+    term.carriage_return();
+
+    // Below the image: 32 chars wrap onto 2 rows at columns=20.
+    type_text(&mut term, "$ convert image.png sixel:- 1234");
+    term.linefeed();
+    term.carriage_return();
+
+    let initial_abs_row = term.graphics.atlas_placements[0].abs_row;
+    let cursor_before = term.grid.cursor.pos.row.0;
+
+    term.resize(ReflowDim {
+        columns: 50,
+        lines: 10,
+    });
+
+    assert_eq!(
+        term.grid.cursor.pos.row.0,
+        cursor_before - 1,
+        "test setup: the line below the image should have unwrapped"
+    );
+    assert_eq!(
+        term.graphics.atlas_placements[0].abs_row, initial_abs_row,
+        "unwrapping below the image must not move it"
+    );
+}
+
+#[test]
+fn test_resize_widen_kitty_above_wrap_change_stays_put() {
+    // Kitty twin of the sixel test above: dest_row goes through the
+    // same exact reflow remap.
+    use crate::performer::handler::Handler;
+    let event_listener = TestEventListener;
+    let window_id = unsafe { WindowId::dummy() };
+    let mut term: Crosswords<TestEventListener> = Crosswords::new(
+        crate::crosswords::CrosswordsSize::new(20, 10),
+        crate::ansi::CursorShape::Block,
+        event_listener,
+        window_id,
+        0,
+        10_000,
+    );
+    term.graphics.cell_width = 10.0;
+    term.graphics.cell_height = 20.0;
+
+    type_text(&mut term, "img");
+    term.linefeed();
+    term.carriage_return();
+
+    store_red_pixel(&mut term, 1);
+    let placement = kitty_graphics_protocol::PlacementRequest {
+        image_id: 1,
+        placement_id: 0,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        columns: 1,
+        rows: 1,
+        z_index: 0,
+        virtual_placement: false,
+        unicode_placeholder: 0,
+        cursor_movement: 1,
+        cell_x_offset: 0,
+        cell_y_offset: 0,
+    };
+    term.place_graphic(placement);
+    term.linefeed();
+    term.carriage_return();
+
+    type_text(&mut term, "$ convert image.png sixel:- 1234");
+    term.linefeed();
+    term.carriage_return();
+
+    let initial_dest_row = term
+        .graphics
+        .kitty_placements
+        .values()
+        .next()
+        .unwrap()
+        .dest_row;
+
+    term.resize(ReflowDim {
+        columns: 50,
+        lines: 10,
+    });
+
+    assert_eq!(
+        term.graphics
+            .kitty_placements
+            .values()
+            .next()
+            .unwrap()
+            .dest_row,
+        initial_dest_row,
+        "unwrapping below the image must not move it"
+    );
+}
+
 // Animation actions surface EINVAL (regression).
 
 #[test]


### PR DESCRIPTION
`Crosswords::resize` shifted kitty placements to follow reflowed text and marked the overlay dirty, but never touched sixel/iTerm2 placements. After a resize their rows were stale and the renderer kept painting from an old placement snapshot, so images drew mispositioned and under text that had never clipped them.
