### PR TITLE
rio-vt: own the terminal size type instead of borrowing teletypewriter's

### DIFF
--- a/frontends/rioterm/src/messenger.rs
+++ b/frontends/rioterm/src/messenger.rs
@@ -1,6 +1,6 @@
 use crate::event::Msg;
+use rio_backend::event::WindowSize;
 use std::borrow::Cow;
-use teletypewriter::WinsizeBuilder;
 
 pub struct Messenger {
     pub channel: corcovado::channel::Sender<Msg>,
@@ -28,7 +28,7 @@ impl Messenger {
     }
 
     #[inline]
-    pub fn send_resize(&self, new_size: WinsizeBuilder) -> Result<&str, String> {
+    pub fn send_resize(&self, new_size: WindowSize) -> Result<&str, String> {
         match self.channel.send(Msg::Resize(new_size)) {
             Ok(..) => Ok("Resized"),
             Err(..) => Err("Error sending message".to_string()),

--- a/frontends/rioterm/src/renderer/utils.rs
+++ b/frontends/rioterm/src/renderer/utils.rs
@@ -43,10 +43,10 @@ pub fn padding_top_from_config(
 }
 
 #[inline]
-pub fn terminal_dimensions(layout: &ContextDimension) -> teletypewriter::WinsizeBuilder {
+pub fn terminal_dimensions(layout: &ContextDimension) -> rio_backend::event::WindowSize {
     let width = layout.width - layout.margin.left - layout.margin.right;
     let height = layout.height - layout.margin.top - layout.margin.bottom;
-    teletypewriter::WinsizeBuilder {
+    rio_backend::event::WindowSize {
         width: width as u16,
         height: height as u16,
         cols: layout.columns as u16,

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -15,6 +15,7 @@ use rio_vt::ansi::CursorShape;
 use rio_vt::crosswords::pos::{Column as PosColumn, Line, Pos, Side};
 use rio_vt::crosswords::{Crosswords, Mode};
 use rio_vt::event::sync::FairMutex;
+use rio_vt::event::WindowSize;
 use rio_vt::event::{EventListener, Msg, RioEvent, WindowId};
 use rio_vt::performer::Machine;
 use rio_vt::selection::{Selection, SelectionType};
@@ -26,7 +27,6 @@ use std::sync::{Arc, Mutex};
 use teletypewriter::create_pty;
 #[cfg(not(target_os = "windows"))]
 use teletypewriter::create_pty_with_spawn;
-use teletypewriter::WinsizeBuilder;
 
 pub type SurfaceId = usize;
 
@@ -330,7 +330,7 @@ impl Surface {
             rows: rows as usize,
             cols: cols as usize,
         });
-        let _ = self.channel.send(Msg::Resize(WinsizeBuilder {
+        let _ = self.channel.send(Msg::Resize(WindowSize {
             rows,
             cols,
             width: pixel_width,

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -14,7 +14,6 @@ use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
-use teletypewriter::WinsizeBuilder;
 
 #[cfg(feature = "rio-window")]
 use rio_window::event_loop::EventLoopProxy;
@@ -53,6 +52,29 @@ impl From<rio_window::window::WindowId> for WindowId {
     }
 }
 
+/// Terminal viewport size, in cells and in pixels.
+///
+/// Owned by the core so the event model does not name the PTY layer's type
+/// for four integers; the PTY driver converts at its own boundary.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WindowSize {
+    pub rows: u16,
+    pub cols: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+impl From<WindowSize> for teletypewriter::WinsizeBuilder {
+    fn from(size: WindowSize) -> Self {
+        Self {
+            rows: size.rows,
+            cols: size.cols,
+            width: size.width,
+            height: size.height,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum RioEventType {
     Rio(RioEvent),
@@ -68,7 +90,7 @@ pub enum Msg {
     #[allow(dead_code)]
     Shutdown,
 
-    Resize(WinsizeBuilder),
+    Resize(WindowSize),
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -213,7 +235,7 @@ pub enum RioEvent {
     /// Request to write the text area size to the PTY of `route_id`.
     TextAreaSizeRequest(
         usize,
-        Arc<dyn Fn(WinsizeBuilder) -> String + Sync + Send + 'static>,
+        Arc<dyn Fn(WindowSize) -> String + Sync + Send + 'static>,
     ),
 
     /// Cursor blinking state has changed.
@@ -384,7 +406,7 @@ impl From<EventPayload> for RioWindowEvent<EventPayload> {
 }
 
 pub trait OnResize {
-    fn on_resize(&mut self, window_size: WinsizeBuilder);
+    fn on_resize(&mut self, window_size: WindowSize);
 }
 
 /// Event Loop for notifying the renderer about terminal events.

--- a/rio-vt/src/performer/mod.rs
+++ b/rio-vt/src/performer/mod.rs
@@ -243,7 +243,7 @@ where
             match msg {
                 Msg::Input(input) => state.write_list.push_back(input),
                 Msg::Resize(window_size) => {
-                    let _ = self.pty.set_winsize(window_size);
+                    let _ = self.pty.set_winsize(window_size.into());
                 }
                 Msg::Shutdown => return false,
             }


### PR DESCRIPTION
`Msg::Resize`, `RioEvent::TextAreaSizeRequest` and `OnResize` all carried `teletypewriter::WinsizeBuilder`, so anything that touched the event model had to name the PTY crate's type for what is four `u16`s. The core now has its own `WindowSize`, and the PTY driver converts to `WinsizeBuilder` at the single place it calls `set_winsize`, which is where knowledge of the PTY layer belongs.

The practical effect is on embedders: one that hands rio-vt an already-open PTY, or that drives the parser and never opens one at all, no longer needs teletypewriter in its own API surface just to resize a terminal. `From<WindowSize> for WinsizeBuilder` is public for anyone calling `set_winsize` directly.

Call-site churn is small: rioterm's `terminal_dimensions` and `Messenger::send_resize` and librio's resize path now name `WindowSize`. I also checked it against the Zed terminal, which drives `Machine` with its own PTY: combined with the re-exports you added in b99ba187f9, `rio-vt` becomes its only direct rio dependency, with teletypewriter and corcovado reached through `rio_vt::` instead of being duplicated in its manifest. Workspace tests, fmt and clippy --all-targets --all-features are clean, plus Zed's 94 terminal tests against this branch.