### PR TITLE
expand and validate working-dir, honor it on fork path

### DIFF
--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -263,6 +263,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                 pty = match create_pty_with_fork(
                     &Cow::Borrowed(&config.shell.program),
                     &config.shell.args,
+                    &config.working_dir,
                     cols,
                     rows,
                     initial_winsize.width,

--- a/teletypewriter/examples/spawn.rs
+++ b/teletypewriter/examples/spawn.rs
@@ -10,7 +10,7 @@ fn main() -> std::io::Result<()> {
     use teletypewriter::{create_pty_with_fork, ProcessReadWrite, Pty};
 
     let shell = Cow::Borrowed("bash");
-    let mut process: Pty = create_pty_with_fork(&shell, &[], 80, 25, 0, 0)?;
+    let mut process: Pty = create_pty_with_fork(&shell, &[], &None, 80, 25, 0, 0)?;
 
     process.writer().write_all(b"1").unwrap();
     process.writer().write_all(b"2").unwrap();

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -61,6 +61,40 @@ extern "C" {
     fn ptsname(fd: *mut libc::c_int) -> *mut libc::c_char;
 }
 
+/// Expand a leading `~` against `$HOME`. Returns None (with a
+/// warning) when the expansion is impossible.
+fn expand_tilde(dir: &str) -> Option<String> {
+    if dir == "~" || dir.starts_with("~/") {
+        match std::env::var("HOME") {
+            Ok(home) => Some(format!("{home}{}", &dir[1..])),
+            Err(_) => {
+                tracing::warn!(
+                    "working-dir {dir:?} needs $HOME, which is unset; inheriting the current directory"
+                );
+                None
+            }
+        }
+    } else {
+        Some(dir.to_string())
+    }
+}
+
+/// Expand a leading `~` and validate the configured working
+/// directory. Unusable values fall back to inheriting the parent's
+/// directory with a warning instead of failing the spawn or silently
+/// landing somewhere unexpected.
+pub fn resolve_working_dir(dir: &Option<String>) -> Option<String> {
+    let expanded = expand_tilde(dir.as_deref()?)?;
+    if std::path::Path::new(&expanded).is_dir() {
+        Some(expanded)
+    } else {
+        tracing::warn!(
+            "working-dir {expanded:?} is not a directory; inheriting the current directory"
+        );
+        None
+    }
+}
+
 fn default_shell_command(shell: &str, args: &[String]) {
     // Ignored signal dispositions survive exec (unlike caught
     // handlers), so the shell inherits whatever the launcher left
@@ -479,6 +513,11 @@ pub fn create_pty_with_spawn(
     width: u16,
     height: u16,
 ) -> Result<Pty, Error> {
+    // Only expanded here: the flatpak branch below hands the path to
+    // the host, which may see directories this sandbox cannot, so
+    // existence is validated at the local use site instead.
+    let working_directory = working_directory.as_deref().and_then(expand_tilde);
+
     #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
     let mut is_controling_terminal = true;
 
@@ -560,7 +599,7 @@ pub fn create_pty_with_spawn(
                 "--env=TERM=rio".to_string(),
             ];
 
-            if let Some(directory) = working_directory {
+            if let Some(directory) = &working_directory {
                 with_args.push(format!(
                     "--directory={}",
                     std::path::Path::new(directory).display()
@@ -623,7 +662,13 @@ pub fn create_pty_with_spawn(
 
     // Handle set working directory option.
     if let Some(dir) = &working_directory {
-        builder.current_dir(dir);
+        if std::path::Path::new(dir).is_dir() {
+            builder.current_dir(dir);
+        } else {
+            tracing::warn!(
+                "working-dir {dir:?} is not a directory; inheriting the current directory"
+            );
+        }
     }
 
     // Prepare signal handling before spawning child.
@@ -675,11 +720,16 @@ pub fn create_pty_with_spawn(
 pub fn create_pty_with_fork(
     shell: &str,
     args: &[String],
+    working_directory: &Option<String>,
     columns: u16,
     rows: u16,
     width: u16,
     height: u16,
 ) -> Result<Pty, Error> {
+    // Resolved in the parent so the failure path can log; the fork
+    // child only consumes the already-validated CString.
+    let working_directory =
+        resolve_working_dir(working_directory).and_then(|dir| CString::new(dir).ok());
     let mut main = 0;
     let winsize = Winsize {
         ws_row: rows as libc::c_ushort,
@@ -715,6 +765,11 @@ pub fn create_pty_with_fork(
         )
     } {
         0 => {
+            if let Some(dir) = &working_directory {
+                unsafe {
+                    libc::chdir(dir.as_ptr());
+                }
+            }
             default_shell_command(shell_program, args);
             Err(Error::other(format!(
                 "forkpty has reach unreachable with {shell_program}"
@@ -1049,6 +1104,51 @@ where
             .spawn()?
             .wait()
             .map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod resolve_working_dir_tests {
+    use super::resolve_working_dir;
+
+    #[test]
+    fn none_stays_none() {
+        assert_eq!(resolve_working_dir(&None), None);
+    }
+
+    #[test]
+    fn tilde_expands_to_home() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(resolve_working_dir(&Some("~".into())), Some(home));
+    }
+
+    #[test]
+    fn tilde_slash_expands_under_home() {
+        // Use a path guaranteed to exist under $HOME on any system
+        // running the tests: $HOME itself via `~/.`.
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(
+            resolve_working_dir(&Some("~/.".into())),
+            Some(format!("{home}/."))
+        );
+    }
+
+    #[test]
+    fn absolute_dir_passes_through() {
+        assert_eq!(resolve_working_dir(&Some("/".into())), Some("/".into()));
+    }
+
+    #[test]
+    fn missing_dir_falls_back_to_inherit() {
+        assert_eq!(
+            resolve_working_dir(&Some("/definitely/not/a/real/dir".into())),
+            None
+        );
+    }
+
+    #[test]
+    fn mid_string_tilde_is_not_expanded() {
+        assert_eq!(resolve_working_dir(&Some("/tmp/~x".into())), None);
     }
 }
 


### PR DESCRIPTION
Three related `working-dir` problems (#1088):

- `working-dir = "~"` (or `~/projects`) was passed to the pty literally and failed, since nothing expanded the tilde.
- A nonexistent directory made the spawn fail or land somewhere unexpected with no feedback.
- The fork pty path, the default on Linux/BSD via `use-fork = true`, never received the working directory at all, so the option was silently ignored there (same family as the `shell.args` bug fixed in #1721).

`resolve_working_dir` now expands a leading tilde, validates the path is a directory, and logs a warning while falling back to inheriting the current directory when it is not. The spawn path resolves through it, and `create_pty_with_fork` takes the directory and chdirs in the forked child before exec (resolved in the parent so the failure path can log). Six unit tests cover the resolution rules.

Closes #1088.