### PR TITLE
copy finished selection instead of firing hint on release

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1433,23 +1433,26 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             return;
                         }
 
-                        // Trigger hints highlighted by the mouse
-                        if button == MouseButton::Left
-                            && route
-                                .window
-                                .screen
-                                .trigger_hint(&mut self.router.clipboard)
-                        {
-                            return;
-                        }
-
-                        if let MouseButton::Left | MouseButton::Right = button {
-                            if self.config.copy_on_select {
-                                route.window.screen.copy_selection(
-                                    ClipboardType::Clipboard,
-                                    &mut self.router.clipboard,
-                                );
+                        // Releasing a drag selection copies it (with
+                        // copy-on-select) and must not activate a hint
+                        // sitting under the release point; hints fire on
+                        // plain clicks only, when no selection exists.
+                        if route.window.screen.selection_is_empty() {
+                            if button == MouseButton::Left
+                                && route
+                                    .window
+                                    .screen
+                                    .trigger_hint(&mut self.router.clipboard)
+                            {
+                                return;
                             }
+                        } else if matches!(button, MouseButton::Left | MouseButton::Right)
+                            && self.config.copy_on_select
+                        {
+                            route.window.screen.copy_selection(
+                                ClipboardType::Clipboard,
+                                &mut self.router.clipboard,
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
With `copy-on-select` enabled, releasing a drag selection over a highlighted hint or hyperlink never copied: `trigger_hint()` ran first and its early return skipped the copy block entirely (#1494, previously attempted in #1497).

The release handler now branches on whether a selection exists. A finished selection copies to the clipboard and does not activate whatever hint happens to sit under the release point, so sweeping a selection across a URL no longer opens it. Plain clicks with no selection trigger hints exactly as before.

The PRIMARY-buffer half of #1497 is intentionally left out; #1626 covers it more completely by claiming PRIMARY on every selection, not only with copy-on-select.

Closes #1494.