### PR TITLE
rio-vt: fix visible viewport under DECSTBM, and expose keyboard and cell-text accessors

### DIFF
--- a/rio-vt/src/crosswords/grid/mod.rs
+++ b/rio-vt/src/crosswords/grid/mod.rs
@@ -582,6 +582,25 @@ use crate::crosswords::square::Square;
 use crate::crosswords::style::{Style, StyleId};
 
 impl Grid<Square> {
+    /// The full text of the cell at `pos`: its base character followed by any
+    /// zero-width marks (combining accents, ZWJ joiners, variation selectors).
+    ///
+    /// Prefer this over [`Square::c`], which returns the base character alone
+    /// and so drops the marks. Reading the marks by hand also needs a guard
+    /// that is easy to miss: a background-only cell reuses the extras-id bits
+    /// for its color, so `extras_id()` on one yields a colour channel rather
+    /// than an id.
+    pub fn cell_text(&self, pos: Pos) -> impl Iterator<Item = char> + '_ {
+        let square = self[pos];
+        let marks = square
+            .extras_id()
+            .filter(|_| !square.is_bg_only())
+            .and_then(|id| self.extras_table.get(id))
+            .map(|extras| extras.zerowidth.as_slice())
+            .unwrap_or(&[]);
+        std::iter::once(square.c()).chain(marks.iter().copied())
+    }
+
     /// Free extras slots no longer referenced by any cell.
     ///
     /// Cells are overwritten and rows drop off the scrollback ring without

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -1880,13 +1880,7 @@ impl<U: EventListener> Crosswords<U> {
         extras: &mut rustc_hash::FxHashMap<u16, crate::crosswords::square::Extras>,
     ) {
         use crate::event::TerminalDamage;
-        let mut start = self.scroll_region.start.0;
-        let mut end = self.scroll_region.end.0;
-        let scroll = self.display_offset() as i32;
-        if scroll != 0 {
-            start -= scroll;
-            end -= scroll;
-        }
+        let (start, end) = self.visible_line_bounds();
         let count = (end - start) as usize;
 
         let _ = cols;
@@ -1968,19 +1962,26 @@ impl<U: EventListener> Crosswords<U> {
         }
     }
 
