### PR TITLE
run cli command only in the first context

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -36,6 +36,9 @@ pub struct Application<'a> {
     router: Router<'a>,
     scheduler: Scheduler,
     app_id: Option<String>,
+    /// One-shot shell from `rio -e ...`; consumed by the first window's
+    /// first context only.
+    cli_shell: Option<rio_backend::config::Shell>,
     global_hotkey: Option<crate::global_hotkey::GlobalHotkeys>,
     /// Frontmost app when the quake window was shown, re-activated
     /// when it hides so focus returns where the user was.
@@ -49,6 +52,7 @@ impl Application<'_> {
         config_error: Option<rio_backend::config::ConfigError>,
         event_loop: &EventLoop<EventPayload>,
         app_id: Option<String>,
+        cli_shell: Option<rio_backend::config::Shell>,
     ) -> Application<'app> {
         // SAFETY: Since this takes a pointer to the winit event loop, it MUST be dropped first,
         // which is done in `exiting`.
@@ -80,6 +84,7 @@ impl Application<'_> {
             router,
             scheduler,
             app_id,
+            cli_shell,
             global_hotkey: None,
             #[cfg(target_os = "macos")]
             quake_previous_app: None,
@@ -299,6 +304,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             self.event_proxy.clone(),
             &self.config,
             None,
+            self.cli_shell.take(),
             self.app_id.as_deref(),
         );
 
@@ -896,6 +902,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     self.event_proxy.clone(),
                     &self.config,
                     None,
+                    None,
                     self.app_id.as_deref(),
                 );
             }
@@ -1062,6 +1069,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     self.event_proxy.clone(),
                     config,
                     Some(url),
+                    None,
                     self.app_id.as_deref(),
                 );
             }

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -351,6 +351,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
 
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         cursor_state: (&Cursor, bool),
         event_proxy: T,
@@ -358,17 +359,33 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         route_id: usize,
         rich_text_id: usize,
         ctx_config: ContextManagerConfig,
+        initial_shell: Option<Shell>,
         size: ContextDimension,
         scaled_margin: Margin,
         sugarloaf_errors: Option<SugarloafErrors>,
     ) -> Result<Self, Box<dyn Error>> {
+        // A one-shot shell (`rio -e ...`) runs only in the very first
+        // context; the manager keeps the regular config so new tabs,
+        // splits and windows spawn the configured shell (#1020).
+        let initial_ctx_config = match initial_shell {
+            Some(shell) => {
+                let mut one_shot = ctx_config.clone();
+                one_shot.shell = shell;
+                #[cfg(not(target_os = "windows"))]
+                {
+                    one_shot.use_fork = false;
+                }
+                one_shot
+            }
+            None => ctx_config.clone(),
+        };
         let initial_context = match ContextManager::create_context(
             cursor_state,
             event_proxy.clone(),
             window_id,
             rich_text_id,
             size,
-            &ctx_config,
+            &initial_ctx_config,
         ) {
             Ok(context) => context,
             Err(err_message) => {

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -173,6 +173,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // windows.shell.args = ["-l"]
     config.overwrite_based_on_platform();
 
+    // Consumed by the first window's first context only; the config
+    // keeps the regular shell so new tabs, splits and windows spawn
+    // the configured shell instead of re-running the command.
+    let cli_shell = args.window_options.terminal_options.command();
+
     {
         let log_to_file = args.window_options.terminal_options.enable_log_file;
         if let Err(e) = setup_logs_by_filter_level(
@@ -180,11 +185,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             log_to_file || config.developer.enable_log_file,
         ) {
             eprintln!("unable to configure the logger: {e:?}");
-        }
-
-        if let Some(command) = args.window_options.terminal_options.command() {
-            config.shell = command;
-            config.use_fork = false;
         }
 
         if let Some(working_dir_cli) = args.window_options.terminal_options.working_dir {
@@ -244,6 +244,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         config_error,
         &window_event_loop,
         app_id,
+        cli_shell,
     );
     let _ = application.run(window_event_loop);
 

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -465,6 +465,7 @@ impl Router<'_> {
             None,
             None,
             None,
+            None,
             false,
         );
         let id = window.winit_window.id();
@@ -510,6 +511,7 @@ impl Router<'_> {
         event_proxy: EventProxy,
         config: &'a rio_backend::config::Config,
         open_url: Option<String>,
+        initial_shell: Option<rio_backend::config::Shell>,
         app_id: Option<&str>,
     ) {
         let tab_id = if config.navigation.is_native() {
@@ -528,6 +530,7 @@ impl Router<'_> {
             RIO_TITLE,
             tab_id.as_deref(),
             open_url,
+            initial_shell,
             app_id,
             false,
         );
@@ -565,6 +568,7 @@ impl Router<'_> {
             None,
             None,
             None,
+            None,
             true,
         );
         let id = window.winit_window.id();
@@ -597,6 +601,7 @@ impl Router<'_> {
             RIO_TITLE,
             tab_id,
             open_url,
+            None,
             None,
             false,
         );
@@ -714,6 +719,7 @@ impl<'a> RouteWindow<'a> {
         window_name: &str,
         tab_id: Option<&str>,
         open_url: Option<String>,
+        initial_shell: Option<rio_backend::config::Shell>,
         app_id: Option<&str>,
         quake: bool,
     ) -> RouteWindow<'a> {
@@ -748,8 +754,15 @@ impl<'a> RouteWindow<'a> {
             window_id: winit_window.id(),
         };
 
-        let screen = Screen::new(properties, config, event_proxy, font_library, open_url)
-            .expect("Screen not created");
+        let screen = Screen::new(
+            properties,
+            config,
+            event_proxy,
+            font_library,
+            open_url,
+            initial_shell,
+        )
+        .expect("Screen not created");
 
         if config.window.columns.is_some() || config.window.rows.is_some() {
             let (physical_width, physical_height) = compute_window_size_from_grid(

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -119,6 +119,7 @@ impl Screen<'_> {
         event_proxy: EventProxy,
         font_library: &rio_backend::sugarloaf::font::FontLibrary,
         open_url: Option<String>,
+        initial_shell: Option<rio_backend::config::Shell>,
     ) -> Result<Screen<'screen>, Box<dyn Error>> {
         let size = window_properties.size;
         let scale = window_properties.scale;
@@ -275,6 +276,7 @@ impl Screen<'_> {
             0,
             rich_text_id,
             context_manager_config,
+            initial_shell,
             context_dimension,
             scaled_margin,
             sugarloaf_errors,


### PR DESCRIPTION
`rio -e vi` (or any `-e`/`--command` invocation) overwrote `config.shell` globally, so every new tab, split and window re-ran the command instead of opening the configured shell, and closing a short-lived command in a tab could not give you a shell back (#1020).

The CLI command is now carried separately from the config and consumed by the first window's first context only, keeping the existing behavior of forcing the spawn path for that context. Tabs, splits, subsequent windows and dock-reopen windows all spawn the configured shell.

Closes #1020.