### PR TITLE
drop stale selection when a click switches panels

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -379,6 +379,10 @@ impl Screen<'_> {
             .select_current_based_on_mouse(&self.mouse)
         {
             self.context_manager.select_route_from_current_grid();
+            // The focusing click never reaches on_left_click, so a
+            // selection left behind in the target panel would
+            // drag-extend from its stale anchor; drop it on switch.
+            self.clear_selection();
             return true;
         }
         false


### PR DESCRIPTION
Clicking into an unfocused split switches panels without running `on_left_click`, the only path that resets a selection. A selection left behind in the target panel therefore kept its anchor, and the next drag extended it from that stale position instead of starting fresh (#1638).

Switching panels via click now clears the target panel's selection, so a subsequent drag begins a new one from the click position, matching the usual click-clears-selection behavior.

Closes #1638.