### PR TITLE
Fix scale desync after sleep/wake and on hidden tabs

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1982,7 +1982,18 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 let focus_changed = route.window.is_focused != focused;
                 route.window.is_focused = focused;
 
-                if focus_changed {
+                // Focus is a cheap checkpoint to catch backing-scale changes
+                // whose ScaleFactorChanged never arrived (sleep/wake display
+                // reconfiguration).
+                if focused
+                    && route
+                        .window
+                        .screen
+                        .reconcile_scale(&route.window.winit_window)
+                {
+                    route.window.update_vblank_interval();
+                    route.request_redraw();
+                } else if focus_changed {
                     route.request_redraw();
                 }
 
@@ -1996,6 +2007,18 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 // If window was occluded and is now visible, mark for one-time render
                 if was_occluded && !occluded {
                     route.window.needs_render_after_occlusion = true;
+                    // Same checkpoint as focus: the un-occlusion after wake
+                    // is often the first event the window receives.
+                    if route
+                        .window
+                        .screen
+                        .reconcile_scale(&route.window.winit_window)
+                    {
+                        route.window.update_vblank_interval();
+                    }
+                    // An idle terminal produces no PTY traffic to trigger the
+                    // deferred post-occlusion render; request it directly.
+                    route.request_redraw();
                 }
             }
 

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -797,7 +797,19 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         &mut self,
         route_id: usize,
     ) -> Option<&mut ContextGridItem<T>> {
-        self.contexts[self.current_index].get_by_route_id(route_id)
+        // Search every tab, current first: per-route events (damage marks,
+        // titles, color/size requests) must reach panes in background tabs,
+        // otherwise their state is silently dropped until the pane's own
+        // PTY speaks again.
+        let current = self.current_index;
+        if self.contexts[current].get_by_route_id(route_id).is_some() {
+            return self.contexts[current].get_by_route_id(route_id);
+        }
+        self.contexts
+            .iter_mut()
+            .enumerate()
+            .filter(|(i, _)| *i != current)
+            .find_map(|(_, grid)| grid.get_by_route_id(route_id))
     }
 
     #[inline]

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -1186,6 +1186,52 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
         let _ = self.try_update_size(self.width, self.height);
     }
 