+    /// Half-open grid line range currently on screen, as `(start, end)`.
+    ///
+    /// This is the full screen height offset by the scrollback position, and
+    /// deliberately has nothing to do with `scroll_region`: DECSTBM bounds
+    /// where scrolling happens, not what is displayed. Both were once read
+    /// from `scroll_region`, so an app that narrowed it (vim, less, htop,
+    /// tmux, man) lost rows off the snapshot.
+    #[inline]
+    fn visible_line_bounds(&self) -> (i32, i32) {
+        let scroll = self.display_offset() as i32;
+        (-scroll, self.grid.screen_lines() as i32 - scroll)
+    }
+
     /// Copy the visible viewport into `dst` in place. Reuses both the
     /// outer `Vec`'s capacity and each inner `Row`'s `Vec<Square>`
     /// allocation (via [`Row::copy_from`]) so the renderer's frame
     /// buffer doesn't reallocate every frame at steady state.
     #[inline]
     pub fn fill_visible_rows(&self, dst: &mut Vec<Row<Square>>) {
-        let mut start = self.scroll_region.start.0;
-        let mut end = self.scroll_region.end.0;
-        let scroll = self.display_offset() as i32;
-        if scroll != 0 {
-            start -= scroll;
-            end -= scroll;
-        }
+        let (start, end) = self.visible_line_bounds();
         let count = (end - start) as usize;
 
         // Copy each visible row into the matching slot. Excess slots
@@ -7730,5 +7731,64 @@ mod tests {
 
         // Cursor must be untouched.
         assert_eq!(cw.grid.cursor.pos, cursor_before);
+    }
+
+    /// DECSTBM bounds where scrolling happens, not what is on screen. Both
+    /// shapes matter: `1;N` only shrinks `end`, so a fix that just zeroed
+    /// `start` would pass that case while still dropping the bottom rows.
+    #[test]
+    fn visible_rows_ignore_the_scroll_region() {
+        use crate::performer::handler::Processor;
+        fn term_with_lines(rows: usize) -> (Crosswords<VoidListener>, Processor) {
+            let mut term = Crosswords::new(
+                CrosswordsSize::new(20, rows),
+                CursorShape::Block,
+                VoidListener,
+                crate::event::WindowId::from(0),
+                0,
+                100,
+            );
+            let mut parser = Processor::default();
+            for i in 0..rows {
+                parser
+                    .advance(&mut term, format!("\x1b[{};1Hline{}", i + 1, i).as_bytes());
+            }
+            (term, parser)
+        }
+
+        let first_row_text = |term: &Crosswords<VoidListener>| -> String {
+            let rows = term.visible_rows();
+            (0..5).map(|c| rows[0][Column(c)].c()).collect()
+        };
+
+        // Region narrowed at both ends: full height, no vertical shift.
+        let (mut term, mut parser) = term_with_lines(10);
+        parser.advance(&mut term, b"\x1b[2;8r");
+        assert_eq!(term.screen_lines(), 10);
+        assert_eq!(term.visible_rows().len(), 10);
+        assert_eq!(first_row_text(&term), "line0");
+
+        // Region narrowed at the bottom only, as vim does around its status
+        // line: the last row must still be reported.
+        let (mut term, mut parser) = term_with_lines(10);
+        parser.advance(&mut term, b"\x1b[1;9r");
+        assert_eq!(term.visible_rows().len(), 10);
+        assert_eq!(first_row_text(&term), "line0");
+
+        // Same on the alternate screen.
+        let (mut term, mut parser) = term_with_lines(6);
+        parser.advance(&mut term, b"\x1b[?1049h\x1b[1;3r");
+        assert_eq!(term.visible_rows().len(), 6);
+
+        // Scrolled into history, the viewport still spans the screen height
+        // and starts one line up per scrolled line.
+        let (mut term, mut parser) = term_with_lines(4);
+        for i in 0..4 {
+            parser.advance(&mut term, format!("\r\nscroll{i}").as_bytes());
+        }
+        parser.advance(&mut term, b"\x1b[2;3r");
+        term.scroll_display(crate::crosswords::grid::Scroll::Delta(2));
+        assert_eq!(term.display_offset(), 2);
+        assert_eq!(term.visible_rows().len(), 4);
     }
 }

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -462,6 +462,7 @@ where
     pub damage_event_in_flight: bool,
 
     // The stack for the keyboard modes.
+    modify_other_keys: u8,
     keyboard_mode_stack: [u8; KEYBOARD_MODE_STACK_MAX_DEPTH],
     keyboard_mode_idx: usize,
     inactive_keyboard_mode_stack: [u8; KEYBOARD_MODE_STACK_MAX_DEPTH],
