### PR TITLE
derive implied grid for virtual placements without c/r

### DIFF
--- a/rio-backend/src/ansi/kitty_virtual.rs
+++ b/rio-backend/src/ansi/kitty_virtual.rs
@@ -588,9 +588,22 @@ pub fn compute_run_geometry(
     let crop_w = crop_w as f32;
     let crop_h = crop_h as f32;
 
-    // 1. Placement box in pixels.
-    let p_cols_px = placement_cols.max(1) as f32 * cell_width;
-    let p_rows_px = placement_rows.max(1) as f32 * cell_height;
+    // 1. Placement box in pixels. `c=`/`r=` are optional on virtual
+    // placements (yazi's kgp driver omits both); any missing side is
+    // implied from the crop's pixel size rounded up to whole cells,
+    // so the image keeps its native cell footprint.
+    let p_cols = if placement_cols > 0 {
+        placement_cols as f32
+    } else {
+        (crop_w / cell_width).ceil().max(1.0)
+    };
+    let p_rows = if placement_rows > 0 {
+        placement_rows as f32
+    } else {
+        (crop_h / cell_height).ceil().max(1.0)
+    };
+    let p_cols_px = p_cols * cell_width;
+    let p_rows_px = p_rows * cell_height;
 
     // 2. Aspect-fit + centering.
     let scale = (p_cols_px / crop_w).min(p_rows_px / crop_h);
@@ -1109,6 +1122,154 @@ mod tests {
             0,
         );
         assert!(none.is_none());
+    }
+
+    #[test]
+    fn geom_implied_grid_when_cols_rows_omitted() {
+        // yazi's kgp driver transmits `a=T,U=1` with no `c=`/`r=`:
+        // placement_cols/rows arrive as 0 and the grid is implied from
+        // the image's natural size. Image 100×40, cell 10×20 → 10 cols
+        // × 2 rows, drawn 1:1.
+        //
+        // Row 0, cells 0..=9: top half of the image, full width.
+        let g = compute_run_geometry(
+            &run(0, 0, 10),
+            0,
+            0,
+            100,
+            40,
+            (0, 0, 0, 0),
+            10.0,
+            20.0,
+            0.0,
+            0.0,
+            0,
+            0,
+        )
+        .expect("row 0 visible");
+        approx(g.x, 0.0);
+        approx(g.y, 0.0);
+        approx(g.width, 100.0);
+        approx(g.height, 20.0);
+        approx(g.source_rect[0], 0.0);
+        approx(g.source_rect[1], 0.0);
+        approx(g.source_rect[2], 1.0);
+        approx(g.source_rect[3], 0.5);
+
+        // Row 1: bottom half. Regression: this returned None (and row 0
+        // squeezed the whole image into one cell) when omitted `c=`/`r=`
+        // fell through as a 1×1 placement box.
+        let g = compute_run_geometry(
+            &run(1, 0, 10),
+            0,
+            0,
+            100,
+            40,
+            (0, 0, 0, 0),
+            10.0,
+            20.0,
+            0.0,
+            0.0,
+            1,
+            0,
+        )
+        .expect("row 1 visible");
+        approx(g.y, 20.0);
+        approx(g.height, 20.0);
+        approx(g.source_rect[1], 0.5);
+        approx(g.source_rect[3], 1.0);
+    }
+
+    #[test]
+    fn geom_implied_grid_rounds_up_to_whole_cells() {
+        // Image 95×30, cell 10×20: implied grid rounds up to 10×2
+        // (box 100×40). The usual aspect-fit then applies: scale
+        // 100/95, fit 100×31.58, centered vertically (pad_y 4.21).
+        // Row 1 shows the bottom half of the image.
+        let g = compute_run_geometry(
+            &run(1, 0, 10),
+            0,
+            0,
+            95,
+            30,
+            (0, 0, 0, 0),
+            10.0,
+            20.0,
+            0.0,
+            0.0,
+            1,
+            0,
+        )
+        .expect("visible");
+        approx(g.y, 20.0);
+        approx(g.width, 100.0);
+        approx(g.height, 300.0 / 19.0);
+        approx(g.source_rect[1], 0.5);
+        approx(g.source_rect[3], 1.0);
+
+        // A run past the image's implied rows draws nothing.
+        let none = compute_run_geometry(
+            &run(2, 0, 10),
+            0,
+            0,
+            95,
+            30,
+            (0, 0, 0, 0),
+            10.0,
+            20.0,
+            0.0,
+            0.0,
+            2,
+            0,
+        );
+        assert!(none.is_none(), "run below the image should be culled");
+    }
+
+    #[test]
+    fn geom_implied_rows_from_image_when_only_cols_given() {
+        // `c=5` with `r=` omitted: rows come from the image's native
+        // height, ceil(50/10) = 5, so the box is 50×50. Image 100×50
+        // aspect-fits at scale 0.5 (fit 50×25), centered vertically
+        // (pad_y 12.5). Row 0 lies entirely in the top padding.
+        let none = compute_run_geometry(
+            &run(0, 0, 5),
+            5,
+            0,
+            100,
+            50,
+            (0, 0, 0, 0),
+            10.0,
+            10.0,
+            0.0,
+            0.0,
+            0,
+            0,
+        );
+        assert!(none.is_none(), "top-padding run should be culled");
+
+        // Row 1 clips against the padding and shows the image top.
+        let g = compute_run_geometry(
+            &run(1, 0, 5),
+            5,
+            0,
+            100,
+            50,
+            (0, 0, 0, 0),
+            10.0,
+            10.0,
+            0.0,
+            0.0,
+            1,
+            0,
+        )
+        .expect("visible");
+        approx(g.x, 0.0);
+        approx(g.y, 12.5);
+        approx(g.width, 50.0);
+        approx(g.height, 7.5);
+        approx(g.source_rect[1], 0.0);
+        approx(g.source_rect[2], 1.0);
+        approx(g.source_rect[3], 0.3);
     }
 
     #[test]

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -7068,6 +7068,113 @@ mod tests {
         }
     }
 
