### PR TITLE
Add option to extend edge cell backgrounds into padding

### DIFF
--- a/extra/man/rio.5.scd
+++ b/extra/man/rio.5.scd
@@ -42,6 +42,18 @@ On Windows, the config file will be looked for in:
 
 	Default: _false_
 
+*padding-color* = _"Background"_ | _"Extend"_
+
+	Determines how pixels outside the terminal grid are colored.
+
+	*Background*
+		Fill padding with Rio's primary background color.
+	*Extend*
+		Extend the nearest grid cell's background color into the padding.
+		This is applied only when the window contains a single panel.
+
+	Default: _"Background"_
+
 *env-vars* = [_"<string>"_,]
 
 	Environment variables to set for spawned processes.

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -225,9 +225,9 @@ impl Application<'_> {
             }
             #[cfg(not(target_os = "macos"))]
             {
-                let _ = window.request_inner_size(
-                    rio_window::dpi::PhysicalSize::new(width, height),
-                );
+                let _ = window.request_inner_size(rio_window::dpi::PhysicalSize::new(
+                    width, height,
+                ));
                 window.set_outer_position(rio_window::dpi::PhysicalPosition::new(
                     x, mpos.y,
                 ));

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -37,6 +37,7 @@ use rio_backend::clipboard::Clipboard;
 use rio_backend::clipboard::ClipboardType;
 use rio_backend::config::layout::Margin;
 use rio_backend::config::renderer::Backend;
+use rio_backend::config::PaddingColor;
 use rio_backend::crosswords::pos::{Boundary, CursorState, Direction, Line};
 use rio_backend::crosswords::search::RegexSearch;
 use rio_backend::error::{RioError, RioErrorLevel, RioErrorType};
@@ -75,6 +76,7 @@ pub struct Screen<'screen> {
     pub context_manager: context::ContextManager<EventProxy>,
     last_ime_cursor_pos: Option<(f32, f32)>,
     hints_config: Vec<std::rc::Rc<rio_backend::config::hints::Hint>>,
+    padding_color: PaddingColor,
     pub resize_state: Option<crate::layout::ResizeState>,
     #[cfg(target_os = "macos")]
     pub allow_manual_dragging: bool,
@@ -303,6 +305,7 @@ impl Screen<'_> {
                 .iter()
                 .map(|h| std::rc::Rc::new(h.clone()))
                 .collect(),
+            padding_color: config.padding_color,
             mouse_bindings: crate::bindings::default_mouse_bindings(),
             modifiers: Modifiers::default(),
             context_manager,
@@ -419,6 +422,7 @@ impl Screen<'_> {
         font_library: &rio_backend::sugarloaf::font::FontLibrary,
         should_update_font_library: bool,
     ) {
+        self.padding_color = config.padding_color;
         let num_tabs = self.ctx().len();
         let padding_y_top = padding_top_from_config(
             &config.navigation,
@@ -4042,6 +4046,8 @@ impl Screen<'_> {
             }
 
             // --- ensure every panel has a matching GridRenderer ---
+            let extend_single_panel_edges =
+                self.padding_color == PaddingColor::Extend && panels.len() == 1;
             for p in &panels {
                 self.ensure_grid(p.route_id, p.cols, p.rows);
             }
@@ -4349,12 +4355,10 @@ impl Screen<'_> {
                     // grid_padding = (top, right, bottom, left). The
                     // bg shader only reads `.w` (left) + `.x` (top)
                     // to anchor the grid, so right/bottom can stay
-                    // 0. padding_extend is 0 too — each panel's
-                    // grid must stay bounded to its own rect so
-                    // sibling panels / the window margin aren't
-                    // painted by this grid. The full-window bg fill
-                    // (re-enabled in sugarloaf's render_metal) now
-                    // handles the space outside all panels.
+                    // 0. A single panel extends its edge-cell backgrounds
+                    // through the otherwise unused window margin. Multiple
+                    // panels remain bounded so they cannot paint over their
+                    // siblings.
                     grid_padding: [panel_top, 0.0, 0.0, panel_left],
                     cursor_color: cursor_col_u,
                     cursor_bg_color: cursor_bg_u,
@@ -4364,7 +4368,14 @@ impl Screen<'_> {
                     _pad_cursor: [0; 2],
                     min_contrast: 0.0,
                     flags: 0,
-                    padding_extend: 0,
+                    padding_extend: if extend_single_panel_edges {
+                        rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_LEFT
+                            | rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_RIGHT
+                            | rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_UP
+                            | rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_DOWN
+                    } else {
+                        0
+                    },
                     input_colorspace,
                 };
 

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -79,6 +79,18 @@ impl Default for Developer {
     }
 }
 
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PaddingColor {
+    /// Fill the padding with Rio's primary background color.
+    #[default]
+    #[serde(alias = "background")]
+    Background,
+
+    /// Extend the nearest grid cell's background color into the padding.
+    #[serde(alias = "extend")]
+    Extend,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Config {
     #[serde(default)]
@@ -101,6 +113,8 @@ pub struct Config {
     pub working_dir: Option<String>,
     #[serde(rename = "line-height", default = "default_line_height")]
     pub line_height: f32,
+    #[serde(rename = "padding-color", default)]
+    pub padding_color: PaddingColor,
     #[serde(default = "String::default")]
     pub theme: String,
     #[serde(default = "Scroll::default")]
@@ -647,6 +661,7 @@ impl Default for Config {
             #[cfg(feature = "renderer")]
             fonts: SugarloafFonts::default(),
             line_height: default_line_height(),
+            padding_color: PaddingColor::default(),
             navigation: Navigation::default(),
             option_as_alt: default_option_as_alt(),
             margin: default_margin(),
@@ -738,6 +753,7 @@ mod tests {
 
         assert_eq!(result.fonts, SugarloafFonts::default());
         assert_eq!(result.theme, String::default());
+        assert_eq!(result.padding_color, PaddingColor::Background);
 
         // Colors
         assert_eq!(result.colors, Colors::default());
@@ -745,6 +761,18 @@ mod tests {
         // Developer
         assert_eq!(result.developer.log_level, default_log_level());
         assert!(!result.developer.enable_fps_counter);
+    }
+
+    #[test]
+    fn test_padding_color() {
+        let result = create_temporary_config(
+            "padding-color",
+            r#"
+            padding-color = "Extend"
+        "#,
+        );
+
+        assert_eq!(result.padding_color, PaddingColor::Extend);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a `padding-color` option with `Background` (the existing behavior) and `Extend`
- enable the existing grid padding-extension shader flags for single-panel windows
- update the setting on live configuration reloads
- document the option and cover its deserialization and default with tests

`Extend` fills otherwise unused edge pixels using the nearest terminal cell's
background. Multi-panel windows remain bounded to prevent one grid from painting
over sibling panels. The default remains unchanged.

## Testing

- `cargo test --workspace`
