### PR TITLE
collapse crlf to cr in bracketed paste

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3553,7 +3553,12 @@ impl Screen<'_> {
             // We remove `\x1b` to ensure it's impossible for the pasted text to write the bracketed
             // paste end escape `\x1b[201~` and `\x03` since some shells incorrectly terminate
             // bracketed paste on its receival.
-            let filtered = text.replace(['\x1b', '\x03'], "");
+            //
+            // CRLF collapses to `\r` even in bracketed mode: the
+            // Windows clipboard terminates every line with `\r\n`,
+            // and shells treat that as two breaks, doubling every
+            // newline pasted into WSL or ssh. Lone `\n` stays as is.
+            let filtered = text.replace(['\x1b', '\x03'], "").replace("\r\n", "\r");
             self.ctx_mut()
                 .current_mut()
                 .messenger


### PR DESCRIPTION
Pasting multi-line text from the Windows clipboard into WSL or ssh sessions doubled every line break: the clipboard terminates lines with CRLF, the bracketed-paste path forwarded it verbatim, and shells treat `\r\n` as two breaks (#1669). The non-bracketed path already normalizes line endings.

Bracketed paste now collapses `\r\n` to `\r`, matching kitty. Lone `\n` is left untouched so Unix-style multi-line pastes into editors behave exactly as before. Verbatim-forwarding terminals (wezterm without canonicalization) exhibit the same doubling this fixes, which is why kitty's normalization is the better default here.

Closes #1669.