### PR TITLE
fix(sugarloaf): draw all image layers in one Vulkan instance-buffer pass

### DIFF
--- a/sugarloaf/src/renderer/mod.rs
+++ b/sugarloaf/src/renderer/mod.rs
@@ -2486,23 +2486,25 @@ impl Renderer {
         // texture lookup needs an immutable borrow on
         // `self.image_textures` which would conflict with the
         // brush's `&mut self`.
-        let below: Vec<(ash::vk::DescriptorSet, ImageInstance)> = self
+        // Collect both image layers into a SINGLE list, BelowText first
+        // then AboveText. `render_image_overlays` writes every instance
+        // from offset 0 of one shared per-slot instance buffer, so two
+        // separate calls in one frame clobber each other — the second
+        // call's write lands before the GPU executes the first call's
+        // draw, so only the last-submitted layer renders and the other
+        // draws blank (a kitty image and a sixel on screen together, or
+        // one then the other, each hid the earlier one). One call keeps
+        // every instance at its own offset; painter order is list order,
+        // so BelowText still draws under AboveText.
+        let ordered: Vec<(ash::vk::DescriptorSet, ImageInstance)> = self
             .image_draws
             .iter()
             .filter(|d| d.layer == ImageLayer::BelowText)
-            .filter_map(|d| {
-                let entry = self.image_textures.get(&d.image_id)?;
-                if let ImageTexture::Vulkan(tex) = &entry.gpu {
-                    Some((tex.descriptor_set, d.instance))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        let above: Vec<(ash::vk::DescriptorSet, ImageInstance)> = self
-            .image_draws
-            .iter()
-            .filter(|d| d.layer == ImageLayer::AboveText)
+            .chain(
+                self.image_draws
+                    .iter()
+                    .filter(|d| d.layer == ImageLayer::AboveText),
+            )
             .filter_map(|d| {
                 let entry = self.image_textures.get(&d.image_id)?;
                 if let ImageTexture::Vulkan(tex) = &entry.gpu {
@@ -2525,10 +2527,9 @@ impl Renderer {
                 }
             }
 
-            brush.render_image_overlays(cmd, slot, viewport, &below);
+            brush.render_image_overlays(cmd, slot, viewport, &ordered);
             brush.render_quads(cmd, slot, viewport, &self.instances);
             brush.render_geometry(cmd, slot, viewport, &self.vertices);
-            brush.render_image_overlays(cmd, slot, viewport, &above);
             brush.draw_bootstrap(cmd);
         }
     }


### PR DESCRIPTION
Fixes #1761

## Problem

On the native Vulkan backend, showing two image layers at once (a kitty
image + a sixel/iTerm2 image, or a BelowText + an AboveText placement)
renders only one of them — whichever is drawn last. The other goes
blank. See the linked issue for full analysis and repro.

## Root cause

`render_vulkan` calls `render_image_overlays` twice per frame (once for
the `below` layer, once for `above`), but that function writes every
instance from offset 0 of one shared per-slot instance buffer. Vulkan
draws execute at submit time, so the second call's buffer write clobbers
the first call's instance data before the GPU runs the first draw —
only the last-submitted layer survives.

## Fix

Collect both layers into a single list (BelowText first, then
AboveText) and issue **one** `render_image_overlays` call. Every
instance keeps its own offset in the buffer, so nothing is overwritten,
and painter order (list order) preserves BelowText-under-AboveText
layering. This mirrors how the wgpu path already shares one instance
write across its two layer passes.

One file, one function (`Renderer::render_vulkan`), +17/-16.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p rioterm --all-features` — no new warnings
- `cargo build --features wgpu` — clean
- Verified on native Vulkan (Linux): kitty→sixel, sixel→kitty, and both
  on screen together all render correctly now; previously the earlier
  one was blank.