+    /// Refresh the grid's DPI scale and every scale-derived value baked
+    /// into the taffy tree at creation time: container gaps, panel
+    /// padding/margins, and the live reads (border hit-boxes, divider
+    /// math) that go through `self.scale`. Without this a grid created on
+    /// one display keeps its creation-time DPI for paddings and gaps
+    /// forever, even though the cell metrics update.
+    pub fn update_scale(&mut self, new_scale: f32) {
+        if (self.scale - new_scale).abs() < f32::EPSILON {
+            return;
+        }
+        self.scale = new_scale;
+
+        let gap = geometry::Size {
+            width: length(self.panel_config.column_gap * new_scale),
+            height: length(self.panel_config.row_gap * new_scale),
+        };
+        let padding = geometry::Rect {
+            left: length(self.panel_config.padding.left * new_scale),
+            right: length(self.panel_config.padding.right * new_scale),
+            top: length(self.panel_config.padding.top * new_scale),
+            bottom: length(self.panel_config.padding.bottom * new_scale),
+        };
+        let margin = geometry::Rect {
+            left: length(self.panel_config.margin.left * new_scale),
+            right: length(self.panel_config.margin.right * new_scale),
+            top: length(self.panel_config.margin.top * new_scale),
+            bottom: length(self.panel_config.margin.bottom * new_scale),
+        };
+
+        let mut stack = vec![self.root_node];
+        while let Some(node) = stack.pop() {
+            if let Ok(mut style) = self.tree.style(node).cloned() {
+                if self.inner.contains_key(&node) {
+                    style.padding = padding;
+                    style.margin = margin;
+                } else {
+                    style.gap = gap;
+                }
+                let _ = self.tree.set_style(node, style);
+            }
+            if let Ok(children) = self.tree.children(node) {
+                stack.extend(children);
+            }
+        }
+    }
+
     pub fn update_line_height(&mut self, line_height: f32) {
         for context in self.inner.values_mut() {
             context.val.dimension.update_line_height(line_height);

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -10,7 +10,6 @@ pub mod trail_cursor;
 pub mod utils;
 
 use rio_backend::event::TerminalDamage;
-use taffy::NodeId;
 
 use crate::context::renderable::{PendingUpdate, RenderableContent};
 use crate::context::ContextManager;
@@ -59,7 +58,12 @@ pub struct Renderer {
     pub command_palette: command_palette::CommandPalette,
     unfocused_split_opacity: f32,
     unfocused_split_fill: Option<ColorArray>,
-    last_active: Option<NodeId>,
+    /// Route id of the pane rendered as active last frame. Keyed on
+    /// `route_id` (globally unique) rather than the grid's taffy `NodeId`:
+    /// each tab owns its own taffy tree and identically-shaped trees hand
+    /// out identical NodeIds, so a tab switch would compare equal and skip
+    /// the full-damage refresh the incoming tab needs.
+    last_active: Option<usize>,
     /// Last `rio_backend::sugarloaf::Color` we applied to sugarloaf's window clear via
     /// `set_background_color`. Lets the per-frame "derive bg from
     /// active panel's OSC state" loop avoid redundant resyncs.
@@ -278,12 +282,12 @@ impl Renderer {
     ) -> (Option<crate::context::renderable::WindowUpdate>, bool) {
         let mut any_panel_dirty = false;
         let grid = context_manager.current_grid_mut();
-        let active_key = grid.current;
+        let active_route = grid.current().route_id;
         let grid_scaled_margin = grid.get_scaled_margin();
         let mut has_active_changed = false;
-        if self.last_active != Some(active_key) {
+        if self.last_active != Some(active_route) {
             has_active_changed = true;
-            self.last_active = Some(active_key);
+            self.last_active = Some(active_route);
         }
 
         for (_key, grid_context) in grid.contexts_mut().iter_mut() {
@@ -618,6 +622,9 @@ impl Renderer {
                 tint[2],
                 1.0 - self.unfocused_split_opacity,
             ];
+            // Within-grid comparison: taffy keys are only meaningful
+            // inside a single tab's tree.
+            let active_key = grid.current;
             for (key, grid_context) in grid.contexts_mut().iter() {
                 if &active_key == key {
                     continue;

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -574,10 +574,7 @@ impl Screen<'_> {
     /// producer de-dupes on the numeric value and wake notifications
     /// coalesce), so cheap checkpoints call this instead of trusting
     /// event delivery. Returns whether a rescale ran.
-    pub fn reconcile_scale(
-        &mut self,
-        winit_window: &rio_window::window::Window,
-    ) -> bool {
+    pub fn reconcile_scale(&mut self, winit_window: &rio_window::window::Window) -> bool {
         let live_scale = winit_window.scale_factor() as f32;
         if live_scale > 0.0
             && (live_scale - self.sugarloaf.scale_factor()).abs() > f32::EPSILON
@@ -613,6 +610,7 @@ impl Screen<'_> {
                 unscaled_margin.bottom * new_scale,
                 unscaled_margin.left * new_scale,
             ));
+            context_grid.update_scale(new_scale);
 
             for context in context_grid.contexts_mut().values_mut() {
                 let ctx = context.context_mut();

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -567,6 +567,27 @@ impl Screen<'_> {
         self
     }
 
+    /// Re-read the window's live scale factor and re-run the rescale path
+    /// when it diverged from the one being rendered with. Display
+    /// reconfiguration during sleep/wake can change the backing scale
+    /// without a `ScaleFactorChanged` ever being delivered (the macOS
+    /// producer de-dupes on the numeric value and wake notifications
+    /// coalesce), so cheap checkpoints call this instead of trusting
+    /// event delivery. Returns whether a rescale ran.
+    pub fn reconcile_scale(
+        &mut self,
+        winit_window: &rio_window::window::Window,
+    ) -> bool {
+        let live_scale = winit_window.scale_factor() as f32;
+        if live_scale > 0.0
+            && (live_scale - self.sugarloaf.scale_factor()).abs() > f32::EPSILON
+        {
+            self.set_scale(live_scale, winit_window.inner_size());
+            return true;
+        }
+        false
+    }
+
     #[inline]
     pub fn set_scale(
         &mut self,
@@ -594,7 +615,15 @@ impl Screen<'_> {
             ));
 
             for context in context_grid.contexts_mut().values_mut() {
-                context.context_mut().dimension.update_scale(new_scale);
+                let ctx = context.context_mut();
+                ctx.dimension.update_scale(new_scale);
+                // Resident GPU cell buffers hold glyphs shaped at the old
+                // scale; a scale change that preserves cols/rows produces
+                // no terminal damage on its own, so without this the grid
+                // geometry updates while the sprites stay stale.
+                ctx.renderable_content
+                    .pending_update
+                    .set_terminal_damage(rio_backend::event::TerminalDamage::Full);
             }
 
             context_grid.update_dimensions(&mut self.sugarloaf);
@@ -4376,6 +4405,13 @@ impl Screen<'_> {
                     self.sugarloaf.render();
                 } else {
                     self.sugarloaf.render_with_grids(&mut frame_grids);
+                }
+                // A dropped frame (no drawable, e.g. right after wake)
+                // already consumed this frame's damage; without a retry
+                // the content is lost until unrelated PTY traffic.
+                if self.sugarloaf.take_frame_dropped() {
+                    self.mark_dirty();
+                    self.context_manager.request_render();
                 }
             } else {
                 // Nothing to draw this frame, but `Renderer::run`

--- a/rio-window/src/platform_impl/macos/app_delegate.rs
+++ b/rio-window/src/platform_impl/macos/app_delegate.rs
@@ -25,6 +25,7 @@ use super::event_handler::EventHandler;
 use super::event_loop::{stop_app_immediately, ActiveEventLoop, PanicInfo};
 use super::observer::{EventLoopWaker, RunLoop};
 use super::window::WinitWindow;
+use super::window_delegate::WindowDelegate;
 use super::{menu, WindowId, DEVICE_ID};
 use crate::dpi::PhysicalSize;
 use crate::event::{
@@ -259,6 +260,29 @@ declare_class!(
                 if existing_value.is_null() {
                     let false_value: *mut Object = msg_send![class!(NSNumber), numberWithBool:false];
                     let _: () = msg_send![user_defaults, setObject: false_value forKey: name];
+                }
+            }
+        }
+
+        #[method(applicationDidChangeScreenParameters:)]
+        fn application_did_change_screen_parameters(&self, _: Option<&AnyObject>) {
+            trace_scope!("applicationDidChangeScreenParameters:");
+            // Display reconfiguration (sleep/wake, monitor connect,
+            // arrangement or resolution change) can alter a window's
+            // backing scale without AppKit delivering
+            // windowDidChangeBackingProperties: to every window. Re-run
+            // the scale check on all of them; the per-window numeric
+            // de-dupe makes this a no-op where nothing changed.
+            let mtm = MainThreadMarker::from(self);
+            let app = NSApplication::sharedApplication(mtm);
+            for window in app.windows().iter() {
+                if let Some(delegate) = unsafe { window.delegate() } {
+                    if delegate.is_kind_of::<WindowDelegate>() {
+                        // SAFETY: Just checked the class.
+                        let delegate: Retained<WindowDelegate> =
+                            unsafe { Retained::cast(delegate) };
+                        delegate.queue_static_scale_factor_changed_event();
+                    }
                 }
             }
         }

--- a/rio-window/src/platform_impl/macos/window_delegate.rs
+++ b/rio-window/src/platform_impl/macos/window_delegate.rs
@@ -913,7 +913,7 @@ impl WindowDelegate {
             .queue_window_event(self.window().id(), event);
     }
 
-    fn queue_static_scale_factor_changed_event(&self) {
+    pub(crate) fn queue_static_scale_factor_changed_event(&self) {
         let scale_factor = self.scale_factor();
         if scale_factor == self.ivars().previous_scale_factor.get() {
             return;

--- a/rio-window/src/platform_impl/macos/window_delegate.rs
+++ b/rio-window/src/platform_impl/macos/window_delegate.rs
@@ -424,6 +424,13 @@ declare_class!(
             } else {
                 tracing::info!("Display link reinitialized for new screen");
             }
+
+            // The new screen may carry a different backing scale, and
+            // AppKit does not reliably pair this notification with
+            // windowDidChangeBackingProperties: (ordered-out windows,
+            // wake-time display reshuffles). Re-run the scale check; the
+            // numeric de-dupe makes it a no-op when nothing changed.
+            self.queue_static_scale_factor_changed_event();
         }
     }
 
@@ -756,7 +763,7 @@ impl WindowDelegate {
             _ => NSSize::new(1., 1.),
         };
 
-        let scale_factor = window.backingScaleFactor() as _;
+        let scale_factor = window.backingScaleFactor() as f64;
 
         let current_theme = match attrs.preferred_theme {
             Some(theme) => Some(theme),
@@ -768,7 +775,11 @@ impl WindowDelegate {
             window: window.retain(),
             current_theme: Cell::new(current_theme),
             previous_position: Cell::new(None),
-            previous_scale_factor: Cell::new(scale_factor),
+            // 1.0, not the current scale: the synthesized startup event
+            // below must survive the equality guard in
+            // queue_static_scale_factor_changed_event, otherwise a window
+            // created on a HiDPI display never reports its scale.
+            previous_scale_factor: Cell::new(1.0),
             resize_increments: Cell::new(resize_increments),
             decorations: Cell::new(attrs.decorations),
             resizable: Cell::new(attrs.resizable),

--- a/sugarloaf/src/context/metal.rs
+++ b/sugarloaf/src/context/metal.rs
@@ -179,6 +179,12 @@ impl MetalContext {
     #[inline]
     pub fn set_scale(&mut self, scale: f32) {
         self.scale = scale;
+        // Re-assert the layer's contentsScale: it was set at creation and
+        // AppKit can reset layer state across sleep/wake or display
+        // reconfiguration. Without this the compositor rescales the
+        // texture and every glyph looks off even though the grid math
+        // is self-consistent. Cheap property write; safe to repeat.
+        self.layer.set_contents_scale(scale as f64);
     }
 
     /// Toggle the CAMetalLayer's opaque flag. `true` (default) lets the

--- a/sugarloaf/src/renderer/mod.rs
+++ b/sugarloaf/src/renderer/mod.rs
@@ -840,6 +840,10 @@ pub struct BackgroundImagePixels {
 }
 
 pub struct Renderer {
+    /// Set when a frame could not be presented (drawable acquisition
+    /// failed, e.g. right after sleep/wake). Consumed by the embedder via
+    /// `Sugarloaf::take_frame_dropped` to schedule a retry.
+    pub(crate) frame_dropped: bool,
     brush_type: RendererType,
     comp: Compositor,
     instances: Vec<batch::QuadInstance>,
@@ -1024,6 +1028,7 @@ impl Renderer {
         };
 
         Self {
+            frame_dropped: false,
             brush_type,
             comp: Compositor::new(),
             instances: vec![],
@@ -2172,7 +2177,12 @@ impl Renderer {
         let surface_texture = match context.get_current_texture() {
             Ok(t) => t,
             Err(e) => {
+                // Common right after sleep/wake: the layer has no drawable
+                // yet. The frame's damage was already consumed upstream, so
+                // record the drop for the embedder to schedule a retry —
+                // otherwise the content is lost until unrelated damage.
                 tracing::error!("Metal surface error: {}", e);
+                self.frame_dropped = true;
                 return;
             }
         };

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -877,6 +877,14 @@ impl Sugarloaf<'_> {
     }
 
     #[inline]
+    /// Whether the last frame failed to present (drawable acquisition
+    /// failure, common right after sleep/wake). Reading clears the flag.
+    /// Embedders should mark content dirty and schedule another frame,
+    /// since the dropped frame's damage was already consumed.
+    pub fn take_frame_dropped(&mut self) -> bool {
+        std::mem::take(&mut self.renderer.frame_dropped)
+    }
+
     pub fn render(&mut self) {
         self.render_with_grids(&mut []);
     }


### PR DESCRIPTION
Been chasing the "font/grid looks wrong after my mac wakes from sleep" bug for a while, plus a similar one where switching to a tab that wasn't visible shows glyphs at the wrong size. Finally sat down and traced the whole scale pipeline. Turns out we read the window's scale factor exactly once at creation and after that everything depends on a single ScaleFactorChanged event being delivered and fully applied. Neither is reliable.

The sleep/wake case: our only macOS producer is windowDidChangeBackingProperties, and it de-dupes on the numeric value. Wake sequences rebuild the backing store without the number changing, so nothing fires. And even when rio's numbers are fine, the CAMetalLayer contentsScale was set once at creation and never re-applied, so AppKit resetting layer state across wake leaves the compositor rescaling our texture. There was also a nasty one where the first frame after wake fails to get a drawable and we returned early after already consuming that frame's damage, so the content was just gone until you typed something (pretty sure this is #1506).

The tab case is more subtle. The resize/rescale fan-out actually does update every tab's dimensions and PTY, that part was never broken. What goes stale is the rendered glyphs: nothing turned a scale change into full terminal damage (three separate cols/rows early-returns conspire), and the safety net that forces a rebuild when the active pane changes compared taffy NodeIds across different tabs' trees. Each tab has its own tree and identical layouts hand out identical ids, so tab switches compared equal and skipped the rebuild. Also get_by_route_id only searched the current tab, so damage marks for background panes were silently dropped.

What this PR does:

- re-read the live scale at cheap checkpoints (window focus, un-occlusion, windowDidChangeScreen, and a new applicationDidChangeScreenParameters handler that sweeps all windows) instead of trusting one event. All of these no-op when nothing changed.
- rescale now stamps TerminalDamage::Full on every pane in every tab, so stale sprites can't survive it
- renderer keys "active pane changed" on route_id instead of cross-tree NodeIds
- get_by_route_id searches all tabs, current first
- MetalContext::set_scale re-asserts contentsScale on the layer
- dropped frames (no drawable) now mark dirty and schedule a retry instead of losing the consumed damage
- un-occlusion requests a redraw directly so an idle shell repaints after wake
- fixed the startup synthesized scale event that was dead code (previous_scale_factor was initialized to the current scale so the guard always ate it)
- ContextGrid.scale was written once at creation and never updated, so paddings/gaps/border hit boxes kept their creation DPI forever. There's an update_scale now that rewrites the scale-derived taffy styles

Tests pass everywhere and clippy is clean, but the real validation is manual: sleep/wake with a mixed-DPI external display, dragging between monitors and switching tabs, quake window across monitors. I'll do a pass on my setup before merging. Should fix #1506.
