### PR TITLE
rio-vt: parse OSC 7 without the url crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4043,7 +4043,6 @@ dependencies = [
  "teletypewriter",
  "tracing",
  "unicode-width-16",
- "url",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4021,7 +4021,6 @@ version = "0.5.6"
 dependencies = [
  "base64",
  "bitflags 2.13.1",
- "bytemuck",
  "copypasta",
  "corcovado",
  "cursor-icon",

--- a/rio-vt/Cargo.toml
+++ b/rio-vt/Cargo.toml
@@ -19,7 +19,6 @@ tracing = { workspace = true }
 base64 = { workspace = true }
 memchr = { version = "2.8.3", default-features = false }
 bitflags = { workspace = true }
-bytemuck = { workspace = true }
 corcovado = { workspace = true }
 rustc-hash = { workspace = true }
 regex = { workspace = true }

--- a/rio-vt/Cargo.toml
+++ b/rio-vt/Cargo.toml
@@ -32,7 +32,6 @@ rio-graphics = { workspace = true }
 rio-grapheme-width = { workspace = true }
 teletypewriter = { workspace = true }
 unicode-width = { workspace = true }
-url = { workspace = true }
 regex-automata = "0.4.16"
 cursor-icon = { version = "1.1.0", default-features = false }
 smallvec = { workspace = true }

--- a/rio-vt/src/performer/osc.rs
+++ b/rio-vt/src/performer/osc.rs
@@ -195,17 +195,73 @@ pub(super) fn parse_palette_entries(params: &[&[u8]]) -> Option<Vec<PaletteEntry
     Some(out)
 }
 
+/// The only URL scheme rio-vt ever parses.
+const FILE_SCHEME: &str = "file://";
+
 /// OSC 7: working directory as a `file://` URL.
+///
+/// The payload is `file://<host>/<path>`, where the host is informational and
+/// the path is percent-encoded. Parsed by hand rather than with a URL crate:
+/// this is the only URL the terminal core looks at, and a general parser costs
+/// an IDNA/Unicode stack just to reach `.path()`.
 pub(super) fn parse_current_directory(param: &[u8]) -> Option<String> {
     let s = simd_utf8::from_utf8_fast(param).ok()?;
-    let url = url::Url::parse(s).ok()?;
-    let path = url.path();
 
-    // The URL crate prepends a leading slash on Windows paths; strip it.
+    // Schemes are case-insensitive.
+    let after_scheme = s
+        .get(..FILE_SCHEME.len())
+        .filter(|scheme| scheme.eq_ignore_ascii_case(FILE_SCHEME))
+        .map(|_| &s[FILE_SCHEME.len()..])?;
+
+    // Skip the host: the path begins at its trailing slash. A payload with no
+    // path at all leaves nothing to report.
+    let path = &after_scheme[after_scheme.find('/')?..];
+
+    // A query or fragment is not part of the path.
+    let path = &path[..path.find(['?', '#']).unwrap_or(path.len())];
+
+    // Windows paths arrive as `/C:/...`; drop the leading slash.
     #[cfg(windows)]
     let path = path.strip_prefix('/').unwrap_or(path);
 
-    Some(path.to_owned())
+    percent_decode(path)
+}
+
+/// Percent-decode a URL path. Invalid escapes are passed through as written,
+/// which is friendlier than dropping the directory over one stray `%`.
+fn percent_decode(path: &str) -> Option<String> {
+    if !path.contains('%') {
+        return Some(path.to_owned());
+    }
+
+    let bytes = path.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        // Only `%` followed by two hex digits is an escape. `from_str_radix`
+        // would accept a leading `+` here, decoding `%+A` to a byte.
+        let escape = (bytes[index] == b'%')
+            .then(|| {
+                let hex = bytes.get(index + 1..index + 3)?;
+                let high = (hex[0] as char).to_digit(16)?;
+                let low = (hex[1] as char).to_digit(16)?;
+                Some((high * 16 + low) as u8)
+            })
+            .flatten();
+
+        match escape {
+            Some(byte) => {
+                out.push(byte);
+                index += 3;
+            }
+            None => {
+                out.push(bytes[index]);
+                index += 1;
+            }
+        }
+    }
+
+    String::from_utf8(out).ok()
 }
 
 /// OSC 8: extract `id=...` from `key=val:key=val` link params.
