### PR TITLE
scroll to bottom on esc bindings and plain pastes

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3564,6 +3564,13 @@ impl Screen<'_> {
                 .messenger
                 .send_write(&b"\x1b[201~"[..]);
         } else {
+            // Input reaching the shell scrolls back to the prompt and
+            // drops the selection, exactly like typed text does; this
+            // path carries Esc bindings (arrow keys, backspace) and
+            // pastes into applications without bracketed mode.
+            self.scroll_bottom_when_cursor_not_visible();
+            self.clear_selection();
+
             let payload = if bracketed {
                 // In non-bracketed (ie: normal) mode, terminal applications cannot distinguish
                 // pasted data from keystrokes.


### PR DESCRIPTION
Typing a character while scrolled up jumps the viewport back to the prompt, but arrow keys, backspace and every other key bound as an `Esc` byte sequence did not: those go through `paste(_, false)`, whose non-bracketed branch never called `scroll_bottom_when_cursor_not_visible`. Pastes into applications without bracketed-paste mode had the same gap (#1427).

The plain-write branch of `paste` now scrolls to bottom and clears the selection, matching both the typed-text path and the bracketed-paste path.

Closes #1427.