### PR TITLE
scale wheel line delta by cell size not font size

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1807,11 +1807,16 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                 match delta {
                     MouseScrollDelta::LineDelta(columns, lines) => {
-                        let font_size =
-                            route.window.screen.ctx().current().dimension.font_size;
-                        if font_size > 0.0 {
-                            let new_scroll_px_x = columns * font_size;
-                            let new_scroll_px_y = lines * font_size;
+                        // One wheel notch is one line/column. Convert
+                        // with the cell size: scroll() divides the
+                        // accumulated pixels by it, and converting
+                        // with font_size (smaller than a cell) made
+                        // single notches floor to zero lines (#1350).
+                        let cell =
+                            route.window.screen.ctx().current().dimension.dimension;
+                        if cell.width > 0.0 && cell.height > 0.0 {
+                            let new_scroll_px_x = columns * cell.width;
+                            let new_scroll_px_y = lines * cell.height;
                             route
                                 .window
                                 .screen


### PR DESCRIPTION
Notched mouse wheels report LineDelta, one notch per line. The handler converted notches to pixels with `font_size`, but `scroll()` consumes accumulated pixels by dividing by the cell size, which is larger than the font size (line-height and display scale both inflate it). A single notch floored to zero lines and only the accumulator made the second notch scroll, hence two ticks per line on Windows (#1350); the same mismatch also made `scroll.multiplier` behave inconsistently between wheel mice and trackpads on every platform.

Notches are now converted with the cell dimensions, so one notch is exactly one line before the configured multiplier: with the default `scroll.multiplier = 3` a notch scrolls the conventional three lines.

Closes #1350.