### PR TITLE
fix: recompute grid rows when the tab bar appears/disappears

### DIFF
--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -1206,6 +1206,15 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             dim.update_dimensions(text_dims, cell);
         }
 
+        // Re-push the current size through Taffy with the *current*
+        // scaled_margin before laying out. Callers (e.g. tab create/close
+        // toggling `hide_if_single`) update scaled_margin.top to add/remove
+        // the tab-bar band, but apply_taffy_layout alone reuses Taffy's last
+        // available height — computed with the old margin — so the grid kept
+        // too many rows and the bottom row was clipped until a window resize
+        // refreshed it.
+        let _ = self.try_update_size(self.width, self.height);
+
         // Always apply Taffy layout for consistent positioning
         self.apply_taffy_layout(sugarloaf);
     }


### PR DESCRIPTION
Creating a tab toggles hide_if_single, which grows scaled_margin.top to
make room for the tab bar. update_dimensions then re-laid out via
apply_taffy_layout, but never refreshed Taffy's available height for the
new margin -- so the grid kept its old (taller) row count and the bottom
row was clipped off the window until a window resize (which calls
try_update_size) corrected it. Refresh the Taffy size with the current
scaled_margin in update_dimensions before laying out.

