### PR TITLE
Disarm sync-update timeout on inline ESU and flush expired updates

### DIFF
--- a/rio-vt/src/performer/handler.rs
+++ b/rio-vt/src/performer/handler.rs
@@ -610,6 +610,13 @@ impl Processor {
                 let new_len = self.state.sync_state.buffer.len() - bsu_offset;
                 self.state.sync_state.buffer.copy_within(bsu_offset.., 0);
                 self.state.sync_state.buffer.truncate(new_len);
+
+                // Replaying the processed bytes may have parsed an inline ESU
+                // that cleared the timeout, but this BSU is still pending.
+                self.state
+                    .sync_state
+                    .timeout
+                    .set_timeout(SYNC_UPDATE_TIMEOUT);
             }
             // Report mode and clear state if no new BSU is present.
             None => {
@@ -1331,6 +1338,11 @@ impl<U: Handler> Perform for Performer<'_, U> {
             }
             ('l', [b'?']) => {
                 for param in params_iter.map(|param| param[0]) {
+                    // Handle sync updates opaquely.
+                    if param == NamedPrivateMode::SyncUpdate as u16 {
+                        self.state.sync_state.timeout.clear_timeout();
+                    }
+
                     handler.unset_private_mode(PrivateMode::new(param))
                 }
             }
