### PR TITLE
stop forking real shells in context tests

### DIFF
--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -120,6 +120,12 @@ impl<T: EventListener> Context<T> {
 
 #[derive(Clone, Default)]
 pub struct ContextManagerConfig {
+    /// Build contexts without spawning a PTY (see
+    /// `create_dead_context`). Unit tests fork one real `$SHELL` per
+    /// context otherwise, which is slow and flaky under the parallel
+    /// test runner (fork failures surface as random test panics).
+    #[cfg(test)]
+    pub dead_pty: bool,
     pub shell: Shell,
     #[cfg(not(target_os = "windows"))]
     pub use_fork: bool,
@@ -196,17 +202,7 @@ pub fn create_mock_context<
     dimension: ContextDimension,
 ) -> Context<T> {
     let config = ContextManagerConfig {
-        #[cfg(not(target_os = "windows"))]
-        use_fork: true,
-        working_dir: None,
-        shell: Shell {
-            program: std::env::var("SHELL").unwrap_or("bash".to_string()),
-            args: vec![],
-        },
-        spawn_performer: false,
-        is_native: false,
-        should_update_title_extra: false,
-        cwd: false,
+        dead_pty: true,
         ..ContextManagerConfig::default()
     };
     ContextManager::create_context(
@@ -231,6 +227,18 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         config: &ContextManagerConfig,
     ) -> Result<Context<T>, Box<dyn Error>> {
         let route_id = ROUTE_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+        #[cfg(test)]
+        if config.dead_pty {
+            return Ok(create_dead_context(
+                event_proxy,
+                window_id,
+                route_id,
+                rich_text_id,
+                dimension,
+            ));
+        }
+
         let cols: u16 = dimension.columns.try_into().unwrap_or(MIN_COLUMNS as u16);
         let rows: u16 = dimension.lines.try_into().unwrap_or(MIN_LINES as u16);
         #[cfg(not(target_os = "windows"))]
@@ -426,17 +434,8 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         window_id: WindowId,
     ) -> Result<Self, Box<dyn Error>> {
         let config = ContextManagerConfig {
-            #[cfg(not(target_os = "windows"))]
-            use_fork: true,
-            working_dir: None,
-            shell: Shell {
-                program: std::env::var("SHELL").unwrap_or("bash".to_string()),
-                args: vec![],
-            },
-            spawn_performer: false,
-            is_native: false,
-            should_update_title_extra: false,
-            cwd: false,
+            #[cfg(test)]
+            dead_pty: true,
             ..ContextManagerConfig::default()
         };
         let initial_context = ContextManager::create_context(
@@ -1056,6 +1055,8 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         );
 
         let context_manager_config = ContextManagerConfig {
+            #[cfg(test)]
+            dead_pty: false,
             cwd: config.navigation.current_working_directory,
             shell,
             working_dir,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -212,6 +212,8 @@ impl Screen<'_> {
         );
 
         let context_manager_config = context::ContextManagerConfig {
+            #[cfg(test)]
+            dead_pty: false,
             cwd: config.navigation.current_working_directory,
             shell,
             working_dir,


### PR DESCRIPTION
The context unit tests forked a real `$SHELL` for every context they created, some tests five at a time, all in parallel. Under load the forks intermittently fail; `start_with_capacity` unwraps the failure and `add_context` silently drops the context, so a random test panicked or mis-counted on roughly every other full-suite run.

`ContextManagerConfig` gains a test-only `dead_pty` flag that routes `create_context` through the existing `create_dead_context` fallback (real terminal, no PTY). The test constructors set it; production initializers are untouched apart from naming the field. The context suite goes from 0.42s to 0.06s and survived 12 consecutive runs that previously failed about half the time.