### PR TITLE
feat(ui): close tab on hover with an optional double-click guard

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -668,6 +668,12 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     } else {
                         let size = route.window.screen.context_manager.len();
                         route.window.screen.resize_top_or_bottom_line(size);
+                        // A tab just closed: indices shifted, so any armed
+                        // close button now points at the wrong tab. Drop it.
+                        if let Some(island) = route.window.screen.renderer.island.as_mut()
+                        {
+                            island.disarm();
+                        }
                     }
                 }
             }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1168,9 +1168,11 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         && button == MouseButton::Left
                         && route.window.screen.allow_manual_dragging
                     {
-                        use crate::renderer::island::ISLAND_HEIGHT;
                         let scale = route.window.screen.sugarloaf.scale_factor();
-                        if route.window.screen.mouse.y <= (ISLAND_HEIGHT * scale) as f64 {
+                        let tab_bar_height =
+                            route.window.screen.renderer.navigation.tab_bar_height;
+                        if route.window.screen.mouse.y <= (tab_bar_height * scale) as f64
+                        {
                             let _ = route.window.winit_window.drag_window();
                         }
                     }
@@ -1305,10 +1307,15 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                             #[cfg(target_os = "macos")]
                             if route.window.screen.allow_manual_dragging {
-                                use crate::renderer::island::ISLAND_HEIGHT;
                                 let scale = route.window.screen.sugarloaf.scale_factor();
+                                let tab_bar_height = route
+                                    .window
+                                    .screen
+                                    .renderer
+                                    .navigation
+                                    .tab_bar_height;
                                 if route.window.screen.mouse.y
-                                    <= (ISLAND_HEIGHT * scale) as f64
+                                    <= (tab_bar_height * scale) as f64
                                 {
                                     route
                                         .window
@@ -1609,11 +1616,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 // tab on macOS) the band at the top has no tabs to
                 // hover, and the I-beam from the terminal grid below
                 // should stay during top-edge drags.
-                use crate::renderer::island::ISLAND_HEIGHT;
                 let scale_factor = route.window.screen.sugarloaf.scale_factor();
-                let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
                 let num_tabs = route.window.screen.ctx().len();
                 let nav = &route.window.screen.renderer.navigation;
+                let island_height_px = (nav.tab_bar_height * scale_factor) as f64;
                 if nav.island_visible(num_tabs) && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -218,6 +218,8 @@ struct IslandFills {
     active: [f32; 4],
     outline: Option<[f32; 4]>,
     close_hover: [f32; 4],
+    /// Overlay composited onto an inactive island under the pointer.
+    hover: [f32; 4],
 }
 
 fn island_fills(bg: [f32; 4]) -> IslandFills {
@@ -228,6 +230,7 @@ fn island_fills(bg: [f32; 4]) -> IslandFills {
             active: [1.0, 1.0, 1.0, 0.92],
             outline: Some([0.0, 0.0, 0.0, 0.14]),
             close_hover: [0.0, 0.0, 0.0, 0.09],
+            hover: [0.0, 0.0, 0.0, 0.08],
         }
     } else {
         IslandFills {
@@ -235,6 +238,7 @@ fn island_fills(bg: [f32; 4]) -> IslandFills {
             active: [1.0, 1.0, 1.0, 0.18],
             outline: None,
             close_hover: [1.0, 1.0, 1.0, 0.14],
+            hover: [1.0, 1.0, 1.0, 0.10],
         }
     }
 }
@@ -407,6 +411,17 @@ pub struct Island {
     /// Cursor is over the active island's close button — draws the
     /// hover backdrop. Updated on every cursor move by `Screen`.
     close_hover: bool,
+    /// Tab slot currently under the pointer (hover highlight).
+    hovered_tab: Option<usize>,
+    /// `[navigation] tab-close-on-hover` — show the close button on
+    /// the hovered tab, not only the active one.
+    pub close_on_hover: bool,
+    /// `[navigation] tab-close-confirm` — first click arms, second
+    /// click closes.
+    pub close_confirm: bool,
+    /// Armed close button: (tab index, armed-at). Cleared when the
+    /// pointer leaves the tab or the arm times out.
+    armed_close: Option<(usize, std::time::Instant)>,
 }
 
 impl Island {
@@ -439,11 +454,80 @@ impl Island {
             slide_springs: FxHashMap::default(),
             last_anim_frame: Instant::now(),
             close_hover: false,
+            hovered_tab: None,
+            close_on_hover: true,
+            close_confirm: false,
+            armed_close: None,
         }
     }
 
     /// Set whether the cursor hovers the active island's close button.
     /// Returns true when the state changed (the caller redraws).
+    pub fn set_hovered_tab(&mut self, tab: Option<usize>) -> bool {
+        let hover_moved = self.hovered_tab != tab;
+        let mut changed = hover_moved;
+        self.hovered_tab = tab;
+        // Moving the pointer ONTO a different tab disarms the close
+        // button. Two things must NOT disarm: leaving the bar entirely
+        // (keyboard-armed closes survive the pointer idling over the
+        // terminal — the timeout covers abandonment), and a static
+        // re-hover re-asserted every render frame (gated by hover_moved,
+        // so a keyboard-armed tab isn't disarmed the instant the pointer
+        // happens to already rest over a different tab).
+        if hover_moved {
+            if let (Some((armed_idx, _)), Some(hovered)) = (self.armed_close, tab) {
+                if hovered != armed_idx {
+                    self.armed_close = None;
+                    changed = true;
+                }
+            }
+        }
+        changed
+    }
+
+    /// How long an armed close button stays armed.
+    pub const ARM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+    /// Two-click close: returns true when the click should CLOSE the
+    /// tab (unarmed mode, or second click on an armed button); false
+    /// means the click armed the button and was consumed.
+    pub fn confirm_close_click(&mut self, tab_index: usize) -> bool {
+        if !self.close_confirm {
+            return true;
+        }
+        match self.armed_close {
+            Some((armed_idx, at))
+                if armed_idx == tab_index && at.elapsed() < Self::ARM_TIMEOUT =>
+            {
+                self.armed_close = None;
+                true
+            }
+            _ => {
+                self.armed_close = Some((tab_index, std::time::Instant::now()));
+                false
+            }
+        }
+    }
+
+    /// Drop an armed close button whose window expired. Returns true
+    /// when state changed (caller repaints).
+    pub fn disarm_stale(&mut self) -> bool {
+        if let Some((_, at)) = self.armed_close {
+            if at.elapsed() >= Self::ARM_TIMEOUT {
+                self.armed_close = None;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Unconditionally drop any armed close button. Called when the tab
+    /// list mutates (a tab closed / shell exited), since the bare armed
+    /// index would otherwise point at a different tab after the shift.
+    pub fn disarm(&mut self) {
+        self.armed_close = None;
+    }
+
     pub fn set_close_hover(&mut self, hover: bool) -> bool {
         let changed = self.close_hover != hover;
         self.close_hover = hover;
@@ -607,6 +691,11 @@ impl Island {
             return;
         }
 
+        // A reorder moves the armed × out from under the pointer; rather
+        // than remap the bare index (and risk authorizing a one-click
+        // close of a tab that shifted into the armed slot), just disarm.
+        self.armed_close = None;
+
         self.slide_springs = self
             .slide_springs
             .drain()
@@ -647,6 +736,9 @@ impl Island {
         if a == b {
             return;
         }
+
+        // Disarm on reorder (see remap_tab_move).
+        self.armed_close = None;
 
         let swap_key = |i: usize| {
             if i == a {
@@ -927,7 +1019,7 @@ impl Island {
             // bleach custom colors to pastel on light themes, so the
             // hierarchy is carried by the mute instead.
             let (ix, iy, iw, ih, radius) = island_rect(tab_x, tab_width, self.geom);
-            let fill = match context_manager.custom_color(tab_index) {
+            let mut fill = match context_manager.custom_color(tab_index) {
                 Some(mut custom) => {
                     if !is_active {
                         custom[3] *= INACTIVE_CUSTOM_MUTE;
@@ -942,6 +1034,10 @@ impl Island {
                     }
                 }
             };
+            // Hover affordances are opt-in; stock rio has none.
+            if !is_active && self.close_on_hover && self.hovered_tab == Some(tab_index) {
+                fill = over(fill, fills.hover);
+            }
             draw_island(
                 sugarloaf,
                 ix,
@@ -955,9 +1051,16 @@ impl Island {
                 0,
             );
 
-            if is_active && num_tabs > 1 {
+            // Close affordance on the active tab and on whichever tab
+            // the pointer hovers (Terminal.app behavior).
+            let is_hovered = self.hovered_tab == Some(tab_index);
+            let shows_close = is_active || (is_hovered && self.close_on_hover);
+            if shows_close && num_tabs > 1 {
                 if let Some(cx) = close_button_center(ix, iw) {
-                    if self.close_hover {
+                    let close_hovered = self.close_hover && is_hovered;
+                    let is_armed =
+                        self.armed_close.is_some_and(|(idx, _)| idx == tab_index);
+                    if close_hovered {
                         sugarloaf.rounded_rect(
                             None,
                             cx - CLOSE_HOVER_HALF,
@@ -973,8 +1076,14 @@ impl Island {
                     draw_close_button(
                         sugarloaf,
                         cx,
-                        self.active_text_color,
-                        self.close_hover,
+                        if is_armed {
+                            [0.90, 0.25, 0.25, 1.0]
+                        } else if is_active {
+                            self.active_text_color
+                        } else {
+                            self.inactive_text_color
+                        },
+                        close_hovered || is_armed,
                         2,
                         self.geom.bar_height,
                     );

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -15,15 +15,66 @@ use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::time::Instant;
 
-pub const ISLAND_HEIGHT: f32 = 38.0;
+#[cfg(test)]
+const ISLAND_HEIGHT: f32 = 38.0;
 const PROGRESS_BAR_HEIGHT: f32 = 3.0;
 
 const PROGRESS_BAR_TIMEOUT_SECS: u64 = 15;
-const TITLE_FONT_SIZE: f32 = 12.0;
+
+/// Configurable tab-strip geometry ([navigation] tab-bar-height /
+/// tab-gap / tab-inset-y / tab-radius). Defaults reproduce the stock
+/// floating-island look; gap = inset = radius = 0 gives a flat strip.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TabGeom {
+    pub bar_height: f32,
+    pub gap: f32,
+    pub inset_y: f32,
+    pub radius: f32,
+    /// Per-tab width cap; `0` disables the cap so tabs expand to
+    /// fill the strip.
+    pub max_tab_width: f32,
+}
+
+impl TabGeom {
+    pub fn from_navigation(nav: &rio_backend::config::navigation::Navigation) -> Self {
+        // Defend the renderer against unclamped config: negative or NaN
+        // sizes here would yield garbage padding / an inverted island.
+        let non_negative = |v: f32| if v.is_finite() { v.max(0.0) } else { 0.0 };
+        Self {
+            bar_height: if nav.tab_bar_height.is_finite() {
+                nav.tab_bar_height.max(1.0)
+            } else {
+                1.0
+            },
+            gap: non_negative(nav.tab_gap),
+            inset_y: non_negative(nav.tab_inset_y),
+            radius: non_negative(nav.tab_radius),
+            max_tab_width: non_negative(nav.tab_max_width),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for TabGeom {
+    fn default() -> Self {
+        Self {
+            bar_height: ISLAND_HEIGHT,
+            gap: TAB_GAP,
+            inset_y: TAB_INSET_Y,
+            radius: TAB_RADIUS,
+            max_tab_width: MAX_TAB_WIDTH,
+        }
+    }
+}
 
 const TAB_PADDING_X: f32 = 27.0;
+#[cfg(test)]
+const MAX_TAB_WIDTH: f32 = 180.0;
+#[cfg(test)]
 const TAB_GAP: f32 = 6.0;
+#[cfg(test)]
 const TAB_INSET_Y: f32 = 7.0;
+#[cfg(test)]
 const TAB_RADIUS: f32 = 6.0;
 const TITLE_ELLIPSIS: char = '…';
 const DRAG_THRESHOLD: f32 = 4.0;
@@ -92,10 +143,11 @@ fn fit_title_to_width<'a>(
     sugarloaf: &mut Sugarloaf,
     title: &'a str,
     max_width: f32,
+    font_size: f32,
 ) -> Cow<'a, str> {
     let attrs = Attributes::default();
     fit_title_with_widths(title, max_width, |c| {
-        sugarloaf.char_advance(c, attrs, TITLE_FONT_SIZE)
+        sugarloaf.char_advance(c, attrs, font_size)
     })
 }
 
@@ -135,7 +187,6 @@ pub struct TabStripLayout {
 }
 
 /// Compute the tab strip layout from the physical window width.
-/// `max_tab_width` comes from `navigation.max-tab-width` (logical px).
 pub fn tab_strip_layout(
     window_width: f32,
     scale_factor: f32,
@@ -149,8 +200,12 @@ pub fn tab_strip_layout(
 
     let available_width =
         (window_width / scale_factor) - ISLAND_MARGIN_RIGHT - left_margin;
-    let tab_width =
-        (available_width / num_tabs.max(1) as f32).clamp(0.0, max_tab_width.max(0.0));
+    let cap = if max_tab_width > 0.0 {
+        max_tab_width
+    } else {
+        f32::INFINITY
+    };
+    let tab_width = (available_width / num_tabs.max(1) as f32).clamp(0.0, cap);
     TabStripLayout {
         left_margin,
         tab_width,
@@ -234,12 +289,14 @@ fn draw_island(
 }
 
 #[inline]
-fn island_rect(slot_x: f32, tab_width: f32) -> (f32, f32, f32, f32, f32) {
-    let x = slot_x + TAB_GAP / 2.0;
-    let w = (tab_width - TAB_GAP).max(0.0);
-    let y = TAB_INSET_Y;
-    let h = ISLAND_HEIGHT - TAB_INSET_Y * 2.0;
-    let radius = TAB_RADIUS.min(w / 2.0).min(h / 2.0);
+fn island_rect(slot_x: f32, tab_width: f32, geom: TabGeom) -> (f32, f32, f32, f32, f32) {
+    let x = slot_x + geom.gap / 2.0;
+    let w = (tab_width - geom.gap).max(0.0);
+    let y = geom.inset_y;
+    // A bar-height smaller than twice the inset would make the island
+    // height negative; floor it so the rect and its radius stay valid.
+    let h = (geom.bar_height - geom.inset_y * 2.0).max(0.0);
+    let radius = geom.radius.max(0.0).min(w / 2.0).min(h / 2.0);
     (x, y, w, h, radius)
 }
 
@@ -250,9 +307,13 @@ fn close_button_center(island_x: f32, island_w: f32) -> Option<f32> {
 }
 
 #[inline]
-fn close_button_center_x(layout: &TabStripLayout, tab_index: usize) -> Option<f32> {
+fn close_button_center_x(
+    layout: &TabStripLayout,
+    tab_index: usize,
+    geom: TabGeom,
+) -> Option<f32> {
     let slot_x = layout.left_margin + tab_index as f32 * layout.tab_width;
-    let (ix, _, iw, _, _) = island_rect(slot_x, layout.tab_width);
+    let (ix, _, iw, _, _) = island_rect(slot_x, layout.tab_width, geom);
     close_button_center(ix, iw)
 }
 
@@ -261,8 +322,9 @@ pub fn close_button_hit(
     layout: &TabStripLayout,
     tab_index: usize,
     x_unscaled: f32,
+    geom: TabGeom,
 ) -> bool {
-    close_button_center_x(layout, tab_index)
+    close_button_center_x(layout, tab_index, geom)
         .is_some_and(|cx| (x_unscaled - cx).abs() <= CLOSE_HIT_HALF_WIDTH)
 }
 
@@ -272,8 +334,9 @@ fn draw_close_button(
     color: [f32; 4],
     hover: bool,
     order: u8,
+    bar_height: f32,
 ) {
-    let cy = ISLAND_HEIGHT / 2.0;
+    let cy = bar_height / 2.0;
     let r = CLOSE_GLYPH_HALF;
     let alpha = if hover {
         CLOSE_ALPHA_HOVER
@@ -305,8 +368,11 @@ fn draw_close_button(
 
 pub struct Island {
     pub hide_if_single: bool,
-    /// Cap on tab width in logical px (`navigation.max-tab-width`).
-    pub max_tab_width: f32,
+    /// Tab-title font size in logical pixels (`navigation.tab-font-size`).
+    pub title_font_size: f32,
+    pub geom: TabGeom,
+    /// Explicit (inactive, active) island fills; None = adaptive.
+    pub fill_override: (Option<[f32; 4]>, Option<[f32; 4]>),
     pub inactive_text_color: [f32; 4],
     pub active_text_color: [f32; 4],
     /// Current progress bar state
@@ -348,11 +414,14 @@ impl Island {
         inactive_text_color: [f32; 4],
         active_text_color: [f32; 4],
         hide_if_single: bool,
-        max_tab_width: f32,
+        title_font_size: f32,
+        geom: TabGeom,
     ) -> Self {
         Self {
             hide_if_single,
-            max_tab_width,
+            title_font_size,
+            geom,
+            fill_override: (None, None),
             inactive_text_color,
             active_text_color,
             progress_state: None,
@@ -636,7 +705,7 @@ impl Island {
         };
 
         let width = window_width / scale_factor;
-        let y_position = ISLAND_HEIGHT;
+        let y_position = self.geom.bar_height;
 
         // Determine color based on state
         let color = match state {
@@ -701,7 +770,7 @@ impl Island {
     /// Get the height of the island
     #[inline]
     pub fn height(&self) -> f32 {
-        ISLAND_HEIGHT
+        self.geom.bar_height
     }
 
     /// Render tabs using equal-width layout
@@ -752,8 +821,12 @@ impl Island {
         self.slide_springs
             .retain(|_, s| s.update(dt, DRAG_ANIMATION_LENGTH));
 
-        let layout =
-            tab_strip_layout(window_width, scale_factor, num_tabs, self.max_tab_width);
+        let layout = tab_strip_layout(
+            window_width,
+            scale_factor,
+            num_tabs,
+            self.geom.max_tab_width,
+        );
         let TabStripLayout {
             left_margin,
             tab_width,
@@ -772,7 +845,14 @@ impl Island {
         // each frame so OSC 11 and theme changes stay coherent. The
         // strip itself keeps the plain window background — the islands
         // float directly on it, with no strip tint or border lines.
-        let fills = island_fills(bg_color);
+        let mut fills = island_fills(bg_color);
+        if let Some(inactive) = self.fill_override.0 {
+            fills.inactive = inactive;
+            fills.outline = None;
+        }
+        if let Some(active) = self.fill_override.1 {
+            fills.active = active;
+        }
 
         // Render each tab
         for tab_index in 0..num_tabs {
@@ -801,7 +881,12 @@ impl Island {
                 continue;
             }
             let max_text_width = (tab_width - TAB_PADDING_X * 2.0).max(0.0);
-            let title = fit_title_to_width(sugarloaf, &raw_title, max_text_width);
+            let title = fit_title_to_width(
+                sugarloaf,
+                &raw_title,
+                max_text_width,
+                self.title_font_size,
+            );
 
             let text_color = if is_active {
                 self.active_text_color
@@ -810,7 +895,7 @@ impl Island {
             };
 
             let title_opts = DrawOpts {
-                font_size: TITLE_FONT_SIZE,
+                font_size: self.title_font_size,
                 color: color_u8(text_color),
                 ..DrawOpts::default()
             };
@@ -831,7 +916,7 @@ impl Island {
                 let ui = sugarloaf.text_mut();
                 let text_width = ui.measure(&title, &title_opts);
                 let text_x = tab_x + (tab_width - text_width) / 2.0;
-                let text_y = (ISLAND_HEIGHT / 2.0) - (TITLE_FONT_SIZE / 2.);
+                let text_y = (self.geom.bar_height / 2.0) - (self.title_font_size / 2.);
                 ui.draw(text_x, text_y, &title, &title_opts);
             }
 
@@ -841,7 +926,7 @@ impl Island {
             // toward the strip — a white "active" overlay would
             // bleach custom colors to pastel on light themes, so the
             // hierarchy is carried by the mute instead.
-            let (ix, iy, iw, ih, radius) = island_rect(tab_x, tab_width);
+            let (ix, iy, iw, ih, radius) = island_rect(tab_x, tab_width, self.geom);
             let fill = match context_manager.custom_color(tab_index) {
                 Some(mut custom) => {
                     if !is_active {
@@ -876,7 +961,7 @@ impl Island {
                         sugarloaf.rounded_rect(
                             None,
                             cx - CLOSE_HOVER_HALF,
-                            ISLAND_HEIGHT / 2.0 - CLOSE_HOVER_HALF,
+                            self.geom.bar_height / 2.0 - CLOSE_HOVER_HALF,
                             CLOSE_HOVER_HALF * 2.0,
                             CLOSE_HOVER_HALF * 2.0,
                             fills.close_hover,
@@ -891,6 +976,7 @@ impl Island {
                         self.active_text_color,
                         self.close_hover,
                         2,
+                        self.geom.bar_height,
                     );
                 }
             }
@@ -901,7 +987,7 @@ impl Island {
 
         // Draw the floating (dragged) tab above the slot tabs.
         if let (Some(drag_idx), Some(floating_x)) = (drag_index, floating_left) {
-            let (ix, iy, iw, ih, radius) = island_rect(floating_x, tab_width);
+            let (ix, iy, iw, ih, radius) = island_rect(floating_x, tab_width, self.geom);
 
             // Soft elevation: a slightly inflated dark halo behind the
             // lifted island so it reads as floating over the strip.
@@ -942,22 +1028,34 @@ impl Island {
             );
 
             if let Some(cx) = close_button_center(ix, iw) {
-                draw_close_button(sugarloaf, cx, self.active_text_color, false, 12);
+                draw_close_button(
+                    sugarloaf,
+                    cx,
+                    self.active_text_color,
+                    false,
+                    12,
+                    self.geom.bar_height,
+                );
             }
 
             let raw_title = self.get_title_for_tab(context_manager, drag_idx);
             if !raw_title.is_empty() {
                 let max_text_width = (tab_width - TAB_PADDING_X * 2.0).max(0.0);
-                let title = fit_title_to_width(sugarloaf, &raw_title, max_text_width);
+                let title = fit_title_to_width(
+                    sugarloaf,
+                    &raw_title,
+                    max_text_width,
+                    self.title_font_size,
+                );
                 let title_opts = DrawOpts {
-                    font_size: TITLE_FONT_SIZE,
+                    font_size: self.title_font_size,
                     color: color_u8(self.active_text_color),
                     ..DrawOpts::default()
                 };
                 let ui = sugarloaf.text_mut();
                 let text_width = ui.measure(&title, &title_opts);
                 let text_x = floating_x + (tab_width - text_width) / 2.0;
-                let text_y = (ISLAND_HEIGHT / 2.0) - (TITLE_FONT_SIZE / 2.);
+                let text_y = (self.geom.bar_height / 2.0) - (self.title_font_size / 2.);
                 ui.draw(text_x, text_y, &title, &title_opts);
             }
         }
@@ -1092,11 +1190,16 @@ impl Island {
             left_margin,
             tab_width,
             ..
-        } = tab_strip_layout(window_width, scale_factor, num_tabs, self.max_tab_width);
+        } = tab_strip_layout(
+            window_width,
+            scale_factor,
+            num_tabs,
+            self.geom.max_tab_width,
+        );
         let tab_x = left_margin + picker_tab as f32 * tab_width;
 
         // Picker is rendered just below the island
-        let picker_y = ISLAND_HEIGHT;
+        let picker_y = self.geom.bar_height;
 
         // Check if click is within picker vertical range
         if mouse_y_unscaled < picker_y || mouse_y_unscaled > picker_y + PICKER_HEIGHT {
@@ -1157,7 +1260,7 @@ impl Island {
         selected_color: Option<[f32; 4]>,
     ) {
         let padding = PICKER_PADDING;
-        let bg_y = ISLAND_HEIGHT;
+        let bg_y = self.geom.bar_height;
 
         // Compute total swatches width to derive the consistent inner content width
         // N color swatches + 1 reset swatch
@@ -1401,6 +1504,7 @@ mod tests {
     fn island_geometry_invariants() {
         const {
             assert!(TAB_INSET_Y * 2.0 < ISLAND_HEIGHT);
+            assert!(TAB_GAP < MAX_TAB_WIDTH);
             assert!(CLOSE_MARGIN_RIGHT + CLOSE_HIT_HALF_WIDTH < CLOSE_MIN_ISLAND_WIDTH);
             assert!(CLOSE_HOVER_HALF * 2.0 <= ISLAND_HEIGHT - TAB_INSET_Y * 2.0);
         }
@@ -1410,14 +1514,14 @@ mod tests {
     fn island_rect_insets_slot_and_clamps_radius() {
         // Slot at x=100, width 180 → island inset by half the gap on
         // each side and TAB_INSET_Y vertically.
-        let (x, y, w, h, radius) = island_rect(100.0, 180.0);
+        let (x, y, w, h, radius) = island_rect(100.0, 180.0, TabGeom::default());
         assert_eq!(x, 100.0 + TAB_GAP / 2.0);
         assert_eq!(y, TAB_INSET_Y);
         assert_eq!(w, 180.0 - TAB_GAP);
         assert_eq!(h, ISLAND_HEIGHT - TAB_INSET_Y * 2.0);
         assert_eq!(radius, TAB_RADIUS);
 
-        let (_, _, w, h, radius) = island_rect(0.0, 4.0);
+        let (_, _, w, h, radius) = island_rect(0.0, 4.0, TabGeom::default());
         assert_eq!(w, 0.0);
         assert_eq!(radius, 0.0);
         assert!(radius <= h / 2.0);
@@ -1465,7 +1569,8 @@ mod tests {
         let inactive_color = [0.5, 0.5, 0.5, 1.0];
         let active_color = [0.9, 0.9, 0.9, 1.0];
 
-        let island = Island::new(inactive_color, active_color, true, 240.0);
+        let island =
+            Island::new(inactive_color, active_color, true, 12.0, TabGeom::default());
 
         assert_eq!(island.inactive_text_color, inactive_color);
         assert_eq!(island.active_text_color, active_color);
@@ -1474,13 +1579,24 @@ mod tests {
 
     #[test]
     fn test_island_height() {
-        let island =
-            Island::new([0.8, 0.8, 0.8, 1.0], [1.0, 1.0, 1.0, 1.0], false, 240.0);
+        let island = Island::new(
+            [0.8, 0.8, 0.8, 1.0],
+            [1.0, 1.0, 1.0, 1.0],
+            false,
+            12.0,
+            TabGeom::default(),
+        );
         assert_eq!(island.height(), ISLAND_HEIGHT);
     }
 
     fn test_island() -> Island {
-        Island::new([0.5, 0.5, 0.5, 1.0], [0.9, 0.9, 0.9, 1.0], false, 240.0)
+        Island::new(
+            [0.5, 0.5, 0.5, 1.0],
+            [0.9, 0.9, 0.9, 1.0],
+            false,
+            12.0,
+            TabGeom::default(),
+        )
     }
 
     #[test]
@@ -1676,7 +1792,7 @@ mod tests {
         // 1000 physical px @ 2x scale → 500 logical px window. Slots
         // stay below the cap here, so the math matches the old
         // fill-the-strip layout.
-        let layout = tab_strip_layout(1000.0, 2.0, 4, 240.0);
+        let layout = tab_strip_layout(1000.0, 2.0, 4, MAX_TAB_WIDTH);
         #[cfg(target_os = "macos")]
         {
             assert_eq!(layout.left_margin, ISLAND_MARGIN_LEFT_MACOS);
@@ -1690,27 +1806,22 @@ mod tests {
             assert_eq!(layout.tabs_width, 492.0);
         }
         // Zero tabs clamps the divisor.
-        assert!(tab_strip_layout(1000.0, 2.0, 0, 240.0)
+        assert!(tab_strip_layout(1000.0, 2.0, 0, MAX_TAB_WIDTH)
             .tab_width
             .is_finite());
     }
 
     #[test]
     fn tab_strip_layout_caps_slot_width() {
-        let layout = tab_strip_layout(3000.0, 2.0, 2, 240.0);
-        assert_eq!(layout.tab_width, 240.0);
-        assert_eq!(layout.tabs_width, 480.0);
-
-        // The cap is configurable via navigation.max-tab-width.
-        let layout = tab_strip_layout(3000.0, 2.0, 2, 280.0);
-        assert_eq!(layout.tab_width, 280.0);
-        assert_eq!(layout.tabs_width, 560.0);
+        let layout = tab_strip_layout(3000.0, 2.0, 2, MAX_TAB_WIDTH);
+        assert_eq!(layout.tab_width, MAX_TAB_WIDTH);
+        assert_eq!(layout.tabs_width, MAX_TAB_WIDTH * 2.0);
         // The tabs region ends well before the 1500 logical px strip.
         assert!(layout.left_margin + layout.tabs_width < 1500.0);
 
         // Pathologically narrow window: width clamps at 0 instead of
         // going negative.
-        let layout = tab_strip_layout(10.0, 2.0, 4, 240.0);
+        let layout = tab_strip_layout(10.0, 2.0, 4, MAX_TAB_WIDTH);
         assert_eq!(layout.tab_width, 0.0);
         assert_eq!(layout.tabs_width, 0.0);
     }
@@ -1783,7 +1894,7 @@ mod tests {
             tab_width: 180.0,
             tabs_width: 360.0,
         };
-        let cx = close_button_center_x(&layout, 1).unwrap();
+        let cx = close_button_center_x(&layout, 1, TabGeom::default()).unwrap();
         assert_eq!(
             cx,
             180.0 + TAB_GAP / 2.0 + (180.0 - TAB_GAP) - CLOSE_MARGIN_RIGHT
@@ -1798,7 +1909,7 @@ mod tests {
             tab_width: 60.0,
             tabs_width: 600.0,
         };
-        assert_eq!(close_button_center_x(&narrow, 3), None);
+        assert_eq!(close_button_center_x(&narrow, 3, TabGeom::default()), None);
     }
 
     #[test]
@@ -1812,7 +1923,7 @@ mod tests {
             tab_width: 180.0,
             tabs_width: 360.0,
         };
-        let cx = close_button_center_x(&layout, 0).unwrap();
+        let cx = close_button_center_x(&layout, 0, TabGeom::default()).unwrap();
         let title_max_right = layout.tab_width - TAB_PADDING_X;
         assert!(cx - CLOSE_HIT_HALF_WIDTH >= title_max_right);
     }

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -118,12 +118,20 @@ impl Renderer {
         }
 
         let island = if config.navigation.is_enabled() {
-            Some(island::Island::new(
-                named_colors.tabs,
-                named_colors.tabs_active,
-                config.navigation.hide_if_single,
-                config.navigation.max_tab_width,
-            ))
+            Some({
+                let mut island = island::Island::new(
+                    named_colors.tabs,
+                    named_colors.tabs_active,
+                    config.navigation.hide_if_single,
+                    config.navigation.tab_font_size,
+                    island::TabGeom::from_navigation(&config.navigation),
+                );
+                island.fill_override = (
+                    config.navigation.tab_fill,
+                    config.navigation.tab_fill_active,
+                );
+                island
+            })
         } else {
             None
         };

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -130,6 +130,9 @@ impl Renderer {
                     config.navigation.tab_fill,
                     config.navigation.tab_fill_active,
                 );
+                island.close_on_hover = config.navigation.tab_close_on_hover;
+                island.close_confirm = config.navigation.tab_close_confirm
+                    == rio_backend::config::navigation::TabCloseConfirm::DoubleClick;
                 island
             })
         } else {

--- a/frontends/rioterm/src/renderer/utils.rs
+++ b/frontends/rioterm/src/renderer/utils.rs
@@ -20,8 +20,7 @@ pub fn padding_top_from_config(
             return constants::PADDING_Y + padding_y_top;
         }
 
-        use crate::renderer::island::ISLAND_HEIGHT;
-        return ISLAND_HEIGHT + padding_y_top;
+        return navigation.tab_bar_height + padding_y_top;
     }
 
     let default_padding = constants::PADDING_Y + padding_y_top;

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -27,7 +27,7 @@ use crate::crosswords::{
 use crate::hints::HintState;
 use crate::layout::ContextDimension;
 use crate::mouse::{calculate_mouse_position, Mouse};
-use crate::renderer::island::{self, TabStripLayout, ISLAND_HEIGHT};
+use crate::renderer::island::{self, TabStripLayout};
 use crate::renderer::{utils::padding_top_from_config, Renderer};
 use crate::screen::hint::HintMatches;
 use crate::selection::{Selection, SelectionType};
@@ -455,7 +455,13 @@ impl Screen<'_> {
         self.renderer.is_window_focused = was_focused;
         if let Some(mut island) = old_island {
             island.update_colors(config.colors.tabs, config.colors.tabs_active);
-            island.max_tab_width = config.navigation.max_tab_width;
+            island.title_font_size = config.navigation.tab_font_size;
+            island.geom =
+                crate::renderer::island::TabGeom::from_navigation(&config.navigation);
+            island.fill_override = (
+                config.navigation.tab_fill,
+                config.navigation.tab_fill_active,
+            );
             self.renderer.island = Some(island);
         }
 
@@ -2686,8 +2692,8 @@ impl Screen<'_> {
             .renderer
             .island
             .as_ref()
-            .map(|island| island.max_tab_width)
-            .unwrap_or_else(rio_backend::config::navigation::default_max_tab_width);
+            .map(|island| island.geom.max_tab_width)
+            .unwrap_or_else(rio_backend::config::navigation::default_tab_max_width);
         island::tab_strip_layout(
             self.sugarloaf.window_size().width,
             self.sugarloaf.scale_factor(),
@@ -2757,11 +2763,12 @@ impl Screen<'_> {
 
         let hovering = num_tabs > 1
             && self.renderer.navigation.island_visible(num_tabs)
-            && mouse_y <= (ISLAND_HEIGHT * scale_factor) as f64
+            && mouse_y <= (self.renderer.navigation.tab_bar_height * scale_factor) as f64
             && island::close_button_hit(
                 &self.island_tab_layout(num_tabs),
                 self.context_manager.current_index(),
                 mouse_x as f32 / scale_factor,
+                island::TabGeom::from_navigation(&self.renderer.navigation),
             );
 
         self.apply_close_hover(hovering)
@@ -2788,7 +2795,8 @@ impl Screen<'_> {
         let mouse_y = self.mouse.y;
 
         let scale_factor = self.sugarloaf.scale_factor();
-        let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
+        let island_height_px =
+            (self.renderer.navigation.tab_bar_height * scale_factor) as f64;
 
         let window_width = self.sugarloaf.window_size().width;
         let num_tabs = self.context_manager.len();
@@ -2848,6 +2856,7 @@ impl Screen<'_> {
                 &layout,
                 self.context_manager.current_index(),
                 mouse_x_unscaled,
+                island::TabGeom::from_navigation(&self.renderer.navigation),
             )
         {
             return true;
@@ -2909,7 +2918,12 @@ impl Screen<'_> {
         }
 
         if clicked_tab == self.context_manager.current_index()
-            && island::close_button_hit(&layout, clicked_tab, mouse_x_unscaled)
+            && island::close_button_hit(
+                &layout,
+                clicked_tab,
+                mouse_x_unscaled,
+                island::TabGeom::from_navigation(&self.renderer.navigation),
+            )
         {
             self.stop_hint_mode_if_active();
             self.last_close_press = Some((std::time::Instant::now(), mouse_x_unscaled));

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1590,7 +1590,52 @@ impl Screen<'_> {
         }
     }
 
+    /// Misclick guard shared by the tab close entry points. Returns true
+    /// when the close may proceed; false when it was consumed (a
+    /// double-click arm was set). The `Ask` confirm mode has no overlay
+    /// in this build and behaves like `Never` (immediate close).
+    fn confirm_close_gate(&mut self, tab_index: usize) -> bool {
+        use rio_backend::config::navigation::TabCloseConfirm;
+        match self.renderer.navigation.tab_close_confirm {
+            TabCloseConfirm::Never | TabCloseConfirm::Ask => true,
+            TabCloseConfirm::DoubleClick => {
+                // With a single tab there is no visible close button to
+                // arm — invisible arming would just eat the keypress.
+                if self.context_manager.len() <= 1 {
+                    return true;
+                }
+                let confirmed = self
+                    .renderer
+                    .island
+                    .as_mut()
+                    .is_none_or(|island| island.confirm_close_click(tab_index));
+                if !confirmed {
+                    self.mark_dirty();
+                }
+                confirmed
+            }
+        }
+    }
+
+    /// Close a specific tab by index, routing through the misclick gate.
+    pub fn close_tab_at(&mut self, tab_index: usize, clipboard: &mut Clipboard) {
+        if !self.confirm_close_gate(tab_index) {
+            return;
+        }
+        if tab_index != self.context_manager.current_index() {
+            self.context_manager.select_tab(tab_index);
+        }
+        self.close_tab_confirmed(clipboard);
+    }
+
     pub fn close_tab(&mut self, clipboard: &mut Clipboard) {
+        if !self.confirm_close_gate(self.context_manager.current_index()) {
+            return;
+        }
+        self.close_tab_confirmed(clipboard);
+    }
+
+    pub fn close_tab_confirmed(&mut self, clipboard: &mut Clipboard) {
         self.clear_selection();
         self.context_manager
             .close_current_context(&mut self.sugarloaf);
@@ -2758,25 +2803,78 @@ impl Screen<'_> {
     }
 
     pub fn update_close_button_hover(&mut self, mouse_x: f64, mouse_y: f64) -> bool {
+        use rio_backend::config::navigation::TabCloseConfirm;
+        // Any pointer movement after the arm window lapsed drops the red
+        // armed button (there is no idle timer in this build; the arm is
+        // functionally dead once ARM_TIMEOUT passes, this repaints it).
+        let disarmed = self
+            .renderer
+            .island
+            .as_mut()
+            .is_some_and(|island| island.disarm_stale());
+        if disarmed {
+            self.mark_dirty();
+        }
+        let close_on_hover = self.renderer.navigation.tab_close_on_hover;
+        let double_click =
+            self.renderer.navigation.tab_close_confirm == TabCloseConfirm::DoubleClick;
+
         let num_tabs = self.context_manager.len();
         let scale_factor = self.sugarloaf.scale_factor();
 
-        let hovering = num_tabs > 1
+        let in_bar = num_tabs > 1
             && self.renderer.navigation.island_visible(num_tabs)
-            && mouse_y <= (self.renderer.navigation.tab_bar_height * scale_factor) as f64
-            && island::close_button_hit(
-                &self.island_tab_layout(num_tabs),
-                self.context_manager.current_index(),
-                mouse_x as f32 / scale_factor,
-                island::TabGeom::from_navigation(&self.renderer.navigation),
-            );
+            && mouse_y <= (self.renderer.navigation.tab_bar_height * scale_factor) as f64;
+        let layout = self.island_tab_layout(num_tabs);
+        let x_unscaled = mouse_x as f32 / scale_factor;
+        // Guard x below the first tab: the cast to usize would wrap a
+        // negative offset to tab 0 (mirrors the click path).
+        let x_in_tabs = x_unscaled - layout.left_margin;
+        let hovered_tab = (in_bar && x_in_tabs >= 0.0 && layout.tab_width > 0.0)
+            .then(|| (x_in_tabs / layout.tab_width) as usize)
+            .filter(|idx| *idx < num_tabs);
+        let hovering = hovered_tab.is_some_and(|idx| {
+            (close_on_hover || idx == self.context_manager.current_index())
+                && island::close_button_hit(
+                    &layout,
+                    idx,
+                    x_unscaled,
+                    island::TabGeom::from_navigation(&self.renderer.navigation),
+                )
+        });
 
-        self.apply_close_hover(hovering)
+        // Only the active tab shows a × unless close-on-hover is set, and
+        // only double-click confirm arms non-active tabs. When neither
+        // mode is on, restrict the tracked tab to the active one so
+        // crossing between background tabs no longer forces a repaint.
+        let tracked = if close_on_hover || double_click {
+            hovered_tab
+        } else {
+            hovered_tab.filter(|idx| *idx == self.context_manager.current_index())
+        };
+
+        let tab_changed = self
+            .renderer
+            .island
+            .as_mut()
+            .is_some_and(|island| island.set_hovered_tab(tracked));
+        if tab_changed {
+            self.mark_dirty();
+        }
+        self.apply_close_hover(hovering) || tab_changed || disarmed
     }
 
     #[inline]
     pub fn clear_close_button_hover(&mut self) -> bool {
-        self.apply_close_hover(false)
+        let tab_changed = self
+            .renderer
+            .island
+            .as_mut()
+            .is_some_and(|island| island.set_hovered_tab(None));
+        if tab_changed {
+            self.mark_dirty();
+        }
+        self.apply_close_hover(false) || tab_changed
     }
 
     pub fn handle_island_click(
@@ -2917,7 +3015,8 @@ impl Screen<'_> {
             return true;
         }
 
-        if clicked_tab == self.context_manager.current_index()
+        if (self.renderer.navigation.tab_close_on_hover
+            || clicked_tab == self.context_manager.current_index())
             && island::close_button_hit(
                 &layout,
                 clicked_tab,
@@ -2927,7 +3026,7 @@ impl Screen<'_> {
         {
             self.stop_hint_mode_if_active();
             self.last_close_press = Some((std::time::Instant::now(), mouse_x_unscaled));
-            self.close_tab(clipboard);
+            self.close_tab_at(clicked_tab, clipboard);
             return true;
         }
 

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -585,8 +585,8 @@ impl Config {
             if let Some(fill) = navigation_overwrite.unfocused_split_fill {
                 self.navigation.unfocused_split_fill = Some(fill);
             }
-            if let Some(max_tab_width) = navigation_overwrite.max_tab_width {
-                self.navigation.max_tab_width = max_tab_width;
+            if let Some(tab_max_width) = navigation_overwrite.tab_max_width {
+                self.navigation.tab_max_width = tab_max_width;
             }
         }
 
@@ -596,8 +596,7 @@ impl Config {
             crate::config::navigation::clamp_unfocused_split_opacity(
                 self.navigation.unfocused_split_opacity,
             );
-        self.navigation.max_tab_width =
-            crate::config::navigation::clamp_max_tab_width(self.navigation.max_tab_width);
+        self.navigation.clamp_tab_geometry();
 
         // Merge renderer fields individually
         if let Some(renderer_overwrite) = &platform_config.renderer {

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -8,19 +8,29 @@ pub fn default_unfocused_split_opacity() -> f32 {
 }
 
 #[inline]
-pub fn default_max_tab_width() -> f32 {
-    240.0
+pub fn default_tab_font_size() -> f32 {
+    12.0
 }
 
-/// Clamp `max_tab_width` to `[80.0, 280.0]`.
-///
-/// Below the lower bound the close button and title no longer fit.
 #[inline]
-pub fn clamp_max_tab_width(v: f32) -> f32 {
-    if !v.is_finite() {
-        return default_max_tab_width();
-    }
-    v.clamp(80.0, 280.0)
+pub fn default_tab_max_width() -> f32 {
+    180.0
+}
+
+pub fn default_tab_gap() -> f32 {
+    6.0
+}
+
+pub fn default_tab_inset_y() -> f32 {
+    7.0
+}
+
+pub fn default_tab_radius() -> f32 {
+    6.0
+}
+
+pub fn default_tab_bar_height() -> f32 {
+    38.0
 }
 
 /// Clamp `unfocused_split_opacity` to `[0.15, 1.0]`.
@@ -31,6 +41,31 @@ pub fn clamp_max_tab_width(v: f32) -> f32 {
 #[inline]
 pub fn clamp_unfocused_split_opacity(v: f32) -> f32 {
     v.clamp(0.15, 1.0)
+}
+
+/// Sanitize tab-strip geometry after load: NaN and negative or zero
+/// sizes would produce a negative island height, garbage padding, or an
+/// oversized hover circle. Fields that may legitimately be `0` (gap,
+/// inset, radius, max-width) are only floored at `0`; the two sizes that
+/// must stay positive (font size, bar height) get a small lower bound.
+impl Navigation {
+    #[inline]
+    pub fn clamp_tab_geometry(&mut self) {
+        let non_negative = |v: f32| if v.is_finite() { v.max(0.0) } else { 0.0 };
+        let positive = |v: f32, floor: f32| {
+            if v.is_finite() {
+                v.max(floor)
+            } else {
+                floor
+            }
+        };
+        self.tab_font_size = positive(self.tab_font_size, 1.0);
+        self.tab_bar_height = positive(self.tab_bar_height, 1.0);
+        self.tab_max_width = non_negative(self.tab_max_width);
+        self.tab_gap = non_negative(self.tab_gap);
+        self.tab_inset_y = non_negative(self.tab_inset_y);
+        self.tab_radius = non_negative(self.tab_radius);
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
@@ -166,11 +201,41 @@ pub struct Navigation {
         rename = "unfocused-split-fill"
     )]
     pub unfocused_split_fill: Option<ColorArray>,
-    /// Maximum width of a tab in logical pixels. Tabs shrink below
-    /// this as more open; the cap only limits how wide a tab grows
-    /// when few are open. Clamped to `[80.0, 280.0]` at load time.
-    #[serde(default = "default_max_tab_width", rename = "max-tab-width")]
-    pub max_tab_width: f32,
+    /// Font size (in logical pixels) for the tab-strip titles.
+    #[serde(default = "default_tab_font_size", rename = "tab-font-size")]
+    pub tab_font_size: f32,
+    /// Height (in logical pixels) of the tab strip / island bar.
+    #[serde(default = "default_tab_bar_height", rename = "tab-bar-height")]
+    pub tab_bar_height: f32,
+    /// Maximum width (logical px) of one tab. 0 = no cap: tabs expand
+    /// to fill the whole strip.
+    #[serde(default = "default_tab_max_width", rename = "tab-max-width")]
+    pub tab_max_width: f32,
+    /// Horizontal gap (logical px) between tab islands. 0 = tabs touch.
+    #[serde(default = "default_tab_gap", rename = "tab-gap")]
+    pub tab_gap: f32,
+    /// Vertical inset (logical px) of each island inside the strip.
+    /// 0 = tabs fill the full bar height (classic flat strip).
+    #[serde(default = "default_tab_inset_y", rename = "tab-inset-y")]
+    pub tab_inset_y: f32,
+    /// Corner radius of each tab island. 0 = square corners.
+    #[serde(default = "default_tab_radius", rename = "tab-radius")]
+    pub tab_radius: f32,
+    /// Explicit island fill for inactive tabs. When unset, fills adapt
+    /// to the window background's luminance.
+    #[serde(
+        default = "Option::default",
+        deserialize_with = "deserialize_to_arr_opt",
+        rename = "tab-fill"
+    )]
+    pub tab_fill: Option<ColorArray>,
+    /// Explicit island fill for the active tab.
+    #[serde(
+        default = "Option::default",
+        deserialize_with = "deserialize_to_arr_opt",
+        rename = "tab-fill-active"
+    )]
+    pub tab_fill_active: Option<ColorArray>,
 }
 
 impl Default for Navigation {
@@ -186,7 +251,14 @@ impl Default for Navigation {
             unfocused_split_opacity: default_unfocused_split_opacity(),
             unfocused_split_fill: None,
             open_config_with_split: true,
-            max_tab_width: default_max_tab_width(),
+            tab_font_size: default_tab_font_size(),
+            tab_bar_height: default_tab_bar_height(),
+            tab_max_width: default_tab_max_width(),
+            tab_gap: default_tab_gap(),
+            tab_inset_y: default_tab_inset_y(),
+            tab_radius: default_tab_radius(),
+            tab_fill: None,
+            tab_fill_active: None,
         }
     }
 }

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -12,6 +12,17 @@ pub fn default_tab_font_size() -> f32 {
     12.0
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, Default)]
+pub enum TabCloseConfirm {
+    #[serde(alias = "never")]
+    #[default]
+    Never,
+    #[serde(alias = "ask")]
+    Ask,
+    #[serde(alias = "double-click", alias = "doubleclick")]
+    DoubleClick,
+}
+
 #[inline]
 pub fn default_tab_max_width() -> f32 {
     180.0
@@ -221,6 +232,18 @@ pub struct Navigation {
     /// Corner radius of each tab island. 0 = square corners.
     #[serde(default = "default_tab_radius", rename = "tab-radius")]
     pub tab_radius: f32,
+    /// Show the close button and a hover highlight on the hovered tab
+    /// (Terminal.app style) and let its click close that tab; on by
+    /// default. When false the close button only exists on the active
+    /// tab and tabs don't react to hover (stock behavior).
+    #[serde(default = "default_bool_true", rename = "tab-close-on-hover")]
+    pub tab_close_on_hover: bool,
+    /// Misclick guard for the tab close button. `never` closes on a
+    /// single click; `ask` pops a y/n confirmation; `double-click`
+    /// arms the button on the first click (it turns red) and closes on
+    /// a second click within a few seconds.
+    #[serde(default, rename = "tab-close-confirm")]
+    pub tab_close_confirm: TabCloseConfirm,
     /// Explicit island fill for inactive tabs. When unset, fills adapt
     /// to the window background's luminance.
     #[serde(
@@ -257,6 +280,8 @@ impl Default for Navigation {
             tab_gap: default_tab_gap(),
             tab_inset_y: default_tab_inset_y(),
             tab_radius: default_tab_radius(),
+            tab_close_on_hover: true,
+            tab_close_confirm: TabCloseConfirm::default(),
             tab_fill: None,
             tab_fill_active: None,
         }

--- a/rio-backend/src/config/platform.rs
+++ b/rio-backend/src/config/platform.rs
@@ -101,8 +101,8 @@ pub struct PlatformNavigation {
     pub open_config_with_split: Option<bool>,
     #[serde(default = "Option::default", rename = "unfocused-split-opacity")]
     pub unfocused_split_opacity: Option<f32>,
-    #[serde(default = "Option::default", rename = "max-tab-width")]
-    pub max_tab_width: Option<f32>,
+    #[serde(default = "Option::default", rename = "tab-max-width")]
+    pub tab_max_width: Option<f32>,
     #[serde(
         default = "Option::default",
         deserialize_with = "crate::config::colors::deserialize_to_arr_opt",


### PR DESCRIPTION
feat(ui): close tab on hover with an optional double-click guard

Adds two `[navigation]` options to the rio-rendered tab strip.

## `tab-close-on-hover` (default `true`)

Shows the close button on whichever tab the pointer is over, not only
the active one, with a subtle hover highlight behind it — Terminal.app
behaviour. Set `false` to keep the close button on the active tab only.

## `tab-close-confirm` (default `never`)

A misclick guard for the close button:

- `never` — clicking × closes the tab immediately.
- `double-click` — the first click arms the button (painted red); a
  second click within a short timeout (3s) closes. Moving the pointer
  to another tab, the timeout expiring, or the tab list changing all
  disarm it.

## Implementation

The island tracks the hovered tab and an armed-close slot. Disarm
happens on pointer-move-to-another-tab, on timeout, and on tab-list
mutation (so an armed index can't point at a tab that shifted). Clicking
a non-active tab's close button routes through the same misclick gate as
the active tab.

## Config example

```toml
[navigation]
tab-close-on-hover = true
tab-close-confirm  = "double-click"
```

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p rioterm --all-features` — no new warnings
- `cargo test --features wgpu` — all suites pass (0 failed)

## Note

Stacked on the tab-strip configurability PR (#1750) — it builds on that
PR's `TabGeom` / island plumbing. Reviewing #1750 first is easiest; this
branch is based on top of it.
