### PR TITLE
fix(config): keep the live config when a hot-reload fails to parse

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -520,10 +520,24 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::UpdateConfig) => {
-                let (config, config_error) = match rio_backend::config::Config::try_load()
-                {
-                    Ok(config) => (config, None),
-                    Err(error) => (rio_backend::config::Config::default(), Some(error)),
+                // A config.toml typo saved mid-edit must not reset the
+                // live config (fonts, colors, bindings) to defaults: keep
+                // running on the current one, surface the error, and pick
+                // up the next successful save. Startup differs — there is
+                // nothing live to keep, so main's load still falls back to
+                // defaults.
+                let config = match rio_backend::config::Config::try_load() {
+                    Ok(config) => config,
+                    Err(error) => {
+                        tracing::warn!(
+                            "config.toml failed to parse; keeping the previous config"
+                        );
+                        for (_id, route) in self.router.routes.iter_mut() {
+                            route.report_error(&error.to_owned().into());
+                            route.request_redraw();
+                        }
+                        return;
+                    }
                 };
 
                 let has_font_updates = self.config.fonts != config.fonts;
@@ -580,11 +594,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     );
                     route.window.configure_window(&self.config);
 
-                    if let Some(error) = &config_error {
-                        route.report_error(&error.to_owned().into());
-                    } else {
-                        route.clear_errors();
-                    }
+                    // The reload parsed: drop any error screen left from a
+                    // previously broken save.
+                    route.clear_errors();
 
                     route.request_redraw();
                 }


### PR DESCRIPTION
fix(config): keep the live config when a hot-reload fails to parse

## Problem

The `UpdateConfig` (hot-reload) handler did:

```rust
let (config, config_error) = match Config::try_load() {
    Ok(config) => (config, None),
    Err(error) => (Config::default(), Some(error)),   // <- substitutes defaults
};
...
self.config = config;   // applied, defaults and all
```

So when a `config.toml` typo is saved mid-edit, the live config is
**replaced with `Config::default()`** — fonts, colors, and key bindings
all snap back to defaults until the file parses cleanly again. The error
screen does show, but it renders over a terminal that has lost the
user's whole configuration.

## Fix

On a failed reload, keep running on the current config: report the parse
error to every window, request a redraw, and skip the reconfiguration
entirely. The next successful save applies normally and clears the error
screen.

Startup is intentionally unchanged — at initial load there is nothing
live to preserve, so a broken `config.toml` still falls back to defaults
there.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p rioterm --all-features` — no new warnings
- `cargo test --features wgpu` — all suites pass (0 failed)

Single-file change to the `UpdateConfig` handler; no config schema or
API changes.
