### PR TITLE
fix(x11): redraw windows after mapping

### DIFF
--- a/rio-window/src/platform_impl/linux/x11/event_processor.rs
+++ b/rio-window/src/platform_impl/linux/x11/event_processor.rs
@@ -856,6 +856,15 @@ impl EventProcessor {
         };
 
         callback(&self.target, event);
+        // Compositors can restore a mapped window without sending Expose, so
+        // event-driven renderers must explicitly present its retained contents.
+        callback(
+            &self.target,
+            Event::WindowEvent {
+                window_id,
+                event: WindowEvent::RedrawRequested,
+            },
+        );
 
         // Window is mapped → flip the mapped bit and (re)evaluate
         // the per-window vsync timer. We DON'T touch the obscured


### PR DESCRIPTION
## Summary

- request a redraw whenever an X11 window is mapped
- restore event-driven rendering immediately after i3/XMonad workspace switches
- keep the existing redraw coalescing behavior when an `Expose` event follows

## Root cause

Tiling window managers such as i3 hide workspace windows with `UnmapWindow` and map
them again when the workspace becomes visible. A compositor can retain the old
window pixels while doing this, so X11 does not necessarily send an `Expose` event
after the map.

Rio already re-emits the current focus state from `MapNotify`, which marks the
terminal contents dirty. However, when that focus state has not changed, no redraw
is requested and the event-based renderer does not present another frame until
keyboard or mouse input produces one.

Queueing `RedrawRequested` immediately after the mapped window's focus event makes
the dirty frame present without switching to the continuously-rendering `Game`
strategy. If X11 also sends `Expose`, the existing redraw queue deduplicates both
requests for the same window.

Closes #1604.

## Validation

- `cargo fmt -- --check --color always`
- `cargo test -p rio-window` (17 tests and 18 doc tests passed; 4 doc tests ignored)
- `cargo check -p rioterm --no-default-features --features x11`
