### PR TITLE
advertise osc 52 clipboard support in primary da

### DIFF
--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -3170,7 +3170,10 @@ impl<U: EventListener> Handler for Crosswords<U> {
         match intermediate {
             None => {
                 trace!("Reporting primary device attributes");
-                let text = String::from("\x1b[?62;4;6;22c");
+                // 62: VT220, 4: sixel, 6: selective erase, 22: ANSI
+                // color, 52: clipboard access via OSC 52 (probed by
+                // tcell and others before enabling clipboard writes).
+                let text = String::from("\x1b[?62;4;6;22;52c");
                 self.event_proxy
                     .send_event(RioEvent::PtyWrite(self.route_id, text), self.window_id);
             }


### PR DESCRIPTION
Rio implements OSC 52 clipboard store/load but the primary device attributes reply did not include `52`, so libraries that probe DA1 before enabling clipboard writes (tcell and friends, per the kitty/foot convention) kept OSC 52 disabled over ssh.

DA1 now replies `?62;4;6;22;52c`.

Closes #1398.