### PR TITLE
fix(graphics): deflate image byte accounting when graphics are freed

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -454,11 +454,37 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     // Process graphics directly in sugarloaf
                     let sugarloaf = &mut route.window.screen.sugarloaf;
 
-                    // Atlas graphics (sixel/iTerm2) share the per-image
-                    // texture store with kitty images, in a disjoint key
-                    // namespace.
+                    // Removals before inserts: an evict-then-retransmit of
+                    // the same kitty id lands in one batch, and the fresh
+                    // pixels must survive the eviction of the old ones.
+                    // The store is shared by every terminal in the window
+                    // while both protocols allocate ids per terminal, so
+                    // every key is scoped to the originating route and its
+                    // id space — a kitty removal must not delete an atlas
+                    // entry (or another tab's image) and leak the texture
+                    // the cells still reference.
+                    for removal in queues.remove_queue {
+                        let key = match removal {
+                            rio_backend::ansi::graphics::GraphicRemoval::Atlas(id) => {
+                                rio_backend::sugarloaf::ImageKey::atlas(
+                                    route_id,
+                                    id.get(),
+                                )
+                            }
+                            rio_backend::ansi::graphics::GraphicRemoval::Kitty(id) => {
+                                rio_backend::sugarloaf::ImageKey::kitty(route_id, id)
+                            }
+                        };
+                        sugarloaf.remove_image(key);
+                    }
+
+                    // Atlas graphics (sixel/iTerm2) → the same per-image
+                    // texture store the overlay pipeline draws from.
                     for graphic_data in queues.pending {
-                        let key = crate::renderer::atlas_image_key(graphic_data.id.get());
+                        let key = rio_backend::sugarloaf::ImageKey::atlas(
+                            route_id,
+                            graphic_data.id.get(),
+                        );
                         sugarloaf.image_data.insert(
                             key,
                             rio_backend::sugarloaf::GraphicDataEntry::from_graphic_data(
@@ -467,21 +493,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         );
                     }
 
-                    // Image textures (kitty) → separate store, no clone
+                    // Image textures (kitty) → same store, no clone
                     for (image_id, graphic_data) in queues.pending_images {
                         sugarloaf.image_data.insert(
-                            crate::renderer::kitty_image_key(image_id),
+                            rio_backend::sugarloaf::ImageKey::kitty(route_id, image_id),
                             rio_backend::sugarloaf::GraphicDataEntry::from_graphic_data(
                                 graphic_data,
                             ),
                         );
-                    }
-
-                    // Removals arrive as final image keys (atlas refs
-                    // dropped off scrollback, kitty evictions) and free
-                    // both the pixel store and the cached GPU texture.
-                    for key in queues.remove_queue {
-                        sugarloaf.remove_image(key);
                     }
 
                     // Mark the panel dirty: the renderer skips non-dirty

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -23,7 +23,7 @@ use rio_backend::config::colors::{
 use rio_backend::config::navigation::Navigation;
 use rio_backend::config::Config;
 use rio_backend::event::EventProxy;
-use rio_backend::sugarloaf::Sugarloaf;
+use rio_backend::sugarloaf::{ImageKey, Sugarloaf};
 
 /// The window-bg clear alpha that flows into sugarloaf's
 /// `set_background_color`. Stored on the renderer and re-applied on
@@ -42,8 +42,6 @@ fn window_bg_alpha(config: &Config) -> f32 {
         config.window.opacity.clamp(0.0, 1.0)
     }
 }
-
-pub use rio_backend::sugarloaf::{atlas_image_key, kitty_image_key};
 
 pub struct Renderer {
     is_vi_mode_enabled: bool,
@@ -460,7 +458,10 @@ impl Renderer {
                             continue;
                         };
                         let mut overlay = rio_backend::sugarloaf::GraphicOverlay {
-                            image_id: p.image_key,
+                            // Per-route atlas key: the window store is shared
+                            // across tabs while GraphicIds restart per
+                            // terminal, so scope by route.
+                            image_id: ImageKey::atlas(context.route_id, p.image_key),
                             x: geometry.x,
                             y: geometry.y,
                             width: geometry.width,
@@ -497,8 +498,12 @@ impl Renderer {
                         else {
                             continue;
                         };
+                        // Per-route image key: the window-level store is
+                        // shared across tabs while kitty ids are
+                        // per-terminal, so scope by route to avoid
+                        // cross-tab collisions.
                         let mut overlay = rio_backend::sugarloaf::GraphicOverlay {
-                            image_id: kitty_image_key(p.image_id),
+                            image_id: ImageKey::kitty(context.route_id, p.image_id),
                             x: geometry.x,
                             y: geometry.y,
                             width: geometry.width,
@@ -522,6 +527,7 @@ impl Renderer {
                     Self::push_virtual_placeholder_overlays(
                         overlays,
                         rc,
+                        context.route_id,
                         origin_x,
                         origin_y,
                         cell_width,
@@ -786,6 +792,7 @@ impl Renderer {
     fn push_virtual_placeholder_overlays(
         overlays: &mut Vec<rio_backend::sugarloaf::GraphicOverlay>,
         rc: &RenderableContent,
+        route_id: usize,
         origin_x: f32,
         origin_y: f32,
         cell_width: f32,
@@ -820,6 +827,7 @@ impl Renderer {
                         flush_run(
                             overlays,
                             rc,
+                            route_id,
                             p.complete(),
                             line_idx,
                             start_col,
@@ -856,6 +864,7 @@ impl Renderer {
                             flush_run(
                                 overlays,
                                 rc,
+                                route_id,
                                 p.complete(),
                                 line_idx,
                                 start_col,
@@ -886,6 +895,7 @@ impl Renderer {
                 flush_run(
                     overlays,
                     rc,
+                    route_id,
                     p.complete(),
                     line_idx,
                     start_col,
@@ -909,6 +919,7 @@ impl Renderer {
         fn flush_run(
             overlays: &mut Vec<rio_backend::sugarloaf::GraphicOverlay>,
             rc: &RenderableContent,
+            route_id: usize,
             run: PlaceholderRun,
             screen_line: usize,
             start_screen_col: usize,
@@ -951,7 +962,7 @@ impl Renderer {
             };
 
             let mut overlay = rio_backend::sugarloaf::GraphicOverlay {
-                image_id: kitty_image_key(run.image_id),
+                image_id: ImageKey::kitty(route_id, run.image_id),
                 x: geom.x,
                 y: geom.y,
                 width: geom.width,

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -640,6 +640,11 @@ pub struct Graphics {
     /// Maps GraphicId to insertion timestamp
     pub image_timestamps: FxHashMap<GraphicId, std::time::Instant>,
 
+    /// Byte size of each tracked atlas graphic, so `untrack_graphic` can
+    /// subtract the exact amount from `total_bytes` when a graphic's last
+    /// referencing cell is dropped (the removal path only knows the id).
+    pub graphic_bytes: FxHashMap<GraphicId, usize>,
+
     /// Weak references to placed textures, for O(1) liveness checks.
     /// Avoids scanning the entire grid to find which graphics are in use.
     /// When an image loses its last placement, the
@@ -697,6 +702,7 @@ impl Default for Graphics {
             total_bytes: 0,
             total_limit: 320 * 1024 * 1024, // 320MB per kitty spec
             image_timestamps: FxHashMap::default(),
+            graphic_bytes: FxHashMap::default(),
             kitty_placements: FxHashMap::default(),
             atlas_placements: Vec::new(),
             atlas_key_refs: FxHashMap::default(),
@@ -746,6 +752,15 @@ impl Graphics {
             && self.pending_images.is_empty()
         {
             return None;
+        }
+
+        // Deflate the byte accounting for atlas graphics whose last
+        // referencing cell was just dropped. Kitty removals deflate at
+        // their delete/evict site, where the image size is still known.
+        for removal in &remove_queue {
+            if let GraphicRemoval::Atlas(id) = removal {
+                self.untrack_graphic_by_id(*id);
+            }
         }
 
         Some(UpdateQueues {
@@ -856,15 +871,25 @@ impl Graphics {
 
     /// Clear all kitty graphics state on both screens. Used by full reset.
     pub fn clear_all_kitty_state(&mut self) {
-        // Subtract bytes from the inactive screen before dropping it,
-        // since total_bytes is the *global* counter.
-        let inactive_bytes: usize = self
-            .kitty_inactive_screen
-            .kitty_images
-            .values()
-            .map(|s| s.data.pixels.len())
-            .sum();
-        self.total_bytes = self.total_bytes.saturating_sub(inactive_bytes);
+        // total_bytes is the *global* counter and every stored image on
+        // either screen inflated it once, so deflate per entry. Both
+        // screens drop their copy, so the window-level texture goes too —
+        // queue each id once (the two screens may share an id).
+        let mut freed = 0usize;
+        {
+            let mut removals = self.texture_operations.lock();
+            for (&id, stored) in &self.kitty_images {
+                freed += stored.data.pixels.len();
+                removals.push(GraphicRemoval::Kitty(id));
+            }
+            for (&id, stored) in &self.kitty_inactive_screen.kitty_images {
+                freed += stored.data.pixels.len();
+                if !self.kitty_images.contains_key(&id) {
+                    removals.push(GraphicRemoval::Kitty(id));
+                }
+            }
+        }
+        self.deflate_total_bytes(freed);
 
         self.kitty_images.clear();
         self.kitty_image_numbers.clear();
@@ -916,7 +941,8 @@ impl Graphics {
 
         // If replacing an existing image, subtract its bytes first
         if let Some(old) = self.kitty_images.get(&image_id) {
-            self.total_bytes = self.total_bytes.saturating_sub(old.data.pixels.len());
+            let old_bytes = old.data.pixels.len();
+            self.deflate_total_bytes(old_bytes);
         }
 
         self.kitty_images.insert(
@@ -948,15 +974,37 @@ impl Graphics {
             .and_then(|id| self.kitty_images.get(id))
     }
 
-    /// Delete kitty graphics images
+    /// Delete kitty graphics images from the active screen's cache.
+    ///
+    /// Deflates `total_bytes` for every image actually dropped and queues
+    /// a `GraphicRemoval::Kitty` — unless the inactive screen still holds
+    /// the same id: both screens share the window-level texture key, so
+    /// the texture must survive until neither screen references it.
     pub fn delete_kitty_images(
         &mut self,
         predicate: impl Fn(&u32, &StoredImage) -> bool,
     ) {
         let before = self.kitty_images.len();
-        self.kitty_images.retain(|id, img| !predicate(id, img));
-        if self.kitty_images.len() != before {
-            self.kitty_graphics_dirty = true;
+        let inactive = &self.kitty_inactive_screen.kitty_images;
+        let mut freed = 0usize;
+        let mut removals: Vec<GraphicRemoval> = Vec::new();
+        self.kitty_images.retain(|id, img| {
+            if !predicate(id, img) {
+                return true;
+            }
+            freed += img.data.pixels.len();
+            if !inactive.contains_key(id) {
+                removals.push(GraphicRemoval::Kitty(*id));
+            }
+            false
+        });
+        if self.kitty_images.len() == before {
+            return;
+        }
+        self.kitty_graphics_dirty = true;
+        self.deflate_total_bytes(freed);
+        if !removals.is_empty() {
+            self.texture_operations.lock().append(&mut removals);
         }
         // Clean up stale number mappings
         self.kitty_image_numbers
@@ -1112,36 +1160,46 @@ impl Graphics {
         // Actually remove the evicted graphics from the right home.
         for (id, source) in evicted {
             let evicted_u32 = id.get() as u32;
-            match source {
+            // Tag the removal with its id space so the handler targets the
+            // correct `image_data` key — an atlas key for `Pending`, the
+            // raw protocol id for either kitty screen. A kitty id living
+            // on both screens shares one window-level texture: queue its
+            // removal only once neither screen references it.
+            let removal = match source {
                 CandidateSource::Pending => {
                     self.pending.retain(|g| g.id != id);
+                    // Byte size is already accounted below via freed_bytes,
+                    // but the per-id bookkeeping still needs clearing.
+                    self.graphic_bytes.remove(&id);
+                    Some(GraphicRemoval::Atlas(id))
                 }
                 CandidateSource::ActiveKitty => {
                     self.kitty_images.remove(&evicted_u32);
                     self.kitty_image_numbers.retain(|_, v| *v != evicted_u32);
                     self.kitty_graphics_dirty = true;
+                    (!self
+                        .kitty_inactive_screen
+                        .kitty_images
+                        .contains_key(&evicted_u32))
+                    .then_some(GraphicRemoval::Kitty(evicted_u32))
                 }
                 CandidateSource::InactiveKitty => {
                     self.kitty_inactive_screen.kitty_images.remove(&evicted_u32);
                     self.kitty_inactive_screen
                         .kitty_image_numbers
                         .retain(|_, v| *v != evicted_u32);
+                    (!self.kitty_images.contains_key(&evicted_u32))
+                        .then_some(GraphicRemoval::Kitty(evicted_u32))
                 }
-            }
+            };
 
             // Remove timestamp (only used for pending atlas graphics)
             self.image_timestamps.remove(&id);
 
-            // Add to removal queue so GPU textures get cleaned up. Tag
-            // with the id space the graphic lived in so the frontend
-            // builds the matching `ImageKey` source.
-            let removal = match source {
-                CandidateSource::Pending => GraphicRemoval::Atlas(id),
-                CandidateSource::ActiveKitty | CandidateSource::InactiveKitty => {
-                    GraphicRemoval::Kitty(id.get() as u32)
-                }
-            };
-            self.texture_operations.lock().push(removal);
+            // Add to removal queue so GPU textures get cleaned up
+            if let Some(removal) = removal {
+                self.texture_operations.lock().push(removal);
+            }
         }
 
         // Sweep dangling placements on both screens. A placement is
@@ -1167,7 +1225,7 @@ impl Graphics {
             .retain(|_, p| inactive_ids.contains(&p.image_id));
 
         // Update total_bytes
-        self.total_bytes = self.total_bytes.saturating_sub(freed_bytes);
+        self.deflate_total_bytes(freed_bytes);
 
         debug!(
             "Evicted {} bytes, new total: {}",
@@ -1195,6 +1253,7 @@ impl Graphics {
     pub fn track_graphic(&mut self, graphic_id: GraphicId, bytes: usize) {
         self.image_timestamps
             .insert(graphic_id, std::time::Instant::now());
+        self.graphic_bytes.insert(graphic_id, bytes);
         self.total_bytes += bytes;
         debug!(
             "Tracked graphic id={}, bytes={}, total_bytes={}",
@@ -1202,14 +1261,38 @@ impl Graphics {
         );
     }
 
+    /// Subtract freed bytes from the running total, saturating at zero.
+    fn deflate_total_bytes(&mut self, bytes: usize) {
+        self.total_bytes = self.total_bytes.saturating_sub(bytes);
+    }
+
     /// Update total_bytes when a graphic is removed
     pub fn untrack_graphic(&mut self, graphic_id: GraphicId, bytes: usize) {
         self.image_timestamps.remove(&graphic_id);
-        self.total_bytes = self.total_bytes.saturating_sub(bytes);
+        self.graphic_bytes.remove(&graphic_id);
+        self.deflate_total_bytes(bytes);
         debug!(
             "Untracked graphic id={}, bytes={}, total_bytes={}",
             graphic_id.0, bytes, self.total_bytes
         );
+    }
+
+    /// Untrack an atlas graphic whose last referencing cell was just
+    /// dropped (id known, byte size looked up from `graphic_bytes`).
+    ///
+    /// Called from the removal queue drain so `total_bytes` deflates as
+    /// soon as a graphic is freed rather than ratcheting forever — the
+    /// 320MB accounting then reflects live pixel data. No-op if the id
+    /// was already untracked (idempotent under duplicate queue entries).
+    pub fn untrack_graphic_by_id(&mut self, graphic_id: GraphicId) {
+        if let Some(bytes) = self.graphic_bytes.remove(&graphic_id) {
+            self.image_timestamps.remove(&graphic_id);
+            self.deflate_total_bytes(bytes);
+            debug!(
+                "Untracked graphic id={}, bytes={}, total_bytes={}",
+                graphic_id.0, bytes, self.total_bytes
+            );
+        }
     }
 }
 
@@ -1257,6 +1340,104 @@ fn check_opaque_region() {
 
     assert!(graphic.is_filled(0, 0, 3, 3));
     assert!(!graphic.is_filled(1, 1, 4, 4));
+}
+
+#[cfg(test)]
+fn test_kitty_pixels(bytes: usize) -> GraphicData {
+    GraphicData {
+        id: GraphicId::new(0),
+        width: 1,
+        height: 1,
+        color_type: sugarloaf::ColorType::Rgba,
+        pixels: vec![255u8; bytes],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: std::time::Instant::now(),
+    }
+}
+
+#[test]
+fn test_delete_kitty_images_deflates_and_queues_removal() {
+    let mut graphics = Graphics::default();
+    graphics.store_kitty_image(1, Some(9), test_kitty_pixels(64));
+    graphics.store_kitty_image(2, None, test_kitty_pixels(32));
+    assert_eq!(graphics.total_bytes, 96);
+
+    graphics.delete_kitty_images(|id, _| *id == 1);
+
+    assert_eq!(graphics.total_bytes, 32);
+    assert!(graphics.kitty_image_numbers.is_empty());
+    assert_eq!(
+        graphics.texture_operations.lock().as_slice(),
+        &[GraphicRemoval::Kitty(1)]
+    );
+}
+
+#[test]
+fn test_delete_kitty_image_shared_with_inactive_screen() {
+    let mut graphics = Graphics::default();
+    graphics.store_kitty_image(1, None, test_kitty_pixels(64));
+    graphics.swap_kitty_screen_state();
+    graphics.store_kitty_image(1, None, test_kitty_pixels(32));
+    assert_eq!(graphics.total_bytes, 96);
+
+    graphics.delete_kitty_images(|_, _| true);
+
+    // Only the active copy's bytes deflate; the inactive screen still
+    // owns the window-level texture, so no removal may be queued.
+    assert_eq!(graphics.total_bytes, 64);
+    assert!(graphics.texture_operations.lock().is_empty());
+}
+
+#[test]
+fn test_clear_all_kitty_state_deflates_and_queues_once() {
+    let mut graphics = Graphics::default();
+    graphics.store_kitty_image(1, None, test_kitty_pixels(64));
+    graphics.swap_kitty_screen_state();
+    graphics.store_kitty_image(1, None, test_kitty_pixels(32));
+    graphics.store_kitty_image(2, None, test_kitty_pixels(16));
+    assert_eq!(graphics.total_bytes, 112);
+
+    graphics.clear_all_kitty_state();
+
+    assert_eq!(graphics.total_bytes, 0);
+    assert!(graphics.kitty_images.is_empty());
+    assert!(graphics.kitty_inactive_screen.kitty_images.is_empty());
+    let ops = graphics.texture_operations.lock();
+    let mut ids: Vec<u32> = ops
+        .iter()
+        .map(|removal| match removal {
+            GraphicRemoval::Kitty(id) => *id,
+            other => panic!("unexpected removal {other:?}"),
+        })
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(ids, [1, 2], "each id queued exactly once across screens");
+}
+
+#[test]
+fn test_eviction_of_shared_id_queues_single_removal() {
+    let mut graphics = Graphics {
+        total_limit: 100,
+        ..Graphics::default()
+    };
+    graphics.store_kitty_image(1, None, test_kitty_pixels(60));
+    graphics.swap_kitty_screen_state();
+    graphics.store_kitty_image(1, None, test_kitty_pixels(40));
+    assert_eq!(graphics.total_bytes, 100);
+
+    // Freeing 80 bytes forces both copies out; the shared window-level
+    // texture must be queued exactly once, after neither screen holds it.
+    let used = std::collections::HashSet::new();
+    assert!(graphics.evict_images(80, &used));
+
+    assert_eq!(graphics.total_bytes, 0);
+    assert_eq!(
+        graphics.texture_operations.lock().as_slice(),
+        &[GraphicRemoval::Kitty(1)]
+    );
 }
 
 #[test]

--- a/rio-backend/src/ansi/graphics.rs
+++ b/rio-backend/src/ansi/graphics.rs
@@ -12,6 +12,22 @@ use std::mem;
 use std::sync::Arc;
 use tracing::debug;
 
+/// A graphic scheduled for removal, tagged with the id space it lives in.
+///
+/// Atlas graphics (sixel/iTerm2) and kitty images don't share an id
+/// space: both allocate per terminal and can collide numerically. The
+/// window-level store is keyed by `sugarloaf::ImageKey` (route, source,
+/// id), and the frontend needs this tag to build the source part — a
+/// bare id can't tell the removal handler which entry to target, so a
+/// kitty removal could delete an atlas entry and leak the real one.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum GraphicRemoval {
+    /// Sixel/iTerm2 atlas graphic (`GraphicId` space).
+    Atlas(GraphicId),
+    /// Kitty image (raw protocol `image_id` space).
+    Kitty(u32),
+}
+
 #[derive(Debug, Clone)]
 pub struct UpdateQueues {
     /// Atlas graphics (sixel/iTerm2) read from the PTY.
@@ -20,9 +36,8 @@ pub struct UpdateQueues {
     /// Image textures (kitty) keyed by image_id.
     pub pending_images: Vec<(u32, GraphicData)>,
 
-    /// Image keys removed from the grid or evicted
-    /// (`sugarloaf::graphics::kitty_image_key` / `atlas_image_key`).
-    pub remove_queue: Vec<u64>,
+    /// Graphics removed from the grid, tagged with their id space.
+    pub remove_queue: Vec<GraphicRemoval>,
 }
 
 /// Kitty graphics Unicode placeholder character
@@ -376,7 +391,10 @@ pub fn kitty_overlay_geometry(
 /// scale of the image.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AtlasPlacement {
-    /// Texture key (`atlas_image_key(GraphicId)`).
+    /// Raw `GraphicId` of the atlas graphic. The frontend scopes it to
+    /// the owning terminal via `ImageKey::atlas(route_id, image_key)`;
+    /// the `ImageKey` source discriminant keeps it disjoint from kitty
+    /// ids, so no numeric shift is needed here.
     pub image_key: u64,
     /// Anchor row in the stable absolute space
     /// (`lines_evicted + history + screen_row` at insert).
@@ -579,8 +597,8 @@ pub struct Graphics {
     /// New image textures (kitty), keyed by image_id.
     pub pending_images: Vec<(u32, GraphicData)>,
 
-    /// Graphics removed from the grid.
-    pub texture_operations: Arc<Mutex<Vec<u64>>>,
+    /// Graphics removed from the grid, tagged with their id space.
+    pub texture_operations: Arc<Mutex<Vec<GraphicRemoval>>>,
 
     /// Shared palette for Sixel graphics.
     pub sixel_shared_palette: Option<Vec<ColorRgb>>,
@@ -792,7 +810,7 @@ impl Graphics {
     fn recount_atlas_keys_for(
         placements: &[AtlasPlacement],
         key_refs: &mut FxHashMap<u64, u32>,
-        texture_operations: &std::sync::Arc<parking_lot::Mutex<Vec<u64>>>,
+        texture_operations: &std::sync::Arc<parking_lot::Mutex<Vec<GraphicRemoval>>>,
     ) {
         let mut refs: FxHashMap<u64, u32> = FxHashMap::default();
         for placement in placements {
@@ -801,7 +819,7 @@ impl Graphics {
         let mut removals = texture_operations.lock();
         for key in key_refs.keys() {
             if !refs.contains_key(key) {
-                removals.push(*key);
+                removals.push(GraphicRemoval::Atlas(GraphicId::new(*key)));
             }
         }
         drop(removals);
@@ -859,10 +877,10 @@ impl Graphics {
         {
             let mut removals = self.texture_operations.lock();
             for key in self.atlas_key_refs.keys() {
-                removals.push(*key);
+                removals.push(GraphicRemoval::Atlas(GraphicId::new(*key)));
             }
             for key in self.kitty_inactive_screen.atlas_key_refs.keys() {
-                removals.push(*key);
+                removals.push(GraphicRemoval::Atlas(GraphicId::new(*key)));
             }
         }
         self.atlas_placements.clear();
@@ -1114,16 +1132,16 @@ impl Graphics {
             // Remove timestamp (only used for pending atlas graphics)
             self.image_timestamps.remove(&id);
 
-            // Add to removal queue so GPU textures get cleaned up.
-            // The key namespace depends on where the image lived:
-            // kitty ids map verbatim, atlas graphics live above 2^32.
-            let key = match source {
-                CandidateSource::Pending => crate::sugarloaf::atlas_image_key(id.get()),
+            // Add to removal queue so GPU textures get cleaned up. Tag
+            // with the id space the graphic lived in so the frontend
+            // builds the matching `ImageKey` source.
+            let removal = match source {
+                CandidateSource::Pending => GraphicRemoval::Atlas(id),
                 CandidateSource::ActiveKitty | CandidateSource::InactiveKitty => {
-                    crate::sugarloaf::kitty_image_key(id.get() as u32)
+                    GraphicRemoval::Kitty(id.get() as u32)
                 }
             };
-            self.texture_operations.lock().push(key);
+            self.texture_operations.lock().push(removal);
         }
 
         // Sweep dangling placements on both screens. A placement is
@@ -1164,8 +1182,7 @@ impl Graphics {
         let mut active = std::collections::HashSet::new();
         // Sixel/iTerm2 liveness: placements are the single owners.
         for placement in &self.atlas_placements {
-            // Atlas keys live above 2^32; recover the GraphicId part.
-            active.insert(placement.image_key - (1u64 << 32));
+            active.insert(placement.image_key);
         }
         // Overlay-based (kitty) liveness — use image_id directly
         for placement in self.kitty_placements.values() {

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -4263,8 +4263,10 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 overlay_changed = true;
 
                 if delete.delete_data {
-                    self.graphics.kitty_images.clear();
-                    self.graphics.kitty_image_numbers.clear();
+                    // Route through delete_kitty_images so the byte
+                    // accounting deflates and the window-level textures
+                    // are queued for removal.
+                    self.graphics.delete_kitty_images(|_, _| true);
                 }
             }
             b'i' | b'I' => {

--- a/rio-backend/src/crosswords/mod.rs
+++ b/rio-backend/src/crosswords/mod.rs
@@ -1853,7 +1853,9 @@ impl<U: EventListener> Crosswords<U> {
             if !stale.atlas_placements.is_empty() {
                 let mut removals = self.graphics.texture_operations.lock();
                 for key in stale.atlas_key_refs.keys() {
-                    removals.push(*key);
+                    removals.push(crate::ansi::graphics::GraphicRemoval::Atlas(
+                        sugarloaf::GraphicId::new(*key),
+                    ));
                 }
                 drop(removals);
                 stale.atlas_placements.clear();
@@ -4067,7 +4069,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
         // this image lives on the grid. Cell fills above remain only
         // until the extras-based path is removed.
         {
-            let key = crate::sugarloaf::atlas_image_key(graphic_id.get());
+            let key = graphic_id.get();
             let placement_columns = (width as usize).div_ceil(cell_width);
             let placement_rows = (height as usize).div_ceil(cell_height);
 

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -2580,6 +2580,32 @@ fn test_delete_uppercase_a_clears_all_image_data() {
 }
 
 #[test]
+fn test_delete_uppercase_a_deflates_byte_accounting() {
+    // d=A must give the stored bytes back to the accounting; otherwise
+    // total_bytes ratchets until every new store evicts live images.
+    let mut term = make_test_term();
+    store_red_pixel(&mut term, 1);
+    store_red_pixel(&mut term, 2);
+    assert_eq!(term.graphics.total_bytes, 8);
+
+    let delete = DeleteRequest {
+        action: b'a',
+        image_id: 0,
+        image_number: 0,
+        placement_id: 0,
+        x: 0,
+        y: 0,
+        z_index: 0,
+        delete_data: true,
+    };
+    term.delete_graphics(delete);
+
+    assert!(term.graphics.kitty_images.is_empty());
+    assert!(term.graphics.kitty_image_numbers.is_empty());
+    assert_eq!(term.graphics.total_bytes, 0);
+}
+
+#[test]
 fn test_delete_lowercase_a_keeps_image_data() {
     // Per spec: lowercase deletes placements only, image data stays so a
     // future `a=p` can still place the same image.

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -1109,7 +1109,7 @@ fn test_place_nonexistent_graphic() {
 #[test]
 fn test_recount_releases_key_exactly_once() {
     let mut graphics = crate::ansi::graphics::Graphics::default();
-    let key = crate::sugarloaf::atlas_image_key(99);
+    let key: u64 = 99;
     graphics
         .atlas_placements
         .push(crate::ansi::graphics::AtlasPlacement {
@@ -1141,7 +1141,12 @@ fn test_recount_releases_key_exactly_once() {
     // Dropping the last piece queues the removal exactly once.
     graphics.atlas_placements.clear();
     graphics.recount_atlas_keys();
-    assert_eq!(graphics.texture_operations.lock().as_slice(), &[key]);
+    assert_eq!(
+        graphics.texture_operations.lock().as_slice(),
+        &[crate::ansi::graphics::GraphicRemoval::Atlas(
+            crate::sugarloaf::GraphicId::new(key)
+        )]
+    );
     graphics.recount_atlas_keys();
     assert_eq!(
         graphics.texture_operations.lock().len(),
@@ -4776,18 +4781,6 @@ fn test_transmit_and_display_refreshes_sibling_placements() {
 }
 
 #[test]
-fn test_image_key_namespaces_are_disjoint() {
-    use crate::sugarloaf::{atlas_image_key, kitty_image_key};
-
-    // kitty clients may pick any u32 image id (kitten icat uses random
-    // ones); the atlas namespace must live entirely above that range.
-    assert_eq!(kitty_image_key(u32::MAX), u32::MAX as u64);
-    assert_eq!(kitty_image_key(0x8000_0001), 0x8000_0001);
-    assert!(atlas_image_key(0) > u32::MAX as u64);
-    assert_eq!(atlas_image_key(7), (1u64 << 32) + 7);
-}
-
-#[test]
 fn test_sixel_cursor_lands_on_last_row_start_column() {
     let mut term = geometry_test_term();
 
@@ -4989,7 +4982,7 @@ fn test_atlas_placement_created_on_insert() {
 
     assert_eq!(term.graphics.atlas_placements.len(), 1);
     let p = &term.graphics.atlas_placements[0];
-    assert_eq!(p.image_key, crate::sugarloaf::atlas_image_key(1));
+    assert_eq!(p.image_key, 1);
     assert_eq!(p.abs_row, 0);
     assert_eq!(p.col, 5, "anchored at the cursor column");
     assert_eq!((p.columns, p.rows), (3, 2), "30x40 at 10x20 cells");
@@ -5216,7 +5209,7 @@ fn test_overlay_clips_to_panel_rect() {
     // ends at x=400 must clip at the divider, showing only the left
     // two-thirds of the texture.
     let mut overlay = GraphicOverlay {
-        image_id: 1,
+        image_id: crate::sugarloaf::ImageKey::kitty(0, 1),
         x: 100.0,
         y: 50.0,
         width: 600.0,
@@ -5238,7 +5231,7 @@ fn test_overlay_clips_to_panel_rect() {
 
     // Fully outside the panel: dropped.
     let mut outside = GraphicOverlay {
-        image_id: 1,
+        image_id: crate::sugarloaf::ImageKey::kitty(0, 1),
         x: 500.0,
         y: 0.0,
         width: 100.0,
@@ -5251,7 +5244,7 @@ fn test_overlay_clips_to_panel_rect() {
     // Partial scroll off the panel top with an existing crop: the
     // source rect shrinks within the crop, not the full texture.
     let mut scrolled = GraphicOverlay {
-        image_id: 1,
+        image_id: crate::sugarloaf::ImageKey::kitty(0, 1),
         x: 0.0,
         y: -50.0,
         width: 100.0,
@@ -5312,7 +5305,7 @@ fn test_narrowing_terminal_keeps_image_span_and_clips_at_edge() {
     };
     let geometry = kitty_overlay_geometry(stored, 100, 100, &viewport).unwrap();
     let mut overlay = GraphicOverlay {
-        image_id: 1,
+        image_id: crate::sugarloaf::ImageKey::kitty(0, 1),
         x: geometry.x,
         y: geometry.y,
         width: geometry.width,

--- a/sugarloaf/src/lib.rs
+++ b/sugarloaf/src/lib.rs
@@ -37,9 +37,9 @@ pub use swash::{Attributes, Stretch, Style, Weight};
 pub use crate::font_cache::ResolvedGlyph;
 pub use crate::sugarloaf::{
     graphics::{
-        atlas_image_key, kitty_image_key, ColorType, Graphic, GraphicData,
-        GraphicDataEntry, GraphicId, GraphicOverlay, Graphics, ResizeCommand,
-        ResizeParameter, MAX_GRAPHIC_DIMENSIONS,
+        ColorType, Graphic, GraphicData, GraphicDataEntry, GraphicId, GraphicOverlay,
+        Graphics, ImageKey, ImageSource, ResizeCommand, ResizeParameter,
+        MAX_GRAPHIC_DIMENSIONS,
     },
     primitives::{
         is_private_user_area, Corners, CursorKind, ImageProperties, Quad, Rect,

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -13,7 +13,7 @@ use crate::context::cpu::CpuContext;
 use crate::renderer::compositor::Vertex;
 use crate::renderer::image_cache::ImageCache;
 use crate::renderer::Renderer;
-use crate::sugarloaf::graphics::{GraphicDataEntry, GraphicOverlay};
+use crate::sugarloaf::graphics::{GraphicDataEntry, GraphicOverlay, ImageKey};
 use rustc_hash::FxHashMap;
 use std::hash::Hasher;
 use wide::{u32x4, u32x8};
@@ -21,7 +21,7 @@ use wide::{u32x4, u32x8};
 /// Image overlays and their pixel stores for a CPU frame.
 pub struct ImageLayers<'a> {
     pub overlays: &'a FxHashMap<usize, Vec<GraphicOverlay>>,
-    pub data: &'a FxHashMap<u64, GraphicDataEntry>,
+    pub data: &'a FxHashMap<ImageKey, GraphicDataEntry>,
 }
 
 #[derive(Default)]
@@ -350,7 +350,12 @@ pub fn render_cpu(
         // retransmitted image gets a fresh handle id).
         h.write_usize(image_overlays.len());
         for overlay in &image_overlays {
-            h.write_u64(overlay.image_id);
+            // ImageKey is (owner, source, id) — hash all three so a
+            // per-route id collision can't alias two panes' images in
+            // the frame cache.
+            h.write_usize(overlay.image_id.owner);
+            h.write_u8(overlay.image_id.source as u8);
+            h.write_u64(overlay.image_id.id);
             h.write_u32(overlay.x.to_bits());
             h.write_u32(overlay.y.to_bits());
             h.write_u32(overlay.width.to_bits());
@@ -557,7 +562,7 @@ fn draw_image_overlays(
     buf_w: i32,
     buf_h: i32,
     overlays: &[&GraphicOverlay],
-    data: &FxHashMap<u64, GraphicDataEntry>,
+    data: &FxHashMap<ImageKey, GraphicDataEntry>,
 ) {
     for overlay in overlays {
         let entry = match data.get(&overlay.image_id) {
@@ -1006,7 +1011,7 @@ mod image_overlay_tests {
 
     fn overlay(x: f32, y: f32, width: f32, height: f32) -> GraphicOverlay {
         GraphicOverlay {
-            image_id: 1,
+            image_id: ImageKey::kitty(0, 1),
             x,
             y,
             width,

--- a/sugarloaf/src/renderer/mod.rs
+++ b/sugarloaf/src/renderer/mod.rs
@@ -759,16 +759,16 @@ const IMAGE_TEXTURE_BUDGET_BYTES: usize = 256 << 20;
 /// Pick which textures to evict to get `total_bytes` back under
 /// `budget`. Never evicts entries referenced by the current frame.
 /// Returns the chosen keys; pure so the policy is unit-testable.
-fn select_texture_evictions(
-    entries: impl Iterator<Item = (u64, u64, usize)>,
+fn select_texture_evictions<K: Copy>(
+    entries: impl Iterator<Item = (K, u64, usize)>,
     total_bytes: usize,
     budget: usize,
     current_frame: u64,
-) -> Vec<u64> {
+) -> Vec<K> {
     if total_bytes <= budget {
         return Vec::new();
     }
-    let mut candidates: Vec<(u64, u64, usize)> = entries
+    let mut candidates: Vec<(K, u64, usize)> = entries
         .filter(|&(_, last_used, _)| last_used < current_frame)
         .collect();
     candidates.sort_by_key(|&(_, last_used, _)| last_used);
@@ -827,7 +827,7 @@ pub(crate) const IMAGE_BG_LIMIT: i32 = i32::MIN / 2;
 
 /// A single image draw command for the image pipeline.
 struct ImageDraw {
-    image_id: u64,
+    image_id: crate::sugarloaf::graphics::ImageKey,
     instance: ImageInstance,
     layer: ImageLayer,
 }
@@ -847,7 +847,7 @@ pub struct Renderer {
     draw_cmds: Vec<batch::DrawCmd>,
     images: ImageCache,
     /// Per-image GPU textures (one map, any backend).
-    image_textures: FxHashMap<u64, ImageTextureEntry>,
+    image_textures: FxHashMap<crate::sugarloaf::graphics::ImageKey, ImageTextureEntry>,
     /// Sum of `bytes` across `image_textures`; compared against
     /// `IMAGE_TEXTURE_BUDGET_BYTES` after uploads.
     image_texture_bytes: usize,
@@ -1073,7 +1073,7 @@ impl Renderer {
         _state: &crate::sugarloaf::state::SugarState,
         _graphics: &mut Graphics,
         image_data: &mut rustc_hash::FxHashMap<
-            u64,
+            crate::sugarloaf::graphics::ImageKey,
             crate::sugarloaf::graphics::GraphicDataEntry,
         >,
         image_overlays: &rustc_hash::FxHashMap<
@@ -1197,7 +1197,7 @@ impl Renderer {
         &mut self,
         context: &mut crate::context::Context,
         image_data: &mut rustc_hash::FxHashMap<
-            u64,
+            crate::sugarloaf::graphics::ImageKey,
             crate::sugarloaf::graphics::GraphicDataEntry,
         >,
         overlays: &[&crate::sugarloaf::graphics::GraphicOverlay],
@@ -1438,7 +1438,10 @@ impl Renderer {
     #[allow(clippy::too_many_arguments)]
     fn draw_images_metal(
         image_draws: &[ImageDraw],
-        image_textures: &FxHashMap<u64, ImageTextureEntry>,
+        image_textures: &FxHashMap<
+            crate::sugarloaf::graphics::ImageKey,
+            ImageTextureEntry,
+        >,
         brush: &MetalRenderer,
         render_encoder: &metal::RenderCommandEncoderRef,
         layer: ImageLayer,
@@ -1657,7 +1660,7 @@ impl Renderer {
     /// kitty eviction); without this, sequential atlas ids from e.g.
     /// sixel animations would grow the texture cache without bound.
     #[inline]
-    pub fn evict_image_texture(&mut self, key: u64) {
+    pub fn evict_image_texture(&mut self, key: crate::sugarloaf::graphics::ImageKey) {
         if let Some(old) = self.image_textures.remove(&key) {
             self.image_texture_bytes -= old.bytes;
         }

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -9,7 +9,7 @@ use crate::font::{fonts::SugarloafFont, FontLibrary};
 use crate::font_cache::{compute_advance, resolve_with, FontCache, ResolvedGlyph};
 use crate::layout::RootStyle;
 use crate::renderer::Renderer;
-use crate::sugarloaf::graphics::{GraphicDataEntry, Graphics};
+use crate::sugarloaf::graphics::{GraphicDataEntry, Graphics, ImageKey};
 use swash::Attributes;
 
 use crate::context::Context;
@@ -38,9 +38,11 @@ pub struct Sugarloaf<'a> {
     pub graphics: Graphics,
     #[cfg(feature = "wgpu")]
     filters_brush: Option<FiltersBrush>,
-    /// Pixel data for standalone image textures, keyed by image key
-    /// (`graphics::kitty_image_key` / `graphics::atlas_image_key`).
-    pub image_data: rustc_hash::FxHashMap<u64, GraphicDataEntry>,
+    /// Pixel data for standalone image textures. Keyed by the composite
+    /// `ImageKey` — this store is window-level while protocol ids are
+    /// per-terminal, so the key must carry the owning terminal and the
+    /// source id space alongside the id.
+    pub image_data: rustc_hash::FxHashMap<ImageKey, GraphicDataEntry>,
     /// Persistent state for the CPU rasterizer (glyph cache + frame hash).
     /// Unused on GPU backends.
     cpu_cache: crate::renderer::cpu::CpuCache,
@@ -906,9 +908,9 @@ impl Sugarloaf<'_> {
     }
 
     /// Remove an image's pixel data and its cached GPU texture.
-    /// `key` is a `graphics::kitty_image_key` / `graphics::atlas_image_key`.
+    /// `key` is an `ImageKey` (`ImageKey::kitty` / `ImageKey::atlas`).
     #[inline]
-    pub fn remove_image(&mut self, key: u64) {
+    pub fn remove_image(&mut self, key: ImageKey) {
         self.image_data.remove(&key);
         self.renderer.evict_image_texture(key);
     }

--- a/sugarloaf/src/sugarloaf/graphics.rs
+++ b/sugarloaf/src/sugarloaf/graphics.rs
@@ -85,30 +85,58 @@ pub struct Graphic {
     pub offset_y: u16,
 }
 
-/// Key for `Sugarloaf::image_data` and the renderer's per-image
-/// texture cache: a kitty image, keyed by its protocol id verbatim.
-/// The full u32 space belongs to the client, so atlas graphics live
-/// in a disjoint range above it (see [`atlas_image_key`]).
-#[inline]
-pub fn kitty_image_key(image_id: u32) -> u64 {
-    image_id as u64
+/// Which protocol id space an `ImageKey`'s id lives in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ImageSource {
+    /// Sixel/iTerm2 atlas graphic (`GraphicId` space, u64).
+    Atlas,
+    /// Kitty graphics image (protocol `image_id` space, u32).
+    Kitty,
 }
 
-/// Key for an atlas graphic (sixel/iTerm2): the sequential
-/// `GraphicId` shifted above the kitty u32 id space so a kitty client
-/// picking a high image id (kitten icat uses random u32 ids) can
-/// never collide with an atlas texture.
-#[inline]
-pub fn atlas_image_key(graphic_id: u64) -> u64 {
-    (1u64 << 32) + graphic_id
+/// Key for the window-level image stores (`Sugarloaf::image_data` and the
+/// renderer's per-image GPU texture map). One window hosts many terminals
+/// (tabs/splits), and both protocol id spaces restart per terminal, so a
+/// bare numeric id cannot address the shared store: one terminal's image
+/// would clobber another's, and a kitty id could land on a sixel's entry.
+/// The key carries all three coordinates so live images never collide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ImageKey {
+    /// Opaque per-terminal namespace supplied by the frontend (rioterm
+    /// passes the route id).
+    pub owner: usize,
+    pub source: ImageSource,
+    /// Protocol-level id, widened to u64: kitty ids may use the full
+    /// u32 range and `GraphicId` is u64 — neither can be shrunk.
+    pub id: u64,
+}
+
+impl ImageKey {
+    #[inline]
+    pub const fn atlas(owner: usize, id: u64) -> Self {
+        Self {
+            owner,
+            source: ImageSource::Atlas,
+            id,
+        }
+    }
+
+    #[inline]
+    pub const fn kitty(owner: usize, id: u32) -> Self {
+        Self {
+            owner,
+            source: ImageSource::Kitty,
+            id: id as u64,
+        }
+    }
 }
 
 /// An overlay image placement.
 /// Used by the renderer to draw images on top of (or behind) terminal content.
 #[derive(Debug, Clone)]
 pub struct GraphicOverlay {
-    /// Image texture key ([`kitty_image_key`] or [`atlas_image_key`]).
-    pub image_id: u64,
+    /// Key of the image in the window-level image store.
+    pub image_id: ImageKey,
     /// Screen position (physical pixels).
     pub x: f32,
     pub y: f32,
@@ -461,6 +489,28 @@ pub struct ResizeCommand {
     pub height: ResizeParameter,
 
     pub preserve_aspect_ratio: bool,
+}
+
+#[test]
+fn image_keys_discriminate_source_and_owner() {
+    // Implicit kitty ids allocate from 0x80000000 while the first sixel's
+    // GraphicId is 1 — under the old flag-packed u32 key both mapped to
+    // 0x80000001 and the kitty transmit clobbered the sixel's entry.
+    assert_ne!(ImageKey::kitty(7, 0x8000_0001), ImageKey::atlas(7, 1));
+    // A client-supplied kitty i= may occupy any u32 value, including ones
+    // numerically equal to an atlas GraphicId.
+    assert_ne!(ImageKey::kitty(7, 1), ImageKey::atlas(7, 1));
+    // Per-terminal id counters restart at 1 (atlas) / 0x80000000 (kitty),
+    // so the same protocol id from two tabs sharing a window must map to
+    // distinct entries.
+    assert_ne!(ImageKey::atlas(1, 1), ImageKey::atlas(2, 1));
+    assert_ne!(
+        ImageKey::kitty(1, 0x8000_0000),
+        ImageKey::kitty(2, 0x8000_0000)
+    );
+    // Identity still holds within one terminal + source.
+    assert_eq!(ImageKey::kitty(3, 42), ImageKey::kitty(3, 42));
+    assert_eq!(ImageKey::atlas(3, 42), ImageKey::atlas(3, 42));
 }
 
 #[test]

--- a/sugarloaf/src/sugarloaf/state.rs
+++ b/sugarloaf/src/sugarloaf/state.rs
@@ -61,7 +61,10 @@ impl SugarState {
         advance_brush: &mut Renderer,
         context: &mut super::Context,
         graphics: &mut Graphics,
-        image_data: &mut rustc_hash::FxHashMap<u64, super::graphics::GraphicDataEntry>,
+        image_data: &mut rustc_hash::FxHashMap<
+            super::graphics::ImageKey,
+            super::graphics::GraphicDataEntry,
+        >,
         image_overlays: &rustc_hash::FxHashMap<
             usize,
             Vec<super::graphics::GraphicOverlay>,


### PR DESCRIPTION
fix(graphics): deflate image byte accounting when graphics are freed

## Problem

`Graphics::total_bytes` is the running total of image pixel bytes,
checked against `total_limit` (320MB, per the kitty spec) before every
insert. When the total exceeds the budget, `evict_images` throws out
least-recently-used images to make room.

Today the counter deflates on most paths — explicit `untrack_graphic`,
LRU `evict_images`, image replacement, and inactive-screen clear — but
**two paths free pixels without giving the bytes back**, so `total_bytes`
ratchets upward until it no longer reflects live data and starts
force-evicting images that are still on screen:

1. **Atlas graphic dropped off the grid.** When a sixel/iTerm2 graphic's
   last referencing cell scrolls out of scrollback, the removal is
   queued by id only — the removal path never knew the graphic's byte
   size, so nothing was subtracted from `total_bytes`.

2. **`d=A` delete-all (`delete_data`).** The kitty "delete everything"
   command cleared `kitty_images` directly
   (`kitty_images.clear(); kitty_image_numbers.clear()`), bypassing the
   accounting entirely. Every deleted image's bytes stayed counted
   forever.

Over a long session these leaks add up and the effective image budget
shrinks toward zero, evicting visible images prematurely.

## Fix

- **Track per-graphic byte size.** A new `graphic_bytes: FxHashMap<GraphicId, usize>`
  records each atlas graphic's size at `track_graphic`, so a removal that
  only carries an id can subtract the exact amount via
  `untrack_graphic_by_id`. Queued atlas removals are drained through it
  in `take_queues`.

- **Route `d=A` through the accounting.** Delete-all now calls
  `delete_kitty_images(|_, _| true)` instead of a raw `clear()`, so it
  deflates and queues texture removals like every other delete.

- **One deflation helper.** The scattered
  `total_bytes = total_bytes.saturating_sub(...)` calls are folded into
  `deflate_total_bytes`.

- **Dedup shared textures across screens.** Deletes, full reset, and
  eviction now queue a window-level texture removal only once *neither*
  the active nor the inactive kitty screen references the id — the two
  screens can hold the same image id but share one GPU texture, so it
  must survive until both drop it.

## Testing

New unit / integration tests:

- `test_delete_kitty_images_deflates_and_queues_removal`
- `test_delete_kitty_image_shared_with_inactive_screen`
- `test_clear_all_kitty_state_deflates_and_queues_once`
- `test_eviction_of_shared_id_queues_single_removal`
- `test_delete_uppercase_a_deflates_byte_accounting` (the `d=A` path)

Each asserts `total_bytes` returns to the expected value and that a
shared id is queued exactly once. Full gate:

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p rioterm --all-features` — no new warnings
- `cargo test --features wgpu` — all suites pass (0 failed)

## Scope note

This covers the byte-accounting leaks that are reachable purely through
upstream code paths. Depends on the `GraphicRemoval` removal-queue type
from #1752 (branched on top of it). A companion GPU-texture eviction fix
for #1591 is submitted separately.