@@ -518,6 +519,7 @@ impl<U: EventListener> Crosswords<U> {
             current_directory: None,
             user_vars: rustc_hash::FxHashMap::default(),
             damage_event_in_flight: false,
+            modify_other_keys: 0,
             keyboard_mode_stack: Default::default(),
             keyboard_mode_idx: 0,
             inactive_keyboard_mode_stack: Default::default(),
@@ -2025,6 +2027,28 @@ impl<U: EventListener> Crosswords<U> {
         self.mark_fully_damaged();
     }
 
+    /// The active xterm `modifyOtherKeys` level, or `None` when disabled.
+    ///
+    /// Set by `CSI > 4 ; n m`. An embedder that encodes key events needs this
+    /// to know whether the application wants keys like ctrl+enter reported as
+    /// `CSI 27 ; …` rather than as their legacy control bytes.
+    #[inline]
+    pub fn modify_other_keys(&self) -> Option<u8> {
+        (self.modify_other_keys > 0).then_some(self.modify_other_keys)
+    }
+
+    /// The kitty keyboard protocol flags currently in effect, i.e. the top of
+    /// the mode stack. This is the same value the terminal reports back to the
+    /// application, so an embedder encoding key events itself does not have to
+    /// rebuild the flag byte out of [`Mode`] bits and keep that bit order in
+    /// sync by hand.
+    #[inline]
+    pub fn keyboard_mode(&self) -> KeyboardModes {
+        KeyboardModes::from_bits_truncate(
+            self.keyboard_mode_stack[self.keyboard_mode_idx],
+        )
+    }
+
     pub fn mode(&self) -> Mode {
         self.mode
     }
@@ -2948,6 +2972,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
         self.scroll_region = Line(0)..Line(self.grid.screen_lines() as i32);
         self.tabs = TabStops::new(self.grid.columns());
         self.title_stack = Vec::new();
+        self.modify_other_keys = 0;
         self.keyboard_mode_stack = [0; KEYBOARD_MODE_STACK_MAX_DEPTH];
         self.inactive_keyboard_mode_stack = [0; KEYBOARD_MODE_STACK_MAX_DEPTH];
         self.keyboard_mode_idx = 0;
@@ -3504,6 +3529,11 @@ impl<U: EventListener> Handler for Crosswords<U> {
         let text = format!("\x1bP>|Rio {version}\x1b\\");
         self.event_proxy
             .send_event(RioEvent::PtyWrite(self.route_id, text), self.window_id);
+    }
+
+    #[inline]
+    fn set_modify_other_keys(&mut self, level: u8) {
+        self.modify_other_keys = level;
     }
 
     #[inline]
@@ -7790,5 +7820,126 @@ mod tests {
         term.scroll_display(crate::crosswords::grid::Scroll::Delta(2));
         assert_eq!(term.display_offset(), 2);
         assert_eq!(term.visible_rows().len(), 4);
+    }
+
+    /// The flag byte an embedder needs to encode keys is the one the terminal
+    /// would report; it must survive set, push and pop.
+    #[test]
+    fn keyboard_mode_reports_the_active_flags() {
+        use crate::performer::handler::Processor;
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(10, 3),
+            CursorShape::Block,
+            VoidListener,
+            crate::event::WindowId::from(0),
+            0,
+            10,
+        );
+        let mut parser = Processor::default();
+        assert_eq!(term.keyboard_mode(), KeyboardModes::NO_MODE);
+
+        // CSI = 5 ; 1 u -> disambiguate + report alternate keys.
+        parser.advance(&mut term, b"\x1b[=5;1u");
+        assert_eq!(
+            term.keyboard_mode(),
+            KeyboardModes::DISAMBIGUATE_ESC_CODES | KeyboardModes::REPORT_ALTERNATE_KEYS
+        );
+
+        // Pushing a new mode shadows it, popping restores it.
+        parser.advance(&mut term, b"\x1b[>1u");
+        assert_eq!(term.keyboard_mode(), KeyboardModes::DISAMBIGUATE_ESC_CODES);
+        parser.advance(&mut term, b"\x1b[<1u");
+        assert_eq!(
+            term.keyboard_mode(),
+            KeyboardModes::DISAMBIGUATE_ESC_CODES | KeyboardModes::REPORT_ALTERNATE_KEYS
+        );
+    }
+
+    /// `c()` alone drops combining marks, which is the trap `cell_text`
+    /// exists to close. Also covers the bg-only guard: those cells reuse the
+    /// extras-id bits for colour, so an unguarded lookup reads a channel as
+    /// an id.
+    #[test]
+    fn cell_text_includes_zero_width_marks() {
+        use crate::performer::handler::Processor;
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(10, 2),
+            CursorShape::Block,
+            VoidListener,
+            crate::event::WindowId::from(0),
+            0,
+            10,
+        );
+        let mut parser = Processor::default();
+        // "e" + U+0301 COMBINING ACUTE, then "X".
+        parser.advance(&mut term, "e\u{0301}X".as_bytes());
+
+        let cell = Pos::new(Line(0), Column(0));
+        assert_eq!(term.grid[cell].c(), 'e', "base char only");
+        assert_eq!(
+            term.grid.cell_text(cell).collect::<String>(),
+            "e\u{0301}",
+            "cell_text keeps the mark"
+        );
+        assert_eq!(
+            term.grid
+                .cell_text(Pos::new(Line(0), Column(1)))
+                .collect::<String>(),
+            "X"
+        );
+
+        // A background-only cell has no text and must not read its colour
+        // bits as an extras id.
+        let bg = Pos::new(Line(1), Column(0));
+        term.grid[bg].set_bg_rgb(0xAA, 0xBB, 0xCC);
+        assert!(term.grid[bg].is_bg_only());
+        assert_eq!(
+            term.grid.cell_text(bg).collect::<String>(),
+            "\0",
+            "bg-only cell is blank, with no marks"
+        );
+    }
+
+    /// modifyOtherKeys has no Mode bit, so without this an embedder has to
+    /// sniff raw PTY bytes outside the parser to find it.
+    #[test]
+    fn modify_other_keys_tracks_the_level() {
+        use crate::performer::handler::Processor;
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(10, 2),
+            CursorShape::Block,
+            VoidListener,
+            crate::event::WindowId::from(0),
+            0,
+            10,
+        );
+        let mut parser = Processor::default();
+        assert_eq!(term.modify_other_keys(), None);
+
+        parser.advance(&mut term, b"\x1b[>4;2m");
+        assert_eq!(term.modify_other_keys(), Some(2));
+
+        parser.advance(&mut term, b"\x1b[>4;1m");
+        assert_eq!(term.modify_other_keys(), Some(1));
+
+        // No level, and an explicit 0, both disable it.
+        parser.advance(&mut term, b"\x1b[>4m");
+        assert_eq!(term.modify_other_keys(), None);
+        parser.advance(&mut term, b"\x1b[>4;2m\x1b[>4;0m");
+        assert_eq!(term.modify_other_keys(), None);
+
+        // Another resource must not be mistaken for modifyOtherKeys, and an
+        // out-of-range level must not reach an embedder as a level it cannot
+        // interpret.
+        parser.advance(&mut term, b"\x1b[>2;2m");
+        assert_eq!(term.modify_other_keys(), None);
+        parser.advance(&mut term, b"\x1b[>4;7m");
+        assert_eq!(term.modify_other_keys(), None);
+
+        // RIS clears it, like the other keyboard state.
+        parser.advance(&mut term, b"\x1b[>4;2m");
+        assert_eq!(term.modify_other_keys(), Some(2));
+        parser.advance(&mut term, b"\x1bc");
+        assert_eq!(term.modify_other_keys(), None);
     }
 }

