### PR TITLE
fix(wayland): handle the wl_keyboard v10 `repeated` key state instead of aborting

### DIFF
--- a/rio-window/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
+++ b/rio-window/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
@@ -58,7 +58,7 @@ impl Dispatch<WlKeyboard, KeyboardData, WinitState> for WinitState {
                         let context = &mut keyboard_state.xkb_context;
                         context.set_keymap_from_fd(fd, size as usize);
                     }
-                    _ => unreachable!(),
+                    format => warn!("unhandled keymap format {format:?}"),
                 },
                 WEnum::Unknown(value) => {
                     warn!("unknown keymap format 0x{:x}", value)
@@ -251,6 +251,23 @@ impl Dispatch<WlKeyboard, KeyboardData, WinitState> for WinitState {
                     }
                 }
             }
+            // Since wl_keyboard v10 the compositor may drive key repeat itself. It only
+            // does so after disabling client side repeat with `repeat_info { rate: 0 }`,
+            // so there's no timer to keep in sync here.
+            WlKeyboardEvent::Key {
+                key,
+                state: WEnum::Value(WlKeyState::Repeated),
+                ..
+            } => {
+                key_input(
+                    keyboard_state,
+                    &mut state.events_sink,
+                    data,
+                    key + 8,
+                    ElementState::Pressed,
+                    true,
+                );
+            }
             WlKeyboardEvent::Modifiers {
                 mods_depressed,
                 mods_latched,
@@ -302,7 +319,7 @@ impl Dispatch<WlKeyboard, KeyboardData, WinitState> for WinitState {
                     RepeatInfo::Repeat { gap, delay }
                 };
             }
-            _ => unreachable!(),
+            event => warn!("Unhandled keyboard event {event:?}"),
         }
     }
 }


### PR DESCRIPTION
## Problem

`wl_keyboard` v10 lets the compositor take over key repeat. It signals this by sending `repeat_info { rate: 0 }` (disabling client-side repeat), then delivers held keys as `key { state: repeated }` — a third `key_state` value added in that version.

The Wayland keyboard dispatch matches only `Pressed` and `Released`:

```rust
WlKeyboardEvent::Key { key, state: WEnum::Value(WlKeyState::Pressed), .. } => { ... }
WlKeyboardEvent::Key { key, state: WEnum::Value(WlKeyState::Released), .. } => { ... }
...
_ => unreachable!(),
```

so anything else aborts the process. That arm is reachable from compositor-supplied data in two ways — the new `Repeated` state, and any `WEnum::Unknown` state — which makes it a panic on untrusted input rather than an invariant.

## Impact

`main` is not affected today: sctk 0.19 caps the `wl_seat` bind at v7, so no compositor will send `repeated`. It becomes a hard crash the moment `rio-window` moves to sctk 0.20, which binds `wl_seat` up to v10.

I hit it on a fork carrying that bump, on mutter 50.3 (advertises `wl_seat` v10). Holding any key killed the terminal:

```
thread 'main' panicked at rio-window/src/platform_impl/linux/wayland/seat/keyboard/mod.rs:305:18:
internal error: entered unreachable code
```

## Fix

- Handle `WlKeyState::Repeated` as a repeat key press. No repeat-timer bookkeeping is needed: per the protocol the compositor only sends it after `repeat_info { rate: 0 }`, so client-side repeat is already disabled and the two paths are mutually exclusive.
- Downgrade the remaining catch-all — and its twin on the keymap format — from `unreachable!()` to `warn!`, so unknown protocol values degrade instead of aborting.

## Verification

Rebuilt with the sctk 0.20 bump on mutter 50.3 and held a key via `ydotool` with `WAYLAND_DEBUG=1`:

```
--- key events (key, state) ---
      2 105 1)
    104 105 2)
RESULT: ALIVE
--- panics: 0 ---
```

104 `state: repeated` events delivered, key repeat works, process survives. Before the change the first one aborted. Also `cargo check -p rio-window` on this branch's base (sctk 0.19) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)