@@ -327,4 +383,114 @@ pub(super) fn parse_palette_reset(params: &[&[u8]]) -> PaletteReset {
     }
     let indices = params[1..].iter().filter_map(|p| parse_number(p)).collect();
     PaletteReset::Indices(indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cwd(payload: &str) -> Option<String> {
+        parse_current_directory(payload.as_bytes())
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn current_directory_from_file_url() {
+        // Empty host is the common shape; a named host is informational.
+        assert_eq!(cwd("file:///home/user"), Some("/home/user".into()));
+        assert_eq!(cwd("file://localhost/home/user"), Some("/home/user".into()));
+        assert_eq!(cwd("file:///"), Some("/".into()));
+
+        // Schemes are case-insensitive.
+        assert_eq!(cwd("FILE:///home/user"), Some("/home/user".into()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn current_directory_strips_windows_leading_slash() {
+        assert_eq!(cwd("file:///C:/Users/user"), Some("C:/Users/user".into()));
+    }
+
+    #[test]
+    fn current_directory_rejects_non_file_payloads() {
+        // Another scheme is not a working directory, and a bare path has no
+        // scheme to speak of.
+        assert_eq!(cwd("http://example.com/home/user"), None);
+        assert_eq!(cwd("/home/user"), None);
+        assert_eq!(cwd(""), None);
+
+        // No path component at all.
+        assert_eq!(cwd("file://localhost"), None);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn current_directory_percent_decodes() {
+        assert_eq!(
+            cwd("file:///home/My%20Files"),
+            Some("/home/My Files".into())
+        );
+        // Multi-byte UTF-8 arrives as a run of escapes.
+        assert_eq!(
+            cwd("file:///home/%E1%BF%AC%CF%8C%CE%B4%CE%BF%CF%82"),
+            Some("/home/Ῥόδος".into())
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn current_directory_keeps_malformed_escapes() {
+        // A stray or truncated `%` is shown as sent rather than discarded.
+        assert_eq!(cwd("file:///home/100%"), Some("/home/100%".into()));
+        assert_eq!(cwd("file:///home/a%zz"), Some("/home/a%zz".into()));
+        assert_eq!(cwd("file:///home/a%2"), Some("/home/a%2".into()));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn current_directory_ignores_query_and_fragment() {
+        assert_eq!(cwd("file:///home/user?x=1"), Some("/home/user".into()));
+        assert_eq!(cwd("file:///home/user#frag"), Some("/home/user".into()));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn current_directory_rejects_non_hex_escapes() {
+        // `from_str_radix` accepts a leading sign, so `%+A` must not decode.
+        assert_eq!(cwd("file:///home/a%+A"), Some("/home/a%+A".into()));
+        assert_eq!(cwd("file:///home/a% 1"), Some("/home/a% 1".into()));
+    }
+
+    #[test]
+    fn current_directory_rejects_invalid_utf8_escapes() {
+        // Decoding must still yield valid UTF-8.
+        assert_eq!(cwd("file:///home/%FF%FE"), None);
+    }
+
+    /// The unit tests above call the helper directly; this drives a real
+    /// terminal through the parser so the OSC 7 wiring is covered too.
+    #[cfg(not(windows))]
+    #[test]
+    fn osc7_sets_current_directory_end_to_end() {
+        use crate::ansi::CursorShape;
+        use crate::crosswords::{Crosswords, CrosswordsSize};
+        use crate::event::{VoidListener, WindowId};
+        use crate::performer::handler::Processor;
+
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(20, 5),
+            CursorShape::Block,
+            VoidListener,
+            WindowId::from(0),
+            0,
+            10,
+        );
+        let mut processor = Processor::default();
+
+        processor.advance(&mut term, b"\x1b]7;file:///home/My%20Files\x1b\\");
+        assert_eq!(
+            term.current_directory.as_deref(),
+            Some(std::path::Path::new("/home/My Files"))
+        );
+    }
 }


### PR DESCRIPTION
The url crate was worth 29 of rio-vt's 83 dependencies: idna, the ICU normalizer and collections, zerovec, yoke, and a handful of proc-macros that also serialize the build. All of it to service one call, Url::parse on an OSC 7 payload so we could read .path(). Parsing file://<host>/<path> by hand puts the core at 54 crates.

I checked this against other implementations before writing it. foot decodes in uri.c with essentially the same loop (find %, validate two nibbles, otherwise pass the byte through), and ghostty goes through std.Uri in reportPwd and takes the raw path. Both also check the scheme. alacritty turns out not to implement OSC 7 at all, and wezterm just stores the parsed Url and defers to its consumers. Two behaviour differences fall out of doing it directly, and I think both are fixes:

- The scheme is now checked. Url::parse accepts any scheme and we used whatever path came back, so `http://evil/x` would set the working directory. foot requires `file`, ghostty requires `file` or `kitty-shell-cwd`.
- The path is percent-decoded. `Url::path()` returns the still-encoded form, so `/home/My Files` was arriving as `/home/My%20Files`. Shells emit encoded paths (vte-urlencode-cwd and its equivalents), so the old output was wrong for anything outside `[A-Za-z0-9/._-]`.

A malformed escape (`100%`, `a%zz`, a truncated `a%2`) is passed through literally instead of discarding the directory, which is what foot does. Dot segments are no longer collapsed, which PathBuf copes with. Tests cover the empty and named host forms, case-insensitive scheme, rejection of non-file and schemeless payloads, decoding including multi-byte UTF-8, malformed escapes, invalid UTF-8, and query/fragment stripping.

One thing I deliberately left out: foot and ghostty both refuse a payload whose host is not the local machine, so an ssh session cannot set your local pwd. ghostty's comment calls that the best practice, and it is. But matching a hostname is fuzzier than it looks (shells send `$HOSTNAME`, which is often not what gethostname returns, .local suffixes, and so on) and rio has never checked it, so silently dropping OSC 7 for some users belongs in its own change rather than riding along here.

Workspace builds, tests, fmt and clippy --all-targets --all-features are clean.