--- a/rio-vt/src/crosswords/square.rs
+++ b/rio-vt/src/crosswords/square.rs
@@ -259,6 +259,11 @@ impl Square {
         self.0
     }
 
+    /// The cell's base character only.
+    ///
+    /// This is **not** the cell's full text: combining marks, ZWJ joiners and
+    /// variation selectors live in [`Extras::zerowidth`], so reading only this
+    /// silently drops them. Use `Grid::cell_text` when you want the text.
     #[inline]
     pub fn c(self) -> char {
         let cp = ((self.0 >> CODEPOINT_SHIFT) & CODEPOINT_MASK) as u32;

--- a/rio-vt/src/performer/handler.rs
+++ b/rio-vt/src/performer/handler.rs
@@ -417,6 +417,10 @@ pub trait Handler {
     /// Handle XTGETTCAP response.
     fn xtgettcap_response(&mut self, _response: String) {}
 
+    /// xterm `modifyOtherKeys` level, from `CSI > 4 ; n m`. Level 0 disables
+    /// it, 1 and 2 widen how many modified keys are reported as `CSI 27 ; …`.
+    fn set_modify_other_keys(&mut self, _level: u8) {}
+
     /// Send a kitty graphics protocol response
     fn kitty_graphics_response(&mut self, _response: String) {}
 
@@ -1442,6 +1446,18 @@ impl<U: Handler> Perform for Performer<'_, U> {
                     _ => KeyboardModesApplyBehavior::Replace,
                 };
                 handler.set_keyboard_mode(mode, behavior);
+            }
+            // xterm modifyOtherKeys. Resource 4 is the only one we model;
+            // `CSI > 4 m` with no level resets to 0, i.e. disabled.
+            ('m', [b'>']) => {
+                let resource = next_param_or(0);
+                let level = next_param_or(0);
+                // xterm defines levels 0, 1 and 2 only; anything else would
+                // reach embedders as a level they cannot interpret.
+                match (resource, level) {
+                    (4, 0..=2) => handler.set_modify_other_keys(level as u8),
+                    _ => csi_unhandled!(),
+                }
             }
             ('u', [b'>']) => {
                 let mode = KeyboardModes::from_bits_truncate(next_param_or(0) as u8);


### PR DESCRIPTION
Four findings from ratty's review of rio-vt as an embedder, §1-§4. Two commits: the correctness fix first, then the API additions.

### The viewport bug (§1)

`fill_visible_rows` and `snapshot_visible` both walked `scroll_region.start..scroll_region.end`, so any application that narrows the region with DECSTBM lost rows off the snapshot while `screen_lines()` kept reporting the full height. vim, less, htop, top, tmux and man all narrow it. On a 10-row grid `CSI 2;8r` returned 7 rows starting at grid line 1.

This reached our own renderer: `renderer/mod.rs` fills `renderable_content.visible_rows` from `snapshot_visible` and draws from it. The reason it has not been reported is the common shape. Apps mostly send `CSI 1;Nr`, where `start` stays 0 so nothing shifts vertically and only the bottom row or two fall out of the snapshot, which reads as stale bottom rows rather than a mangled screen. The nastier `start > 0` case shifts the whole viewport up.

I checked the two implementations worth checking against, and both keep these concepts apart. alacritty's `Grid::display_iter` derives its range from `screen_lines()` and the display offset. ghostty separates them so firmly that `PageList`, which owns every viewport and row iterator, contains no reference to `scrolling_region` at all: the region lives in `Terminal.zig` for cursor and scroll operations only.

Both call sites now share one `visible_line_bounds()`. Having the arithmetic written out twice is how the two came to disagree with `screen_lines()`, and the copies would drift again. The regression test covers `CSI 2;8r`, `CSI 1;9r`, the alternate screen and a scrolled-back viewport; I confirmed it fails (7 vs 10) against the old bounds before keeping it.

### The API gaps (§2-§4)

- `keyboard_mode()` returns the live kitty keyboard flags, the same byte `report_keyboard_mode` sends back. Otherwise every embedder rebuilds it from `Mode` bits and inherits a bit-order contract that will drift. Tested through set, push and pop.
- **modifyOtherKeys is now parsed and tracked**, with `modify_other_keys() -> Option<u8>`. `CSI > 4 ; n m` had no `Mode` bit and no handler, and the suggested workaround of sniffing PTY bytes cannot be made reliable: reads split anywhere, and a scanner matches bytes inside DCS/OSC payloads the parser is consuming as data. Level 0 and an absent level both disable it, other resources stay unhandled, and RIS clears it with the rest of the keyboard state.
- `Grid::cell_text()` yields a cell's base character followed by its zero-width marks, and `Square::c()`'s doc now says it is not the cell's text. Worth noting how sharp the manual path is: `EXTRAS_ID_SHIFT` is 48 and `BG_RGB_B_SHIFT` is also 48, so `extras_id()` on a background-only cell returns a blue channel as an extras id. The helper guards on `is_bg_only()`; the test covers both the combining-mark case and that guard.

I did not take §3's fallback suggestion of surfacing unhandled CSI sequences to the `EventListener`. It is a good idea and more general, but it is a new event-model surface rather than a fix, so it deserves its own change.

Workspace tests (437 in rio-vt), fmt and clippy --all-targets --all-features are clean.