### PR TITLE
rio-vt: survive wide glyphs on a one-column grid

### DIFF
--- a/rio-vt/src/crosswords/grid/resize.rs
+++ b/rio-vt/src/crosswords/grid/resize.rs
@@ -405,12 +405,32 @@ impl Grid<Square> {
                 if row.len() >= columns
                     && matches!(row[Column(columns - 1)].wide(), Wide::Wide)
                 {
-                    let mut spacer = Square::default();
-                    spacer.set_wide(Wide::LeadingSpacer);
+                    if columns < 2 {
+                        // Displacing the char into the next row would never
+                        // terminate here: column 0 is also the last column,
+                        // so it would be displaced again every iteration
+                        // while `new_raw` grew without bound. Destroy the
+                        // wide char and leave a blank narrow cell, which is
+                        // what ghostty does reflowing to one column
+                        // (`PageList.zig`, ReflowCursor), and drop the
+                        // Spacer that followed it so it cannot claim a row
+                        // of its own.
+                        row[Column(columns - 1)] = Square::default();
+                        while matches!(
+                            wrapped.first().map(|cell| cell.wide()),
+                            Some(Wide::Spacer)
+                        ) {
+                            wrapped.remove(0);
+                        }
+                    } else {
+                        let mut spacer = Square::default();
+                        spacer.set_wide(Wide::LeadingSpacer);
 
-                    let wide_char = mem::replace(&mut row[Column(columns - 1)], spacer);
-                    wrapped.insert(0, wide_char);
-                    displaced = 1;
+                        let wide_char =
+                            mem::replace(&mut row[Column(columns - 1)], spacer);
+                        wrapped.insert(0, wide_char);
+                        displaced = 1;
+                    }
                 }
 
                 // Remove wide char spacer before shrinking.

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -1510,6 +1510,20 @@ impl<U: EventListener> Crosswords<U> {
             self.grid[row].kitty_virtual_placeholder = true;
         }
 
+        // A one-column grid can never hold a wide pair, and the wrap-for-room
+        // branch below cannot create room on it: wrapping lands back on
+        // column 0, which is still the last column. Drop the glyph and leave
+        // a blank narrow cell, as ghostty does for the same degenerate size
+        // (`Terminal.zig`, the else branch of the `width == 2` arm), rather
+        // than running the Spacer off the end of the row. Embedders are
+        // entitled to such a grid: drag-resize and tiling layouts produce
+        // them transiently.
+        let (c, width) = if width == 2 && columns < 2 {
+            (' ', 1)
+        } else {
+            (c, width)
+        };
+
         if width == 2 {
             if self.grid.cursor.pos.col + 1 >= columns {
                 if self.mode.contains(Mode::LINE_WRAP) {
@@ -1715,6 +1729,12 @@ impl<U: EventListener> Crosswords<U> {
     #[inline(never)]
     fn apply_emoji_vs16(&mut self) {
         let columns = self.grid.columns();
+        // No wide pair fits on one column, so leave the base narrow: the
+        // wrap branch below would place the trailing Spacer at column 1 of
+        // the new row, off the end of it.
+        if columns < 2 {
+            return;
+        }
         let row = self.grid.cursor.pos.row;
         let cursor_col = self.grid.cursor.pos.col.0;
         let should_wrap = self.grid.cursor.should_wrap;
@@ -7941,5 +7961,59 @@ mod tests {
         assert_eq!(term.modify_other_keys(), Some(2));
         parser.advance(&mut term, b"\x1bc");
         assert_eq!(term.modify_other_keys(), None);
+    }
+    /// A grid one column wide cannot hold a wide pair. Every path that can
+    /// place or preserve one has to cope: the per-cell write, the bulk wide
+    /// run, the VS16 promotion that widens an already-written cell, and the
+    /// reflow that shrinks a grid under existing wide content. Before this
+    /// was handled the first two panicked out of bounds and the last looped
+    /// forever, growing the new row buffer without bound.
+    #[test]
+    fn one_column_grid_handles_wide_glyphs() {
+        use crate::performer::handler::Processor;
+
+        let feed = |cols: usize, bytes: &[u8]| {
+            let mut term = Crosswords::new(
+                CrosswordsSize::new(cols, 3),
+                CursorShape::Block,
+                VoidListener,
+                crate::event::WindowId::from(0),
+                0,
+                100,
+            );
+            Processor::default().advance(&mut term, bytes);
+            term
+        };
+
+        // The reported repro: one wide char, one column. The glyph cannot be
+        // represented, so it is dropped for a blank narrow cell, matching
+        // ghostty on the same degenerate size.
+        let term = feed(1, "你".as_bytes());
+        let cell = term.grid[Pos::new(Line(0), Column(0))];
+        assert!(!cell.is_wide(), "nothing to pair a wide cell with");
+        assert!(!cell.is_spacer(), "and no orphaned Spacer either");
+        assert_eq!(cell.c(), ' ');
+
+        for cols in [1, 2] {
+            feed(cols, "你好世界".as_bytes());
+            feed(cols, "🦀".as_bytes());
+            feed(cols, "\u{2764}\u{FE0F}".as_bytes());
+            feed(cols, "你\u{0301}".as_bytes());
+            feed(cols, "你\r\n好\r\n世".as_bytes());
+            feed(cols, "\x1b[?1049h你好".as_bytes());
+            feed(cols, "\x1b[1;2r你好".as_bytes());
+        }
+
+        // Shrinking under existing wide content, then writing, then growing.
+        // Reflowing to one column destroys the wide chars, so no row should
+        // come out of it still claiming to be wide or a Spacer.
+        let mut term = feed(4, "你好".as_bytes());
+        term.resize(CrosswordsSize::new(1, 3));
+        for row in term.visible_rows() {
+            let cell = row[Column(0)];
+            assert!(!cell.is_wide() && !cell.is_spacer());
+        }
+        Processor::default().advance(&mut term, "世".as_bytes());
+        term.resize(CrosswordsSize::new(4, 3));
     }
 }


### PR DESCRIPTION
ratty's §12: writing a double-width character into a 1-column grid panics out of bounds. Investigating it turned up three sites with one cause, and the third is worse than the reported symptom.

A wide glyph needs a second cell for its trailing `Spacer`, and on a single column there is never one. The usual escape hatch, wrapping to make room, cannot help either: the new row's column 0 is also its last column.

- **`write_codepoint_cell`** fell through its wrap-for-room branch and wrote the `Spacer` at column 1. This is the reported panic.
- **`apply_emoji_vs16`**, which promotes an already-written cell to wide, did the same after wrapping. The report's single repro does not reach this path; a wider test does.
- **`shrink_columns` hangs rather than panics.** With one column, `Column(columns - 1)` *is* column 0, so the reflow swapped the wide char for a `LeadingSpacer` and displaced it into the next row, where it landed at column 0 and was displaced again on the next iteration, forever, while `new_raw` grew without bound. I found it by watching two test processes spin after the first two fixes, then reading the loop. A hang with runaway memory is a worse failure than a clean panic, so this is the most valuable part of the report.

### Following ghostty

ghostty has settled both halves of this, so this PR does what it does rather than inventing a third behaviour.

Its fast path refuses the case outright, commenting "A degenerate 1-wide region can't hold a wide char; print() has special handling so fall back to it" (`Terminal.zig:635`), and `print`'s `width == 2` arm ends in an explicit degenerate branch (`Terminal.zig:1212`):

```zig
} else {
    // This is pretty broken, terminals should never be only 1-wide.
    // We should prevent this downstream.
    self.screens.active.cursorMarkDirty();
    self.printCell(0, .narrow);
},
```

Its reflow cursor has the identical case (`PageList.zig:1507`):

```zig
} else {
    // Edge case, when resizing to 1 column, wide
    // characters are just destroyed and replaced
    // with empty narrow cells.
    self.page_cell.content.codepoint = 0;
    self.page_cell.wide = .narrow;
    self.cursorForward();

    // Skip spacer tail so it doesn't cause a wrap.
    return .skip_next;
```

So both paths here drop the glyph for a blank narrow cell, and reflow also drops the `Spacer` that followed it so it cannot claim a row of its own — that last part I had missed until reading ghostty, and without it a reflowed row keeps a stray spacer. A VS16 promotion is simply declined, leaving the base narrow, which loses nothing already on screen.

I did consider keeping the character as a clipped narrow cell instead of dropping it, since §12 allowed either ("drop or replace"). Matching ghostty is the better call: a wide glyph in one cell is not representable, and two engines disagreeing on it is how embedders end up with divergent snapshots.

On the other alternative, clamping to a two-column floor: alacritty does effectively that, and it is what ratty worked around with, but it silently hands back a size the embedder did not ask for, which then disagrees with their own layout maths.

One thing I checked and want to correct from an earlier draft of this description: ghostty's guard is `right_limit - scrolling_region.left > 1`, which also covers a degenerate *horizontal margin* region. rio has no left/right margin support at all — no DECSLRM, no margin state — so `columns < 2` is already the complete condition here and there is no follow-up hiding behind it.

The test covers the reported repro (asserting the cell ends up blank, not wide, with no orphaned spacer), then every wide path at one and two columns: bulk wide runs, emoji, VS16 promotion, a combining mark on a wide base, wrapping, scrolling, the alternate screen, DECSTBM, and a shrink-write-grow cycle that also asserts no row survives the reflow still claiming to be wide. I confirmed each fix is load-bearing by reverting them individually and watching the test fail.

rio-vt and rio-backend suites, fmt and clippy --all-targets --all-features are clean.