### PR TITLE
rio-vt: drop the unused lazy_static dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4027,7 +4027,6 @@ dependencies = [
  "cursor-icon",
  "flate2",
  "image",
- "lazy_static",
  "libc",
  "memchr",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,6 @@ url = "2.5.4"
 criterion = { version = "0.6.0", features = ["html_reports"] }
 dashmap = "6.1.0"
 flate2 = "1.0"
-lazy_static = "1.5"
 
 [profile.release]
 strip = "symbols"           # See split-debuginfo - allows us to drop the size by ~65%

--- a/rio-vt/Cargo.toml
+++ b/rio-vt/Cargo.toml
@@ -39,7 +39,6 @@ cursor-icon = { version = "1.1.0", default-features = false }
 smallvec = { version = "1.13.2", default-features = false }
 simdutf = { workspace = true }
 flate2 = { workspace = true }
-lazy_static = { workspace = true }
 # Optional: only pulled in when the embedder wants the app-level renderer
 # error variant (font-not-found). Off keeps rio-vt free of sugarloaf.
 sugarloaf = { workspace = true, optional = true }


### PR DESCRIPTION
lazy_static was declared in the workspace and pulled into rio-vt, but nothing references it: no lazy_static! invocations, no macro_use, no imports anywhere in the tree. So this just removes the declaration and the lockfile entry, which drops a crate from the build graph.

Worth noting for the future in case it comes back: std::sync::LazyLock has covered this since 1.80 and the toolchain here is on 1.96, so a plain static is enough and there is no reason to reintroduce the dependency. Workspace builds, tests, fmt and clippy --all-targets --all-features are clean.