### PR TITLE
reset ignored signals in fork pty child

### DIFF
--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -62,6 +62,27 @@ extern "C" {
 }
 
 fn default_shell_command(shell: &str, args: &[String]) {
+    // Ignored signal dispositions survive exec (unlike caught
+    // handlers), so the shell inherits whatever the launcher left
+    // ignored: SIGINT/SIGQUIT from a background-job launch, and
+    // SIGPIPE which the Rust runtime always sets to ignore. Reset
+    // the full set to default before exec.
+    unsafe {
+        libc::signal(libc::SIGABRT, libc::SIG_DFL);
+        libc::signal(libc::SIGALRM, libc::SIG_DFL);
+        libc::signal(libc::SIGBUS, libc::SIG_DFL);
+        libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+        libc::signal(libc::SIGFPE, libc::SIG_DFL);
+        libc::signal(libc::SIGHUP, libc::SIG_DFL);
+        libc::signal(libc::SIGILL, libc::SIG_DFL);
+        libc::signal(libc::SIGINT, libc::SIG_DFL);
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        libc::signal(libc::SIGQUIT, libc::SIG_DFL);
+        libc::signal(libc::SIGSEGV, libc::SIG_DFL);
+        libc::signal(libc::SIGTERM, libc::SIG_DFL);
+        libc::signal(libc::SIGTRAP, libc::SIG_DFL);
+    }
+
     let program = match CString::new(shell) {
         Ok(program) => program,
         Err(_) => return,


### PR DESCRIPTION
Launching rio as a background job (`rio &` from a script, some desktop launchers) left Ctrl-C and Ctrl-\\ dead in the spawned shell: the parent shell marks background jobs' SIGINT/SIGQUIT as ignored, ignored dispositions survive exec, and the fork pty path never reset them. `use-fork` defaults to true on Linux/BSD so the fork path is what most Linux users run. Reproducible per the report in #1120 (`exec rio` as the workaround matches the diagnosis).

The fork child now resets the full set of dispositions to default before exec: ABRT, ALRM, BUS, CHLD, FPE, HUP, ILL, INT, PIPE, QUIT, SEGV, TERM, TRAP. SIGPIPE matters beyond the background-job case: the Rust runtime ignores it in the parent process, so every shell spawned through the fork path inherited a dead SIGPIPE, which subtly changes pipeline behavior (`yes | head` relies on it). The spawn path is unaffected there because std::process restores SIGPIPE on its own; its narrower pre_exec reset list already covers the job-control signals.

Closes #1120.