### PR TITLE
windows: sideload modern conpty for image support + resize quirk

### DIFF
--- a/teletypewriter/src/windows/conpty.rs
+++ b/teletypewriter/src/windows/conpty.rs
@@ -11,8 +11,10 @@ use windows_sys::Win32::Foundation::{HANDLE, S_OK};
 use windows_sys::Win32::System::Console::{
     ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole, COORD, HPCON,
 };
-use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
-use windows_sys::{s, w};
+use windows_sys::Win32::System::LibraryLoader::{
+    GetModuleFileNameW, GetProcAddress, LoadLibraryExW, LOAD_WITH_ALTERED_SEARCH_PATH,
+};
+use windows_sys::s;
 
 use windows_sys::Win32::System::Threading::{
     CreateProcessW, InitializeProcThreadAttributeList, UpdateProcThreadAttribute,
@@ -43,10 +45,11 @@ use crate::windows::{cmdline, win32_string, Pty};
 /// Both are redistributable (MIT) via the `Microsoft.Windows.Console.ConPTY`
 /// NuGet package.
 ///
-/// Loaded by name via the default search order, which resolves the
-/// executable's own directory first (SafeDllSearchMode excludes the working
-/// directory), so a co-located `conpty.dll` is preferred over any in-box
-/// one.
+/// Loaded by absolute path from `rio.exe`'s own directory, never by the
+/// default search order: a bare-name load also walks the working directory
+/// and `PATH`, so a stray or hostile `conpty.dll` there could be preloaded.
+/// Resolving the path ourselves keeps the choice deterministic — the DLL we
+/// bundled next to `rio.exe`, or the in-box API, and nothing else.
 /// `PSEUDOCONSOLE_RESIZE_QUIRK`, an internal ConPTY flag (not in the public
 /// SDK header, so not exported by `windows-sys`; defined here). Without it,
 /// on resize ConPTY re-emits its reflowed buffer sized to the buffer's own
@@ -88,12 +91,34 @@ impl ConptyApi {
         }
     }
 
