### PR TITLE
teletypewriter: env vars, child exit status and direct spawn

### DIFF
--- a/frontends/rioterm/src/cli.rs
+++ b/frontends/rioterm/src/cli.rs
@@ -57,7 +57,7 @@ impl TerminalOptions {
         }
 
         Some(Shell {
-            program: program.clone(),
+            program: Some(program.clone()),
             args: args.to_vec(),
         })
     }

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -23,7 +23,6 @@ use rio_backend::event::EventListener;
 use rio_backend::event::WindowId;
 use rio_backend::selection::SelectionRange;
 use rio_backend::sugarloaf::{font::SugarloafFont, Rect, Sugarloaf, SugarloafErrors};
-use std::borrow::Cow;
 use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -261,7 +260,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             if config.use_fork {
                 tracing::info!("rio -> teletypewriter: create_pty_with_fork");
                 pty = match create_pty_with_fork(
-                    &Cow::Borrowed(&config.shell.program),
+                    config.shell.program.as_deref(),
                     &config.shell.args,
                     cols,
                     rows,
@@ -277,9 +276,10 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             } else {
                 tracing::info!("rio -> teletypewriter: create_pty_with_spawn");
                 pty = match create_pty_with_spawn(
-                    &Cow::Borrowed(&config.shell.program),
+                    config.shell.program.as_deref(),
                     config.shell.args.clone(),
                     &config.working_dir,
+                    None,
                     cols,
                     rows,
                     initial_winsize.width,
@@ -302,9 +302,10 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         #[cfg(target_os = "windows")]
         {
             pty = match create_pty(
-                &Cow::Borrowed(&config.shell.program),
+                config.shell.program.as_deref(),
                 config.shell.args.clone(),
                 &config.working_dir,
+                None,
                 cols,
                 rows,
             ) {

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -249,21 +249,16 @@ impl Surface {
         );
         let terminal = Arc::new(FairMutex::new(terminal));
 
-        #[cfg(not(target_os = "windows"))]
-        let fallback_shell = "/bin/sh";
-        #[cfg(target_os = "windows")]
-        let fallback_shell = "cmd.exe";
-        let shell = desc
-            .shell
-            .clone()
-            .or_else(|| std::env::var("SHELL").ok())
-            .unwrap_or_else(|| String::from(fallback_shell));
+        // No shell in the descriptor means "whatever the user's default is",
+        // which teletypewriter resolves (and starts as a login shell).
+        let shell = desc.shell.as_deref();
 
         #[cfg(not(target_os = "windows"))]
         let pty = create_pty_with_spawn(
-            &Cow::Borrowed(shell.as_str()),
+            shell,
             desc.args.clone(),
             &desc.working_dir,
+            None,
             desc.cols,
             desc.rows,
             desc.pixel_width,
@@ -273,9 +268,10 @@ impl Surface {
 
         #[cfg(target_os = "windows")]
         let pty = create_pty(
-            shell.as_str(),
+            shell,
             desc.args.clone(),
             &desc.working_dir,
+            None,
             desc.cols,
             desc.rows,
         )

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -44,7 +44,7 @@ pub fn default_shell() -> crate::config::Shell {
     #[cfg(not(target_os = "windows"))]
     {
         crate::config::Shell {
-            program: String::from(""),
+            program: None,
             args: vec![String::from("--login")],
         }
     }
@@ -52,7 +52,7 @@ pub fn default_shell() -> crate::config::Shell {
     #[cfg(target_os = "windows")]
     {
         crate::config::Shell {
-            program: String::from("powershell"),
+            program: Some(String::from("powershell")),
             args: vec![],
         }
     }
@@ -106,7 +106,7 @@ pub fn default_editor() -> Shell {
     #[cfg(not(target_os = "windows"))]
     {
         Shell {
-            program: String::from("vi"),
+            program: Some(String::from("vi")),
             args: vec![],
         }
     }
@@ -114,7 +114,7 @@ pub fn default_editor() -> Shell {
     #[cfg(target_os = "windows")]
     {
         Shell {
-            program: String::from("notepad"),
+            program: Some(String::from("notepad")),
             args: vec![],
         }
     }

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -37,11 +37,28 @@ use sugarloaf::font::fonts::SugarloafFonts;
 use theme::{AdaptiveColors, AdaptiveTheme, AppearanceTheme, Theme};
 use tracing::warn;
 
+/// `program` of `None` means no program was configured, so the user's default
+/// shell is used (and, on macOS, started as a login shell).
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Shell {
-    pub program: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_program",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub program: Option<String>,
     #[serde(default)]
     pub args: Vec<String>,
+}
+
+/// `program = ""` used to be how you asked for the default shell, so keep
+/// reading it as "nothing configured" rather than trying to spawn it.
+fn deserialize_program<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let program = Option::<String>::deserialize(deserializer)?;
+    Ok(program.filter(|program| !program.is_empty()))
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -1154,8 +1171,21 @@ mod tests {
         "#,
         );
 
-        assert_eq!(result.shell.program, "/bin/fish");
+        assert_eq!(result.shell.program.as_deref(), Some("/bin/fish"));
         assert_eq!(result.shell.args, ["--hello"]);
+    }
+
+    #[test]
+    fn test_shell_empty_program_means_default() {
+        let result = create_temporary_config(
+            "change-shell-empty-program",
+            r#"
+            shell = { program = "", args = ["--login"] }
+        "#,
+        );
+
+        assert_eq!(result.shell.program, None);
+        assert_eq!(result.shell.args, ["--login"]);
     }
 
     #[test]
@@ -1167,7 +1197,7 @@ mod tests {
         "#,
         );
 
-        assert_eq!(result.shell.program, "/bin/fish");
+        assert_eq!(result.shell.program.as_deref(), Some("/bin/fish"));
         assert_eq!(result.shell.args, Vec::<&str>::new());
     }
 
@@ -1428,7 +1458,7 @@ mod tests {
         result.overwrite_based_on_platform();
 
         // Shell should be completely replaced
-        assert_eq!(result.shell.program, "/bin/zsh");
+        assert_eq!(result.shell.program.as_deref(), Some("/bin/zsh"));
         assert_eq!(result.shell.args, vec!["-l"]);
     }
 
@@ -1559,7 +1589,7 @@ mod tests {
         assert_eq!(result.navigation.mode, navigation::NavigationMode::Tab);
 
         // Shell: completely replaced
-        assert_eq!(result.shell.program, "/bin/zsh");
+        assert_eq!(result.shell.program.as_deref(), Some("/bin/zsh"));
         assert_eq!(result.shell.args, vec!["--login"]);
     }
 

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -242,6 +242,11 @@ pub enum RioEvent {
     /// Leave current terminal.
     CloseTerminal(usize),
 
+    /// The PTY's child process exited, with the raw wait status when the
+    /// platform makes it available (interpret with
+    /// `std::process::ExitStatus::from_raw` / `ExitStatusExt`).
+    ChildExited(usize, Option<i32>),
+
     BlinkCursor(u64, usize),
 
     /// Selection scroll tick — auto-scroll while dragging outside viewport.
@@ -319,6 +324,9 @@ impl Debug for RioEvent {
             RioEvent::Exit => write!(f, "Exit"),
             RioEvent::Quit => write!(f, "Quit"),
             RioEvent::CloseTerminal(route) => write!(f, "CloseTerminal {route}"),
+            RioEvent::ChildExited(route, status) => {
+                write!(f, "ChildExited(route={route}, status={status:?})")
+            }
             RioEvent::CreateWindow => write!(f, "CreateWindow"),
             RioEvent::ToggleQuake => write!(f, "ToggleQuake"),
             RioEvent::CloseWindow => write!(f, "CloseWindow"),

--- a/rio-vt/src/performer/mod.rs
+++ b/rio-vt/src/performer/mod.rs
@@ -385,7 +385,7 @@ where
                             }
                         }
                         token if token == self.pty.child_event_token() => {
-                            if let Some(teletypewriter::ChildEvent::Exited) =
+                            if let Some(teletypewriter::ChildEvent::Exited(status)) =
                                 self.pty.next_child_event()
                             {
                                 // In the future allow configure exit
@@ -396,6 +396,20 @@ where
                                 //     // Without hold, shutdown the terminal.
                                 //     self.terminal.lock().exit();
                                 // }
+
+                                // Drain whatever the child wrote before it
+                                // exited so short-lived commands don't lose
+                                // their final output.
+                                if let Err(err) = self.pty_read(&mut state, &mut buf) {
+                                    tracing::debug!(
+                                        "PTY drain after child exit failed: {err}"
+                                    );
+                                }
+
+                                self.event_proxy.send_event(
+                                    RioEvent::ChildExited(self.route_id, status),
+                                    self.window_id,
+                                );
 
                                 self.terminal.lock().exit();
 

--- a/teletypewriter/examples/spawn.rs
+++ b/teletypewriter/examples/spawn.rs
@@ -2,15 +2,13 @@
 
 #[cfg(unix)]
 fn main() -> std::io::Result<()> {
-    use std::borrow::Cow;
     use std::io::Read;
     use std::io::Write;
     // use std::io::BufRead;
     use std::io::BufReader;
     use teletypewriter::{create_pty_with_fork, ProcessReadWrite, Pty};
 
-    let shell = Cow::Borrowed("bash");
-    let mut process: Pty = create_pty_with_fork(&shell, &[], 80, 25, 0, 0)?;
+    let mut process: Pty = create_pty_with_fork(Some("bash"), &[], 80, 25, 0, 0)?;
 
     process.writer().write_all(b"1").unwrap();
     process.writer().write_all(b"2").unwrap();

--- a/teletypewriter/src/lib.rs
+++ b/teletypewriter/src/lib.rs
@@ -47,8 +47,10 @@ pub trait ProcessReadWrite {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ChildEvent {
-    /// Indicates the child has exited.
-    Exited,
+    /// Indicates the child has exited, with the raw wait status when the
+    /// platform makes it available (interpret with
+    /// `std::process::ExitStatus::from_raw` / `ExitStatusExt`).
+    Exited(Option<i32>),
 }
 
 pub trait EventedPty: ProcessReadWrite {

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -468,12 +468,22 @@ fn login_argv(
 /// which is a command in Unix and Unix-like operating systems to print the file name of the
 /// terminal connected to standard input. tty stands for TeleTYpewriter.
 ///
+/// `env`, when given, is applied on top of the inherited environment,
+/// overriding inherited variables of the same name. `None` inherits as-is.
+///
+/// `shell` of `None` means no program was configured: the user's default shell
+/// is looked up and, on macOS, wrapped in `/usr/bin/login` so the child gets a
+/// login session. A caller that names a program gets exactly that program,
+/// spawned directly, with no `login` in between.
+///
 /// It returns two [`Pty`] along with respective process name [`String`] and process id (`libc::pid_`)
 ///
+#[allow(clippy::too_many_arguments)]
 pub fn create_pty_with_spawn(
-    shell: &str,
+    shell: Option<&str>,
     args: Vec<String>,
     working_directory: &Option<String>,
+    env: Option<Vec<(String, String)>>,
     columns: u16,
     rows: u16,
     width: u16,
@@ -509,33 +519,39 @@ pub fn create_pty_with_spawn(
         return Err(Error::other("openpty failed"));
     }
 
-    let mut shell_program = shell;
-
     let user = match ShellUser::from_env() {
         Ok(data) => data,
         Err(..) => ShellUser {
-            shell: shell.to_string(),
+            shell: shell.unwrap_or_default().to_string(),
             ..Default::default()
         },
     };
 
-    if shell.is_empty() {
-        shell_program = &user.shell;
-    }
+    // No program means the caller wants the user's default shell, which is the
+    // only case that goes through `login`. A named program is spawned as given.
+    let uses_default_shell = shell.is_none();
+    let shell_program = shell.unwrap_or(&user.shell);
 
     tracing::info!("spawn {:?} {:?}", shell_program, args);
 
     let mut builder = {
         #[cfg(target_os = "macos")]
         {
-            // On macOS, use /usr/bin/login to ensure proper login shell environment
-            // This ensures PATH includes directories like /usr/local/bin
-            let hushlogin = std::path::Path::new(&user.home).join(".hushlogin").exists();
+            if uses_default_shell {
+                // On macOS, use /usr/bin/login to ensure proper login shell environment
+                // This ensures PATH includes directories like /usr/local/bin
+                let hushlogin =
+                    std::path::Path::new(&user.home).join(".hushlogin").exists();
 
-            let mut login_cmd = Command::new("/usr/bin/login");
-            login_cmd.args(login_argv(hushlogin, &user.user, shell_program, &args));
+                let mut login_cmd = Command::new("/usr/bin/login");
+                login_cmd.args(login_argv(hushlogin, &user.user, shell_program, &args));
 
-            login_cmd
+                login_cmd
+            } else {
+                let mut cmd = Command::new(shell_program);
+                cmd.args(args);
+                cmd
+            }
         }
 
         #[cfg(not(target_os = "macos"))]
@@ -593,6 +609,9 @@ pub fn create_pty_with_spawn(
 
     builder.env("USER", user.user);
     builder.env("HOME", user.home);
+    if let Some(env) = env {
+        builder.envs(env);
+    }
 
     unsafe {
         builder.pre_exec(move || {
@@ -616,6 +635,13 @@ pub fn create_pty_with_spawn(
             libc::signal(libc::SIGQUIT, libc::SIG_DFL);
             libc::signal(libc::SIGTERM, libc::SIG_DFL);
             libc::signal(libc::SIGALRM, libc::SIG_DFL);
+
+            // The embedding process may run with signals blocked (e.g. on a
+            // background thread); the child must not inherit that mask or
+            // Ctrl-C and friends stop working in the spawned shell.
+            let mut set: libc::sigset_t = std::mem::zeroed();
+            libc::sigemptyset(&mut set);
+            libc::sigprocmask(libc::SIG_SETMASK, &set, std::ptr::null_mut());
 
             Ok(())
         });
@@ -673,7 +699,7 @@ pub fn create_pty_with_spawn(
 /// It returns two [`Pty`] along with respective process name [`String`] and process id (`libc::pid_`)
 ///
 pub fn create_pty_with_fork(
-    shell: &str,
+    shell: Option<&str>,
     args: &[String],
     columns: u16,
     rows: u16,
@@ -689,20 +715,18 @@ pub fn create_pty_with_fork(
     };
     let term = create_termp(true);
 
-    let mut shell_program = shell;
-
     let user = match ShellUser::from_env() {
         Ok(data) => data,
         Err(..) => ShellUser {
-            shell: shell.to_string(),
+            shell: shell.unwrap_or_default().to_string(),
             ..Default::default()
         },
     };
 
-    if shell.is_empty() {
-        tracing::info!("shell configuration is empty, will retrieve from env");
-        shell_program = &user.shell;
-    }
+    let shell_program = shell.unwrap_or_else(|| {
+        tracing::info!("no shell configured, will retrieve from env");
+        &user.shell
+    });
 
     tracing::info!("fork {:?}", shell_program);
 
@@ -883,7 +907,7 @@ impl EventedPty for Pty {
                     None
                 }
                 Ok(None) => None,
-                Ok(Some(..)) => Some(ChildEvent::Exited),
+                Ok(Some(status)) => Some(ChildEvent::Exited(Some(status))),
             }
         })
     }

--- a/teletypewriter/src/windows/child.rs
+++ b/teletypewriter/src/windows/child.rs
@@ -6,11 +6,16 @@ use std::sync::atomic::{AtomicPtr, Ordering};
 
 use windows_sys::Win32::Foundation::{BOOLEAN, HANDLE};
 use windows_sys::Win32::System::Threading::{
-    GetProcessId, RegisterWaitForSingleObject, UnregisterWait, INFINITE,
-    WT_EXECUTEINWAITTHREAD, WT_EXECUTEONLYONCE,
+    GetExitCodeProcess, GetProcessId, RegisterWaitForSingleObject, UnregisterWait,
+    INFINITE, WT_EXECUTEINWAITTHREAD, WT_EXECUTEONLYONCE,
 };
 
 use crate::ChildEvent;
+
+struct ChildExitSender {
+    sender: Sender<ChildEvent>,
+    child_handle: AtomicPtr<c_void>,
+}
 
 /// WinAPI callback to run when child process exits.
 extern "system" fn child_exit_callback(ctx: *mut c_void, timed_out: BOOLEAN) {
@@ -18,8 +23,16 @@ extern "system" fn child_exit_callback(ctx: *mut c_void, timed_out: BOOLEAN) {
         return;
     }
 
-    let event_tx: Box<_> = unsafe { Box::from_raw(ctx as *mut Sender<ChildEvent>) };
-    let _ = event_tx.send(ChildEvent::Exited);
+    let event_tx: Box<ChildExitSender> = unsafe { Box::from_raw(ctx as *mut _) };
+    let mut exit_code = 0_u32;
+    let status = unsafe {
+        GetExitCodeProcess(
+            event_tx.child_handle.load(Ordering::Relaxed) as HANDLE,
+            &mut exit_code,
+        )
+    };
+    let exit_code = (status != 0).then_some(exit_code as i32);
+    let _ = event_tx.sender.send(ChildEvent::Exited(exit_code));
 }
 
 pub struct ChildExitWatcher {
@@ -39,7 +52,10 @@ impl ChildExitWatcher {
         let (event_tx, event_rx) = channel::<ChildEvent>();
 
         let mut wait_handle: HANDLE = std::ptr::null_mut();
-        let sender_ref = Box::new(event_tx);
+        let sender_ref = Box::new(ChildExitSender {
+            sender: event_tx,
+            child_handle: AtomicPtr::from(child_handle),
+        });
 
         let success = unsafe {
             RegisterWaitForSingleObject(
@@ -122,9 +138,9 @@ mod tests {
         poll.poll(&mut events, Some(WAIT_TIMEOUT)).unwrap();
         assert_eq!(events.iter().next().unwrap().token(), child_events_token);
         // Verify that at least one `ChildEvent::Exited` was received.
-        assert_eq!(
+        assert!(matches!(
             child_exit_watcher.event_rx().try_recv(),
-            Ok(ChildEvent::Exited)
-        );
+            Ok(ChildEvent::Exited(_))
+        ));
     }
 }

--- a/teletypewriter/src/windows/conpty.rs
+++ b/teletypewriter/src/windows/conpty.rs
@@ -16,10 +16,12 @@ use windows_sys::{s, w};
 
 use windows_sys::Win32::System::Threading::{
     CreateProcessW, InitializeProcThreadAttributeList, UpdateProcThreadAttribute,
-    EXTENDED_STARTUPINFO_PRESENT, PROCESS_INFORMATION,
+    CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, PROCESS_INFORMATION,
     PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
     STARTUPINFOW,
 };
+
+use std::os::windows::ffi::OsStrExt;
 
 use crate::windows::child::ChildExitWatcher;
 use crate::windows::{cmdline, win32_string, Pty};
@@ -103,9 +105,33 @@ impl Drop for Conpty {
 // The ConPTY handle can be sent between threads.
 unsafe impl Send for Conpty {}
 
+/// Builds a `CREATE_UNICODE_ENVIRONMENT` block from the current process
+/// environment plus `extra_env` (which overrides inherited variables of the
+/// same name): NUL-terminated `KEY=VALUE` UTF-16 entries, with a trailing NUL.
+fn environment_block(extra_env: Vec<(String, String)>) -> Vec<u16> {
+    let mut vars: Vec<(std::ffi::OsString, std::ffi::OsString)> =
+        std::env::vars_os().collect();
+    for (key, value) in extra_env {
+        let key = std::ffi::OsString::from(key);
+        vars.retain(|(existing, _)| !existing.eq_ignore_ascii_case(&key));
+        vars.push((key, value.into()));
+    }
+
+    let mut block = Vec::new();
+    for (key, value) in vars {
+        block.extend(key.encode_wide());
+        block.push('=' as u16);
+        block.extend(value.encode_wide());
+        block.push(0);
+    }
+    block.push(0);
+    block
+}
+
 pub fn new(
-    shell: &str,
+    shell: Option<&str>,
     working_directory: &Option<String>,
+    env: Option<Vec<(String, String)>>,
     columns: u16,
     rows: u16,
 ) -> Result<Pty> {
@@ -215,6 +241,9 @@ pub fn new(
 
     let cmdline = win32_string(&cmdline(shell));
     let cwd = working_directory.as_ref().map(win32_string);
+    // With no overrides, leave the environment pointer null so the child
+    // inherits ours, exactly as before.
+    let mut env_block = env.map(environment_block);
 
     let mut proc_info: PROCESS_INFORMATION = unsafe { mem::zeroed() };
     unsafe {
@@ -224,8 +253,14 @@ pub fn new(
             ptr::null_mut(),
             ptr::null_mut(),
             false as i32,
-            EXTENDED_STARTUPINFO_PRESENT,
-            ptr::null_mut(),
+            match env_block {
+                Some(_) => EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+                None => EXTENDED_STARTUPINFO_PRESENT,
+            },
+            match env_block.as_mut() {
+                Some(block) => block.as_mut_ptr() as *mut std::ffi::c_void,
+                None => ptr::null_mut(),
+            },
             cwd.as_ref().map_or_else(ptr::null, |s| s.as_ptr()),
             &mut startup_info_ex.StartupInfo as *mut STARTUPINFOW,
             &mut proc_info as *mut PROCESS_INFORMATION,

--- a/teletypewriter/src/windows/mod.rs
+++ b/teletypewriter/src/windows/mod.rs
@@ -32,20 +32,28 @@ pub struct Pty {
 
 // Creates conpty instead of pty
 // Windows Pseudo Console (ConPTY)
+//
+// `env`, when given, is applied on top of the inherited environment,
+// overriding inherited variables of the same name. `None` inherits as-is.
+//
+// `shell` of `None` means no program was configured, and the default console
+// host is used.
 pub fn create_pty(
-    shell: &str,
+    shell: Option<&str>,
     args: Vec<String>,
     working_directory: &Option<String>,
+    env: Option<Vec<(String, String)>>,
     columns: u16,
     rows: u16,
 ) -> Result<Pty, std::io::Error> {
-    let exec = if !args.is_empty() {
-        let args = args.join(" ");
-        &format!("{shell} {args}")
-    } else {
-        shell
-    };
-    conpty::new(exec, working_directory, columns, rows)
+    let exec = shell.map(|shell| {
+        if args.is_empty() {
+            shell.to_string()
+        } else {
+            format!("{shell} {}", args.join(" "))
+        }
+    });
+    conpty::new(exec.as_deref(), working_directory, env, columns, rows)
 }
 
 impl Pty {
@@ -224,13 +232,13 @@ impl EventedPty for Pty {
         match self.child_watcher.event_rx().try_recv() {
             Ok(ev) => Some(ev),
             Err(TryRecvError::Empty) => None,
-            Err(TryRecvError::Disconnected) => Some(ChildEvent::Exited),
+            Err(TryRecvError::Disconnected) => Some(ChildEvent::Exited(None)),
         }
     }
 }
 
-fn cmdline(shell: &str) -> String {
-    if !shell.is_empty() {
+fn cmdline(shell: Option<&str>) -> String {
+    if let Some(shell) = shell.filter(|shell| !shell.is_empty()) {
         return shell.to_string();
     }
 


### PR DESCRIPTION
This is what I needed to embed rio-vt in another app that drives the shell itself. ChildEvent::Exited now carries the raw wait status (waitpid on unix, GetExitCodeProcess on windows) rather than being a bare marker, and Machine forwards it as RioEvent::ChildExited so a host can report the exit code of whatever it ran. Machine also reads the PTY once more after the child exits, since a command that writes and exits immediately could otherwise lose its last chunk. On the spawn side, create_pty_with_spawn and create_pty take an optional set of env vars applied on top of the inherited environment; passing None leaves it alone, and on windows that means CreateProcessW still gets a null environment pointer exactly as before. Both signatures changed in place rather than growing a parallel entry point.

"No program configured" is now None instead of an empty string, so config::Shell::program is an Option<String> and the three create_pty entry points take Option<&str>. An existing program = "" in someone's config still reads as None, since that is how you used to ask for the default shell. librio drops its own $SHELL fallback and lets teletypewriter resolve the default, which is also what restores login for it. That same Option decides the macOS /usr/bin/login wrapper, the way alacritty picks it: only a default shell is wrapped, and a named program is spawned directly instead of collecting a utmp entry and a "Last login" banner it never asked for. Rio's default config configures no program, so a default session still goes through login as before. The one behaviour change to know about is that a user who sets shell.program in their config no longer will.

Also resets the signal mask in pre_exec. It already reset ignored dispositions, but a blocked mask survives exec too, so a shell spawned from a thread that had SIGINT blocked came up with Ctrl-C dead. Rio spawns from the main thread so this changes nothing for it. Workspace tests, fmt and clippy --all-targets --all-features are clean. I exercised the unix side on macOS through a host driving rio-vt (exit codes reported, Ctrl-C fine in shells spawned off-thread, env vars reaching the child, login used for a default shell and skipped for an explicit one); the windows paths are compile checked only since I have no box to run them on.