### PR TITLE
feat(wayland): enable the adwaita CSD frame so window titles render

### DIFF
--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -103,6 +103,11 @@ wayland = [
     "rio-backend/wayland",
     "rio-window/wayland",
     "rio-window/wayland-dlopen",
+    # Compositors that implement no zxdg_decoration_manager_v1 (GNOME/Mutter,
+    # among others) leave decorations entirely to the client. Without this,
+    # rio falls back to rio-window's plain frame, which draws the buttons but
+    # no title text at all.
+    "rio-window/wayland-csd-adwaita",
 ]
 wgpu = ["sugarloaf/wgpu", "rio-backend/wgpu"]
 


### PR DESCRIPTION
Compositors that implement no `zxdg_decoration_manager_v1` — GNOME/Mutter among them — leave
decorations entirely to the client. `rio-window` carries an sctk-adwaita frame behind the
`wayland-csd-adwaita` feature, and that feature *is* in `rio-window`'s own `default` list, but
the workspace declares `rio-window = { …, default-features = false }` and `rioterm`'s `wayland`
feature never re-enabled it:

```
$ cargo tree -p rioterm -i sctk-adwaita
error: package ID specification `sctk-adwaita` did not match any packages
```

So on those sessions rio falls back to `rio-window`'s plain frame, which draws the window
buttons and **no title text at all**.

## Change

Five lines in `frontends/rioterm/Cargo.toml` adding `rio-window/wayland-csd-adwaita` to the
`wayland` feature. `Cargo.lock` needs no change — the optional dependencies were already
resolved in it.

## Result

Title set to `😀 世界 ✓ café Ω`, captured on a headless Mutter virtual monitor (no
`zxdg_decoration_manager_v1`, so the client decorates itself — same path as a GNOME session):

| build | title bar |
|---|---|
| `main` today | buttons only, no title text |
| with this PR | `ENABLED ▯ ▯▯ ✓ café Ω` — title renders |

<img width="1678" height="300" alt="main today: title bar is blank; with this PR: the title renders" src="https://github.com/user-attachments/assets/4f6c8ba1-18d1-46cb-9ac5-e0e17ac5bbc3" />

## Cost

| | this PR alone | if #1634 also lands |
|---|---|---|
| transitive crates added | 6 — `sctk-adwaita`, `ab_glyph`, `ab_glyph_rasterizer`, `owned_ttf_parser`, `tiny-skia`, `tiny-skia-path` | 17 — adds `cosmic-text`, `harfrust`, `skrifa`, `fontdb`, `read-fonts` and friends |
| debug binary | +2.8 MiB (+2.3%) | +12.7 MiB (+10.2%) |

Flagging that deliberately: the cost roughly quadruples once #1634 switches the renderer from
`ab_glyph` to `cosmic-text`. If that tradeoff isn't wanted, `wayland-csd-adwaita-notitle` is
the cheaper middle ground, though it gives up the title text this PR is about.

## Relationship to #1634 and #1622

Neither PR resolves #1622 on its own, and they are independent — either can merge first:

- **This PR** enables the renderer, but `ab_glyph` draws from a single font face with no
  fallback, so emoji and CJK still come out as `.notdef` boxes (visible in the table above).
- **#1634** bumps `sctk-adwaita` to 0.11.1 and switches the feature to the `cosmic-text`
  renderer, which shapes and falls back — but nothing enables that feature, so on `main` it
  changes nothing for the rio binary.

Together they make window titles render with correct glyph fallback.