@@ -2118,6 +2130,77 @@ fn get_termcap_capability(name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Default)]
+    struct SyncHandler {
+        printed: String,
+    }
+
+    impl Handler for SyncHandler {
+        fn input(&mut self, c: char) {
+            self.printed.push(c);
+        }
+    }
+
+    #[test]
+    fn sync_update_inline_bsu_esu_disarms_timeout() {
+        let mut handler = SyncHandler::default();
+        let mut processor = Processor::default();
+
+        processor.advance(&mut handler, b"a\x1b[?2026hb\x1b[?2026lc");
+
+        assert_eq!(handler.printed, "abc");
+        assert!(processor.sync_timeout().sync_timeout().is_none());
+        assert_eq!(processor.sync_bytes_count(), 0);
+    }
+
+    #[test]
+    fn sync_update_buffers_across_chunks_until_esu() {
+        let mut handler = SyncHandler::default();
+        let mut processor = Processor::default();
+
+        processor.advance(&mut handler, b"\x1b[?2026h");
+        assert!(processor.sync_timeout().sync_timeout().is_some());
+
+        processor.advance(&mut handler, b"hidden");
+        assert_eq!(handler.printed, "");
+
+        processor.advance(&mut handler, b"\x1b[?2026l");
+        assert_eq!(handler.printed, "hidden");
+        assert!(processor.sync_timeout().sync_timeout().is_none());
+        assert_eq!(processor.sync_bytes_count(), 0);
+    }
+
+    #[test]
+    fn sync_update_stop_sync_flushes_pending_bytes() {
+        let mut handler = SyncHandler::default();
+        let mut processor = Processor::default();
+
+        processor.advance(&mut handler, b"\x1b[?2026h");
+        processor.advance(&mut handler, b"pending");
+        assert_eq!(handler.printed, "");
+
+        processor.stop_sync(&mut handler);
+        assert_eq!(handler.printed, "pending");
+        assert!(processor.sync_timeout().sync_timeout().is_none());
+        assert_eq!(processor.sync_bytes_count(), 0);
+    }
+
+    #[test]
+    fn sync_update_new_bsu_in_replayed_buffer_stays_armed() {
+        let mut handler = SyncHandler::default();
+        let mut processor = Processor::default();
+
+        processor.advance(&mut handler, b"\x1b[?2026h");
+        processor.advance(&mut handler, b"\x1b[?2026l\x1b[?2026htwo");
+        assert_eq!(handler.printed, "");
+        assert!(processor.sync_timeout().sync_timeout().is_some());
+
+        processor.advance(&mut handler, b"\x1b[?2026l");
+        assert_eq!(handler.printed, "two");
+        assert!(processor.sync_timeout().sync_timeout().is_none());
+        assert_eq!(processor.sync_bytes_count(), 0);
+    }
 
     #[test]
     fn semantic_prompt_parsing() {

--- a/rio-vt/src/performer/handler.rs
+++ b/rio-vt/src/performer/handler.rs
@@ -548,6 +548,13 @@ impl StdSyncHandler {
     fn pending_timeout(&self) -> bool {
         self.timeout.is_some()
     }
+
+    /// Whether an armed synchronized update has outlived its deadline.
+    #[inline]
+    fn expired(&self) -> bool {
+        self.timeout
+            .is_some_and(|deadline| deadline <= Instant::now())
+    }
 }
 
 #[derive(Default)]
@@ -569,7 +576,18 @@ impl Processor {
         H: Handler,
     {
         if self.state.sync_state.timeout.pending_timeout() {
-            self.advance_sync(handler, bytes);
+            // Cap synchronized-update latency for embedders that do not
+            // drive the timeout externally: once the deadline has passed,
+            // flush the buffered update before processing new bytes. Event
+            // loops that poll `sync_timeout()` (like Rio's machine) flush at
+            // the deadline itself and never reach this branch.
+            if self.state.sync_state.timeout.expired() {
+                self.stop_sync(handler);
+                let mut performer = Performer::new(&mut self.state, handler);
+                self.parser.advance(&mut performer, bytes);
+            } else {
+                self.advance_sync(handler, bytes);
+            }
         } else {
             let mut performer = Performer::new(&mut self.state, handler);
             self.parser.advance(&mut performer, bytes);
@@ -2182,6 +2200,31 @@ mod tests {
 
         processor.stop_sync(&mut handler);
         assert_eq!(handler.printed, "pending");
+        assert!(processor.sync_timeout().sync_timeout().is_none());
+        assert_eq!(processor.sync_bytes_count(), 0);
+    }
+
+    /// Embedders without an event loop never poll `sync_timeout()`; an
+    /// expired deadline must flush on the next `advance` call instead of
+    /// buffering until `SYNC_BUFFER_SIZE`.
+    #[test]
+    fn sync_update_expired_deadline_flushes_on_next_advance() {
+        let mut handler = SyncHandler::default();
+        let mut processor = Processor::default();
+
+        processor.advance(&mut handler, b"\x1b[?2026h");
+        processor.advance(&mut handler, b"hidden");
+        assert_eq!(handler.printed, "");
+
+        // Simulate the deadline passing without an ESU arriving.
+        processor.state.sync_state.timeout.timeout = Some(
+            Instant::now()
+                .checked_sub(Duration::from_millis(1))
+                .unwrap_or_else(Instant::now),
+        );
+
+        processor.advance(&mut handler, b" visible");
+        assert_eq!(handler.printed, "hidden visible");
         assert!(processor.sync_timeout().sync_timeout().is_none());
         assert_eq!(processor.sync_bytes_count(), 0);
     }


### PR DESCRIPTION
Builds on #1788 (thanks @marc2332 — your commit is kept as-is) and closes #1753. Supersedes #1754, which fixed the same inline-ESU bug correctly but against `rio-backend/src/performer/handler.rs` before the performer moved into rio-vt — credit to @cmoron for the original diagnosis and fix.

On top of the inline-ESU disarm, this adds a second, embedder-facing fix: **flush expired synchronized updates on the next `advance` call**.

## Why

`pending_timeout()` only reports that a sync update is *armed* — the 150 ms deadline is only honored by whoever polls `sync_timeout()` and calls `stop_sync()`. Rio's event loop does that (poll with `deadline - now`, flush on wakeup, same pattern as Alacritty). But rio-vt's embedders — freya-terminal, ratty, shell-use, neomacs, atuin — drive the processor directly from a read loop and none of them poll the timeout. For them, a client that arms mode 2026 and then stalls (crashed TUI, dropped connection mid-frame) freezes the screen until 2 MB of output hits `SYNC_BUFFER_SIZE`, or forever if output stops. The latency cap that makes synchronized updates safe to honor effectively didn't exist outside Rio.

## What

When `advance` is called with the timeout armed and the deadline already past, the buffered update is flushed first and the new bytes are then parsed normally. One `Instant::now()` on the already-cold armed path; the hot path is untouched. Rio's event loop still flushes at the deadline itself (it wakes without new bytes), so its behavior is unchanged and it never reaches the new branch.

The residual case — deadline passes and no further bytes ever arrive — still needs a timer-driven `stop_sync()`, which only an event loop can provide; that remains documented behavior of `sync_timeout()`.

Tests: the four from #1788 plus `sync_update_expired_deadline_flushes_on_next_advance`. Full rio-vt suite passes (408).