-    /// Try loading ConptyApi from a sideloaded `conpty.dll`: load by name
-    /// and let the loader prefer a co-located DLL over the in-box one.
+    /// Try loading ConptyApi from a `conpty.dll` sitting next to `rio.exe`,
+    /// resolved by absolute path so PATH / working-directory copies are never
+    /// picked up.
     fn load_conpty() -> Option<Self> {
         type LoadedFn = unsafe extern "system" fn() -> isize;
         unsafe {
-            let hmodule = LoadLibraryW(w!("conpty.dll"));
+            // Path to `rio.exe`, then swap its file name for `conpty.dll`.
+            let mut buf = [0u16; 4096];
+            let len =
+                GetModuleFileNameW(ptr::null_mut(), buf.as_mut_ptr(), buf.len() as u32);
+            // 0 on failure; == buf.len() means the path was truncated.
+            if len == 0 || len as usize >= buf.len() {
+                return None;
+            }
+            let dir_end = buf[..len as usize]
+                .iter()
+                .rposition(|&c| c == b'\\' as u16)?;
+            let mut dll_path: Vec<u16> = buf[..=dir_end].to_vec();
+            dll_path.extend("conpty.dll".encode_utf16());
+            dll_path.push(0);
+
+            // Absolute path + ALTERED_SEARCH_PATH also roots conpty.dll's own
+            // dependency lookup at its (the exe's) directory.
+            let hmodule = LoadLibraryExW(
+                dll_path.as_ptr(),
+                ptr::null_mut(),
+                LOAD_WITH_ALTERED_SEARCH_PATH,
+            );
             if hmodule.is_null() {
                 return None;
             }

--- a/teletypewriter/src/windows/conpty.rs
+++ b/teletypewriter/src/windows/conpty.rs
@@ -24,15 +24,29 @@ use windows_sys::Win32::System::Threading::{
 use crate::windows::child::ChildExitWatcher;
 use crate::windows::{cmdline, win32_string, Pty};
 
-/// Load the pseudoconsole API from conpty.dll if possible, otherwise use the
-/// standard Windows API.
+/// Load the pseudoconsole API from a sideloaded `conpty.dll` if one sits
+/// next to `rio.exe`, otherwise fall back to the in-box Windows API.
 ///
-/// The conpty.dll from the Windows Terminal project
-/// supports loading OpenConsole.exe, which offers many improvements and
-/// bugfixes compared to the standard conpty that ships with Windows.
+/// A modern `conpty.dll` from the Windows Terminal project (ConPTY 1.22+)
+/// does synchronous VT passthrough: the child's output — including sixel
+/// (DCS), iTerm2 (OSC 1337), and kitty graphics (APC) escape sequences —
+/// reaches Rio unmodified, so image protocols work. The in-box ConPTY
+/// that ships with most Windows builds is older and rewrites/strips those
+/// sequences, which is why terminal graphics are broken on stock Windows
+/// (issues #729, #1759).
 ///
-/// The conpty.dll and OpenConsole.exe files will be searched in PATH and in
-/// the directory where Rio's executable is located.
+/// `conpty.dll` locates its console host (`OpenConsole.exe`) in **its own
+/// directory**; without a matching `OpenConsole.exe` it silently reverts
+/// to the in-box `conhost.exe` and the passthrough benefit is lost. So the
+/// two files must be deployed together next to `rio.exe`, architecture
+/// matched (`conpty.dll` = app arch, `OpenConsole.exe` = system arch).
+/// Both are redistributable (MIT) via the `Microsoft.Windows.Console.ConPTY`
+/// NuGet package. This is the same mechanism WezTerm uses.
+///
+/// Loaded by name via the default search order, which resolves the
+/// executable's own directory first (SafeDllSearchMode excludes the working
+/// directory), so a co-located `conpty.dll` is preferred over any in-box
+/// one.
 type CreatePseudoConsoleFn =
     unsafe extern "system" fn(COORD, HANDLE, HANDLE, u32, *mut HPCON) -> HRESULT;
 type ResizePseudoConsoleFn = unsafe extern "system" fn(HPCON, COORD) -> HRESULT;
@@ -63,7 +77,8 @@ impl ConptyApi {
         }
     }
 
-    /// Try loading ConptyApi from conpty.dll library.
+    /// Try loading ConptyApi from a sideloaded `conpty.dll`. Same as
+    /// WezTerm: load by name and let the loader prefer a co-located DLL.
     fn load_conpty() -> Option<Self> {
         type LoadedFn = unsafe extern "system" fn() -> isize;
         unsafe {

--- a/teletypewriter/src/windows/conpty.rs
+++ b/teletypewriter/src/windows/conpty.rs
@@ -28,8 +28,8 @@ use crate::windows::{cmdline, win32_string, Pty};
 /// next to `rio.exe`, otherwise fall back to the in-box Windows API.
 ///
 /// A modern `conpty.dll` from the Windows Terminal project (ConPTY 1.22+)
-/// does synchronous VT passthrough: the child's output — including sixel
-/// (DCS), iTerm2 (OSC 1337), and kitty graphics (APC) escape sequences —
+/// does synchronous VT passthrough: the child's output, including sixel
+/// (DCS), iTerm2 (OSC 1337), and kitty graphics (APC) escape sequences,
 /// reaches Rio unmodified, so image protocols work. The in-box ConPTY
 /// that ships with most Windows builds is older and rewrites/strips those
 /// sequences, which is why terminal graphics are broken on stock Windows
@@ -41,12 +41,23 @@ use crate::windows::{cmdline, win32_string, Pty};
 /// two files must be deployed together next to `rio.exe`, architecture
 /// matched (`conpty.dll` = app arch, `OpenConsole.exe` = system arch).
 /// Both are redistributable (MIT) via the `Microsoft.Windows.Console.ConPTY`
-/// NuGet package. This is the same mechanism WezTerm uses.
+/// NuGet package.
 ///
 /// Loaded by name via the default search order, which resolves the
 /// executable's own directory first (SafeDllSearchMode excludes the working
 /// directory), so a co-located `conpty.dll` is preferred over any in-box
 /// one.
+/// `PSEUDOCONSOLE_RESIZE_QUIRK`, an internal ConPTY flag (not in the public
+/// SDK header, so not exported by `windows-sys`; defined here). Without it,
+/// on resize ConPTY re-emits its reflowed buffer sized to the buffer's own
+/// line count and overwrites what is on screen, so after the window grows
+/// the child's content stays confined to a stale sub-region
+/// (microsoft/terminal#16911; rio#1759). With it, ConPTY skips that repaint
+/// and defers reflow to the terminal, which owns its grid. Honored by both
+/// the in-box and the sideloaded 1.22+ ConPTY; being folded into the
+/// default upstream, so it is a no-op on the newest hosts.
+const PSEUDOCONSOLE_RESIZE_QUIRK: u32 = 0x2;
+
 type CreatePseudoConsoleFn =
     unsafe extern "system" fn(COORD, HANDLE, HANDLE, u32, *mut HPCON) -> HRESULT;
 type ResizePseudoConsoleFn = unsafe extern "system" fn(HPCON, COORD) -> HRESULT;
@@ -77,8 +88,8 @@ impl ConptyApi {
         }
     }
 
-    /// Try loading ConptyApi from a sideloaded `conpty.dll`. Same as
-    /// WezTerm: load by name and let the loader prefer a co-located DLL.
+    /// Try loading ConptyApi from a sideloaded `conpty.dll`: load by name
+    /// and let the loader prefer a co-located DLL over the in-box one.
     fn load_conpty() -> Option<Self> {
         type LoadedFn = unsafe extern "system" fn() -> isize;
         unsafe {
@@ -141,13 +152,16 @@ pub fn new(
         ws_ypixel: 0 as libc::c_ushort,
     };
 
-    // Create the Pseudo Console, using the pipes.
+    // Create the Pseudo Console, using the pipes. RESIZE_QUIRK makes
+    // ConPTY defer resize repaints to Rio (which lays out its own grid),
+    // avoiding the content-confined-to-a-stale-region artifact after the
+    // window grows (pronounced with the sideloaded 1.22+ ConPTY, #1759).
     let result = unsafe {
         (api.create)(
             winsize.into(),
             conin_pty_handle.into_raw_handle() as HANDLE,
             conout_pty_handle.into_raw_handle() as HANDLE,
-            0,
+            PSEUDOCONSOLE_RESIZE_QUIRK,
             &mut pty_handle as *mut _,
         )
     };


### PR DESCRIPTION
Terminal image protocols are broken on Windows (Yazi previews render incorrectly — [#1759](https://github.com/raphamorim/rio/issues/1759); Sixel — [#729](https://github.com/raphamorim/rio/issues/729)). This is **not** the geometry bug fixed in #1736: the Windows symptom is missing images plus grid/text corruption, which is the ConPTY-passthrough gap.

The in-box ConPTY on most Windows builds is older than 1.22 and rewrites/strips the escape sequences image protocols use (DCS sixel, OSC 1337 iTerm2, APC kitty graphics), and mangles the multi-codepoint grapheme cells Yazi's kitty unicode-placeholder mode relies on. A modern ConPTY (1.22+, [Windows Terminal PR #17510](https://github.com/microsoft/terminal/pull/17510)) does synchronous VT passthrough so those sequences reach Rio unmodified. There is no "passthrough" flag; passthrough is automatic in 1.22+. The mechanism (WezTerm's) is deploying a newer `conpty.dll` + `OpenConsole.exe` next to the executable — **confirmed by a Windows tester in #1759 to fix image rendering.**

The alt-screen-restore and resize-repaint behavior depends on the sideloaded ConPTY build. Early `1.22.2502.x` builds regressed both (microsoft/terminal #17817 alt-restore, #17643/#15976 buffer sync); WezTerm hit the identical bugs and fixed them by bumping to **1.24.2604.02001** ([wezterm#7774](https://github.com/wezterm/wezterm/issues/7774)). So the bundled pair must be **>= 1.24.2604.02001**.

to test

1. Download [`Microsoft.Windows.Console.ConPTY`](https://www.nuget.org/packages/Microsoft.Windows.Console.ConPTY) (a `.nupkg` is a zip; 1.24.2604.02001 is the build WezTerm ships).
2. Copy `runtimes/win-x64/native/conpty.dll` + `build/native/runtimes/x64/OpenConsole.exe` next to `rio.exe` (arm64 files on arm64).
3. Run a build of this branch; verify (a) Yazi image previews render, and (b) **resizing the window keeps content filling the whole grid** (the fix this adds).

If both hold, the follow-up is to bundle these two MIT-licensed files in the installer + portable zip, like WezTerm's `assets/windows/conhost/`.

Refs #1759, #729.


