### PR TITLE
chore(event): drop the dead RioEvent::Exit variant

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -589,7 +589,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     route.request_redraw();
                 }
             }
-            RioEventType::Rio(RioEvent::Exit | RioEvent::Quit) => {
+            RioEventType::Rio(RioEvent::Quit) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     if self.config.confirm_before_quit {
                         route.confirm_quit();

--- a/rio-backend/src/event/mod.rs
+++ b/rio-backend/src/event/mod.rs
@@ -198,9 +198,6 @@ pub enum RioEvent {
         body: String,
     },
 
-    /// Shutdown request.
-    Exit,
-
     /// Quit request.
     Quit,
 
@@ -280,7 +277,6 @@ impl Debug for RioEvent {
             RioEvent::DesktopNotification { title, body } => {
                 write!(f, "DesktopNotification({title}, {body})")
             }
-            RioEvent::Exit => write!(f, "Exit"),
             RioEvent::Quit => write!(f, "Quit"),
             RioEvent::CloseTerminal(route) => write!(f, "CloseTerminal {route}"),
             RioEvent::CreateWindow => write!(f, "CreateWindow"),


### PR DESCRIPTION
The tiny follow-up suggested in #1614.

`RioEvent::Exit` has had no producer since 89c5744eff made `application.rs` handle
`Exit | Quit` in one arm. Only `Quit` is ever sent, from `ContextManager::quit`
(`context/mod.rs:690`), so the `Exit` half of that pattern is unreachable.

Repo-wide, the variant had exactly three references — its declaration, its `Debug` arm,
and that match arm. No glob `use RioEvent::*` import could hide a constructor either
(there are none). Every other `Exit` token in the tree belongs to `rio-window`'s unrelated
`NamedKey::Exit` / `PumpStatus::Exit` / `State::Exit`.

+1 / -5 across two files.

## Note on semver

`RioEvent` is `pub` in `rio-backend`, which is published to crates.io, and the enum isn't
`#[non_exhaustive]` — so dropping a variant is technically breaking for an external
consumer that matched on it exhaustively. Given `rio-backend` exists to serve rio itself
and the variant was never constructible from outside, I don't expect that to matter, but
it's your call whether it wants a version bump.

Verified: `cargo build -p rioterm` clean, 616 rio-backend and 168 rioterm tests pass,
rustfmt clean.