+    /// End-to-end: yazi's kgp driver (yazi-adapter/src/drivers/kgp.rs)
+    /// transmits with `a=T,C=1,U=1` and NO `c=`/`r=` grid params, sets
+    /// the fg via semicolon-form RGB, and writes 2 diacritics per
+    /// placeholder cell. The placement must register and the implied
+    /// grid must come from the image's pixel size, not collapse to a
+    /// 1×1 cell box (the 0.4.12 yazi-preview regression from #1314).
+    #[test]
+    fn yazi_kgp_wire_sequence_implies_grid_from_image_size() {
+        use crate::ansi::kitty_virtual::{DIACRITICS, PLACEHOLDER};
+
+        let size = CrosswordsSize::new(40, 20);
+        let window_id = crate::event::WindowId::from(0);
+        let mut cw = Crosswords::new(
+            size,
+            CursorShape::Block,
+            VoidListener {},
+            window_id,
+            0,
+            10_000,
+        );
+        let mut processor = crate::performer::handler::Processor::default();
+
+        // yazi: id = pid % 0xffffff → 24 bits, no high-byte diacritic.
+        let image_id: u32 = 0x0A12BF;
+        let r = (image_id >> 16) & 0xFF;
+        let g = (image_id >> 8) & 0xFF;
+        let b = image_id & 0xFF;
+
+        // Combined transmit+display, virtual, no c=/r=. 2×2 RGBA image
+        // (base64 of 16 bytes of 0xFF).
+        let xmit = format!(
+            "\x1b_Gq=2,a=T,C=1,U=1,f=32,s=2,v=2,i={image_id},m=0;/////////////////////w==\x1b\\"
+        );
+        processor.advance(&mut cw, xmit.as_bytes());
+
+        // Placeholder grid 4 cols × 2 rows, absolute cursor moves per
+        // row, semicolon-form RGB fg carrying the image id.
+        let cols = 4usize;
+        let rows = 2usize;
+        let mut cells = format!("\x1b[38;2;{r};{g};{b}m");
+        for row in 0..rows {
+            cells.push_str(&format!("\x1b[{};1H", row + 1));
+            for col in 0..cols {
+                cells.push(PLACEHOLDER);
+                cells.push(DIACRITICS[row]);
+                cells.push(DIACRITICS[col]);
+            }
+        }
+        cells.push_str("\x1b[0m");
+        processor.advance(&mut cw, cells.as_bytes());
+
+        let vp = cw
+            .graphics
+            .kitty_virtual_placements
+            .get(&(image_id, 0))
+            .expect("a=T,U=1 must register a virtual placement");
+        assert_eq!((vp.columns, vp.rows), (0, 0), "c=/r= omitted on the wire");
+        assert!(
+            cw.graphics.get_kitty_image(image_id).is_some(),
+            "image stored under id {image_id:#X}"
+        );
+
+        // Placeholder cells landed with both diacritics.
+        let extras = cw.grid.extras_table.clone();
+        for row in 0..rows {
+            let sq = cw.grid[Line(row as i32)][Column(0)];
+            assert_eq!(sq.c(), PLACEHOLDER);
+            let zw = sq
+                .extras_id()
+                .and_then(|id| extras.get(id))
+                .map(|e| e.zerowidth.as_slice())
+                .unwrap_or(&[]);
+            assert_eq!(zw, &[DIACRITICS[row], DIACRITICS[0]]);
+        }
+
+        // The renderer's geometry for each row's run: with the grid
+        // implied from a 2×2 px image on 1×2 px cells (2 cols × 1 row),
+        // row 0 is visible and drawn 1:1. Before the fix the placement
+        // box collapsed to one cell and row 1 of a taller image drew
+        // nothing while row 0 squeezed the whole image.
+        let run = crate::ansi::kitty_virtual::PlaceholderRun {
+            image_id,
+            placement_id: 0,
+            row: 0,
+            col: 0,
+            width: cols as u32,
+        };
+        let geom = crate::ansi::kitty_virtual::compute_run_geometry(
+            &run,
+            vp.columns,
+            vp.rows,
+            2,
+            2,
+            (vp.x, vp.y, vp.width, vp.height),
+            1.0,
+            2.0,
+            0.0,
+            0.0,
+            0,
+            0,
+        )
+        .expect("implied-grid run must be drawable");
+        assert_eq!(geom.width, 2.0);
+        assert_eq!(geom.height, 2.0);
+        assert_eq!(geom.source_rect, [0.0, 0.0, 1.0, 1.0]);
+    }
+
     /// `place_virtual_graphic` is the handler for `_Ga=p,U=1,…\e\` — the
     /// virtual-placement registration used by `kitten icat
     /// --unicode-placeholder`. Per the kitty protocol spec the command


### PR DESCRIPTION
Kitty virtual placements can omit `c=`/`r=`; the spec then implies the grid from the image size and cell size. Rio stored the zeros verbatim and `compute_run_geometry` clamped them to a 1x1 cell box, so the whole image was aspect-fit into a single cell and every run past cell (0,0) was culled.

This is exactly what yazi's kgp driver emits (`a=T,C=1,U=1` with no grid params), which is why yazi previews were still broken on main after the 0.4.12 image rework (see the latest report on #1314, and #1530).

Any missing dimension is now derived independently from the crop's pixel size divided by the cell size, rounded up to whole cells, so the image keeps its native cell footprint. The existing aspect-fit and centering then apply against that box, same as for explicit grids, and explicit `c=`/`r=` behave exactly as before.

Covered by three new geometry unit tests plus an end-to-end test feeding yazi's exact wire sequence through the parser (semicolon-form RGB fg, two diacritics per placeholder cell, chunked transmit). Also verified visually in a dev build against an emulated yazi kgp stream: one contiguous image at its natural cell footprint, empty cells beyond it.