### PR TITLE
raise max tab width to 240

### DIFF
--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -22,7 +22,7 @@ const PROGRESS_BAR_TIMEOUT_SECS: u64 = 15;
 const TITLE_FONT_SIZE: f32 = 12.0;
 
 const TAB_PADDING_X: f32 = 27.0;
-const MAX_TAB_WIDTH: f32 = 180.0;
+const MAX_TAB_WIDTH: f32 = 240.0;
 const TAB_GAP: f32 = 6.0;
 const TAB_INSET_Y: f32 = 7.0;
 const TAB_RADIUS: f32 = 6.0;

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -1702,9 +1702,9 @@ mod tests {
         assert_eq!(layout.tabs_width, 480.0);
 
         // The cap is configurable via navigation.max-tab-width.
-        let layout = tab_strip_layout(3000.0, 2.0, 2, 400.0);
-        assert_eq!(layout.tab_width, 400.0);
-        assert_eq!(layout.tabs_width, 800.0);
+        let layout = tab_strip_layout(3000.0, 2.0, 2, 280.0);
+        assert_eq!(layout.tab_width, 280.0);
+        assert_eq!(layout.tabs_width, 560.0);
         // The tabs region ends well before the 1500 logical px strip.
         assert!(layout.left_margin + layout.tabs_width < 1500.0);
 

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -22,7 +22,6 @@ const PROGRESS_BAR_TIMEOUT_SECS: u64 = 15;
 const TITLE_FONT_SIZE: f32 = 12.0;
 
 const TAB_PADDING_X: f32 = 27.0;
-const MAX_TAB_WIDTH: f32 = 240.0;
 const TAB_GAP: f32 = 6.0;
 const TAB_INSET_Y: f32 = 7.0;
 const TAB_RADIUS: f32 = 6.0;
@@ -136,10 +135,12 @@ pub struct TabStripLayout {
 }
 
 /// Compute the tab strip layout from the physical window width.
+/// `max_tab_width` comes from `navigation.max-tab-width` (logical px).
 pub fn tab_strip_layout(
     window_width: f32,
     scale_factor: f32,
     num_tabs: usize,
+    max_tab_width: f32,
 ) -> TabStripLayout {
     #[cfg(target_os = "macos")]
     let left_margin = ISLAND_MARGIN_LEFT_MACOS;
@@ -148,7 +149,8 @@ pub fn tab_strip_layout(
 
     let available_width =
         (window_width / scale_factor) - ISLAND_MARGIN_RIGHT - left_margin;
-    let tab_width = (available_width / num_tabs.max(1) as f32).clamp(0.0, MAX_TAB_WIDTH);
+    let tab_width =
+        (available_width / num_tabs.max(1) as f32).clamp(0.0, max_tab_width.max(0.0));
     TabStripLayout {
         left_margin,
         tab_width,
@@ -303,6 +305,8 @@ fn draw_close_button(
 
 pub struct Island {
     pub hide_if_single: bool,
+    /// Cap on tab width in logical px (`navigation.max-tab-width`).
+    pub max_tab_width: f32,
     pub inactive_text_color: [f32; 4],
     pub active_text_color: [f32; 4],
     /// Current progress bar state
@@ -344,9 +348,11 @@ impl Island {
         inactive_text_color: [f32; 4],
         active_text_color: [f32; 4],
         hide_if_single: bool,
+        max_tab_width: f32,
     ) -> Self {
         Self {
             hide_if_single,
+            max_tab_width,
             inactive_text_color,
             active_text_color,
             progress_state: None,
@@ -746,7 +752,8 @@ impl Island {
         self.slide_springs
             .retain(|_, s| s.update(dt, DRAG_ANIMATION_LENGTH));
 
-        let layout = tab_strip_layout(window_width, scale_factor, num_tabs);
+        let layout =
+            tab_strip_layout(window_width, scale_factor, num_tabs, self.max_tab_width);
         let TabStripLayout {
             left_margin,
             tab_width,
@@ -1085,7 +1092,7 @@ impl Island {
             left_margin,
             tab_width,
             ..
-        } = tab_strip_layout(window_width, scale_factor, num_tabs);
+        } = tab_strip_layout(window_width, scale_factor, num_tabs, self.max_tab_width);
         let tab_x = left_margin + picker_tab as f32 * tab_width;
 
         // Picker is rendered just below the island
@@ -1394,7 +1401,6 @@ mod tests {
     fn island_geometry_invariants() {
         const {
             assert!(TAB_INSET_Y * 2.0 < ISLAND_HEIGHT);
-            assert!(TAB_GAP < MAX_TAB_WIDTH);
             assert!(CLOSE_MARGIN_RIGHT + CLOSE_HIT_HALF_WIDTH < CLOSE_MIN_ISLAND_WIDTH);
             assert!(CLOSE_HOVER_HALF * 2.0 <= ISLAND_HEIGHT - TAB_INSET_Y * 2.0);
         }
@@ -1459,7 +1465,7 @@ mod tests {
         let inactive_color = [0.5, 0.5, 0.5, 1.0];
         let active_color = [0.9, 0.9, 0.9, 1.0];
 
-        let island = Island::new(inactive_color, active_color, true);
+        let island = Island::new(inactive_color, active_color, true, 240.0);
 
         assert_eq!(island.inactive_text_color, inactive_color);
         assert_eq!(island.active_text_color, active_color);
@@ -1468,12 +1474,13 @@ mod tests {
 
     #[test]
     fn test_island_height() {
-        let island = Island::new([0.8, 0.8, 0.8, 1.0], [1.0, 1.0, 1.0, 1.0], false);
+        let island =
+            Island::new([0.8, 0.8, 0.8, 1.0], [1.0, 1.0, 1.0, 1.0], false, 240.0);
         assert_eq!(island.height(), ISLAND_HEIGHT);
     }
 
     fn test_island() -> Island {
-        Island::new([0.5, 0.5, 0.5, 1.0], [0.9, 0.9, 0.9, 1.0], false)
+        Island::new([0.5, 0.5, 0.5, 1.0], [0.9, 0.9, 0.9, 1.0], false, 240.0)
     }
 
     #[test]
@@ -1669,7 +1676,7 @@ mod tests {
         // 1000 physical px @ 2x scale → 500 logical px window. Slots
         // stay below the cap here, so the math matches the old
         // fill-the-strip layout.
-        let layout = tab_strip_layout(1000.0, 2.0, 4);
+        let layout = tab_strip_layout(1000.0, 2.0, 4, 240.0);
         #[cfg(target_os = "macos")]
         {
             assert_eq!(layout.left_margin, ISLAND_MARGIN_LEFT_MACOS);
@@ -1683,20 +1690,27 @@ mod tests {
             assert_eq!(layout.tabs_width, 492.0);
         }
         // Zero tabs clamps the divisor.
-        assert!(tab_strip_layout(1000.0, 2.0, 0).tab_width.is_finite());
+        assert!(tab_strip_layout(1000.0, 2.0, 0, 240.0)
+            .tab_width
+            .is_finite());
     }
 
     #[test]
     fn tab_strip_layout_caps_slot_width() {
-        let layout = tab_strip_layout(3000.0, 2.0, 2);
-        assert_eq!(layout.tab_width, MAX_TAB_WIDTH);
-        assert_eq!(layout.tabs_width, MAX_TAB_WIDTH * 2.0);
+        let layout = tab_strip_layout(3000.0, 2.0, 2, 240.0);
+        assert_eq!(layout.tab_width, 240.0);
+        assert_eq!(layout.tabs_width, 480.0);
+
+        // The cap is configurable via navigation.max-tab-width.
+        let layout = tab_strip_layout(3000.0, 2.0, 2, 400.0);
+        assert_eq!(layout.tab_width, 400.0);
+        assert_eq!(layout.tabs_width, 800.0);
         // The tabs region ends well before the 1500 logical px strip.
         assert!(layout.left_margin + layout.tabs_width < 1500.0);
 
         // Pathologically narrow window: width clamps at 0 instead of
         // going negative.
-        let layout = tab_strip_layout(10.0, 2.0, 4);
+        let layout = tab_strip_layout(10.0, 2.0, 4, 240.0);
         assert_eq!(layout.tab_width, 0.0);
         assert_eq!(layout.tabs_width, 0.0);
     }

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -122,6 +122,7 @@ impl Renderer {
                 named_colors.tabs,
                 named_colors.tabs_active,
                 config.navigation.hide_if_single,
+                config.navigation.max_tab_width,
             ))
         } else {
             None

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -449,6 +449,7 @@ impl Screen<'_> {
         self.renderer.is_window_focused = was_focused;
         if let Some(mut island) = old_island {
             island.update_colors(config.colors.tabs, config.colors.tabs_active);
+            island.max_tab_width = config.navigation.max_tab_width;
             self.renderer.island = Some(island);
         }
 
@@ -2655,10 +2656,17 @@ impl Screen<'_> {
 
     #[inline]
     fn island_tab_layout(&self, num_tabs: usize) -> TabStripLayout {
+        let max_tab_width = self
+            .renderer
+            .island
+            .as_ref()
+            .map(|island| island.max_tab_width)
+            .unwrap_or_else(rio_backend::config::navigation::default_max_tab_width);
         island::tab_strip_layout(
             self.sugarloaf.window_size().width,
             self.sugarloaf.scale_factor(),
             num_tabs,
+            max_tab_width,
         )
     }
 

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -585,6 +585,9 @@ impl Config {
             if let Some(fill) = navigation_overwrite.unfocused_split_fill {
                 self.navigation.unfocused_split_fill = Some(fill);
             }
+            if let Some(max_tab_width) = navigation_overwrite.max_tab_width {
+                self.navigation.max_tab_width = max_tab_width;
+            }
         }
 
         // Clamp after platform merge so both the base and any override go
@@ -593,6 +596,8 @@ impl Config {
             crate::config::navigation::clamp_unfocused_split_opacity(
                 self.navigation.unfocused_split_opacity,
             );
+        self.navigation.max_tab_width =
+            crate::config::navigation::clamp_max_tab_width(self.navigation.max_tab_width);
 
         // Merge renderer fields individually
         if let Some(renderer_overwrite) = &platform_config.renderer {

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -7,6 +7,23 @@ pub fn default_unfocused_split_opacity() -> f32 {
     0.7
 }
 
+#[inline]
+pub fn default_max_tab_width() -> f32 {
+    240.0
+}
+
+/// Clamp `max_tab_width` to `[80.0, 2000.0]`.
+///
+/// Below the lower bound the close button and title no longer fit; the
+/// upper bound just keeps a typo from producing a strip-wide tab.
+#[inline]
+pub fn clamp_max_tab_width(v: f32) -> f32 {
+    if !v.is_finite() {
+        return default_max_tab_width();
+    }
+    v.clamp(80.0, 2000.0)
+}
+
 /// Clamp `unfocused_split_opacity` to `[0.15, 1.0]`.
 ///
 /// A value of `0.0` makes the inactive pane invisible, which is never what
@@ -150,6 +167,11 @@ pub struct Navigation {
         rename = "unfocused-split-fill"
     )]
     pub unfocused_split_fill: Option<ColorArray>,
+    /// Maximum width of a tab in logical pixels. Tabs shrink below
+    /// this as more open; the cap only limits how wide a tab grows
+    /// when few are open. Clamped to `[80.0, 2000.0]` at load time.
+    #[serde(default = "default_max_tab_width", rename = "max-tab-width")]
+    pub max_tab_width: f32,
 }
 
 impl Default for Navigation {
@@ -165,6 +187,7 @@ impl Default for Navigation {
             unfocused_split_opacity: default_unfocused_split_opacity(),
             unfocused_split_fill: None,
             open_config_with_split: true,
+            max_tab_width: default_max_tab_width(),
         }
     }
 }

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -12,17 +12,15 @@ pub fn default_max_tab_width() -> f32 {
     240.0
 }
 
-/// Clamp `max_tab_width` to `[80.0, 480.0]`.
+/// Clamp `max_tab_width` to `[80.0, 280.0]`.
 ///
 /// Below the lower bound the close button and title no longer fit.
-/// The window width already bounds how wide a tab can actually get,
-/// so the upper bound only keeps configured values in a sane range.
 #[inline]
 pub fn clamp_max_tab_width(v: f32) -> f32 {
     if !v.is_finite() {
         return default_max_tab_width();
     }
-    v.clamp(80.0, 480.0)
+    v.clamp(80.0, 280.0)
 }
 
 /// Clamp `unfocused_split_opacity` to `[0.15, 1.0]`.
@@ -170,7 +168,7 @@ pub struct Navigation {
     pub unfocused_split_fill: Option<ColorArray>,
     /// Maximum width of a tab in logical pixels. Tabs shrink below
     /// this as more open; the cap only limits how wide a tab grows
-    /// when few are open. Clamped to `[80.0, 480.0]` at load time.
+    /// when few are open. Clamped to `[80.0, 280.0]` at load time.
     #[serde(default = "default_max_tab_width", rename = "max-tab-width")]
     pub max_tab_width: f32,
 }

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -12,16 +12,17 @@ pub fn default_max_tab_width() -> f32 {
     240.0
 }
 
-/// Clamp `max_tab_width` to `[80.0, 2000.0]`.
+/// Clamp `max_tab_width` to `[80.0, 480.0]`.
 ///
-/// Below the lower bound the close button and title no longer fit; the
-/// upper bound just keeps a typo from producing a strip-wide tab.
+/// Below the lower bound the close button and title no longer fit.
+/// The window width already bounds how wide a tab can actually get,
+/// so the upper bound only keeps configured values in a sane range.
 #[inline]
 pub fn clamp_max_tab_width(v: f32) -> f32 {
     if !v.is_finite() {
         return default_max_tab_width();
     }
-    v.clamp(80.0, 2000.0)
+    v.clamp(80.0, 480.0)
 }
 
 /// Clamp `unfocused_split_opacity` to `[0.15, 1.0]`.
@@ -169,7 +170,7 @@ pub struct Navigation {
     pub unfocused_split_fill: Option<ColorArray>,
     /// Maximum width of a tab in logical pixels. Tabs shrink below
     /// this as more open; the cap only limits how wide a tab grows
-    /// when few are open. Clamped to `[80.0, 2000.0]` at load time.
+    /// when few are open. Clamped to `[80.0, 480.0]` at load time.
     #[serde(default = "default_max_tab_width", rename = "max-tab-width")]
     pub max_tab_width: f32,
 }

--- a/rio-backend/src/config/platform.rs
+++ b/rio-backend/src/config/platform.rs
@@ -101,6 +101,8 @@ pub struct PlatformNavigation {
     pub open_config_with_split: Option<bool>,
     #[serde(default = "Option::default", rename = "unfocused-split-opacity")]
     pub unfocused_split_opacity: Option<f32>,
+    #[serde(default = "Option::default", rename = "max-tab-width")]
+    pub max_tab_width: Option<f32>,
     #[serde(
         default = "Option::default",
         deserialize_with = "crate::config::colors::deserialize_to_arr_opt",


### PR DESCRIPTION
Tab titles were cropping even with a single tab: the strip capped each tab at 180 logical px, leaving about 126px for the title after padding and the close button.

Two commits:
- The default cap is now 240px, giving roughly ten more characters before the ellipsis kicks in.
- The cap is configurable via `navigation.max-tab-width` (logical px, clamped to `[80, 2000]`, live-reloads, supports per-platform overrides). Tabs still shrink to fit as more open; only the upper bound changes.

```toml
[navigation]
max-tab-width = 240
```