### PR TITLE
rio-vt: Drop the unused EventListener::event hook

### DIFF
--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -150,10 +150,6 @@ impl Listener {
 }
 
 impl EventListener for Listener {
-    fn event(&self) -> (Option<RioEvent>, bool) {
-        (None, false)
-    }
-
     fn send_event(&self, event: RioEvent, _id: WindowId) {
         self.dispatch(event);
     }

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -7,7 +7,7 @@ use crate::ansi::kitty_graphics_protocol::{
 };
 use crate::crosswords::pos::{Column, Line, Pos};
 use crate::crosswords::Crosswords;
-use crate::event::{EventListener, RioEvent, WindowId};
+use crate::event::{EventListener, WindowId};
 use crate::performer::handler::Handler;
 use rio_graphics::{ColorType, GraphicData, GraphicId, ResizeCommand, ResizeParameter};
 
@@ -49,11 +49,7 @@ impl Handler for TestHandler {
 #[derive(Clone)]
 struct TestEventListener;
 
-impl EventListener for TestEventListener {
-    fn event(&self) -> (Option<RioEvent>, bool) {
-        (None, false)
-    }
-}
+impl EventListener for TestEventListener {}
 
 // Integration Tests
 

--- a/rio-vt/examples/kitty_image.rs
+++ b/rio-vt/examples/kitty_image.rs
@@ -18,10 +18,6 @@ use std::sync::{Arc, Mutex};
 struct ImageSink(Arc<Mutex<Vec<(u32, usize, usize, usize)>>>);
 
 impl EventListener for ImageSink {
-    fn event(&self) -> (Option<RioEvent>, bool) {
-        (None, false)
-    }
-
     fn send_event(&self, event: RioEvent, _window: WindowId) {
         if let RioEvent::UpdateGraphics { queues, .. } = event {
             let mut sink = self.0.lock().unwrap();

--- a/rio-vt/examples/sixel.rs
+++ b/rio-vt/examples/sixel.rs
@@ -18,10 +18,6 @@ use std::sync::{Arc, Mutex};
 struct GraphicSink(Arc<Mutex<Vec<(u64, usize, usize, usize)>>>);
 
 impl EventListener for GraphicSink {
-    fn event(&self) -> (Option<RioEvent>, bool) {
-        (None, false)
-    }
-
     fn send_event(&self, event: RioEvent, _window: WindowId) {
         if let RioEvent::UpdateGraphics { queues, .. } = event {
             let mut sink = self.0.lock().unwrap();

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -6972,10 +6972,6 @@ mod tests {
         }
 
         impl EventListener for TestListener {
-            fn event(&self) -> (Option<RioEvent>, bool) {
-                (None, false)
-            }
-
             fn send_event(&self, event: RioEvent, _id: WindowId) {
                 self.events.borrow_mut().push(event);
             }
@@ -7031,10 +7027,6 @@ mod tests {
         }
 
         impl EventListener for TestListener {
-            fn event(&self) -> (Option<RioEvent>, bool) {
-                (None, false)
-            }
-
             fn send_event(&self, event: RioEvent, _id: WindowId) {
                 self.events.borrow_mut().push(event);
             }

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -411,8 +411,6 @@ pub trait OnResize {
 
 /// Event Loop for notifying the renderer about terminal events.
 pub trait EventListener {
-    fn event(&self) -> (Option<RioEvent>, bool);
-
     fn send_event(&self, _event: RioEvent, _id: WindowId) {}
 
     fn send_event_with_high_priority(&self, _event: RioEvent, _id: WindowId) {}
@@ -431,11 +429,7 @@ impl From<RioEvent> for RioEventType {
     }
 }
 
-impl EventListener for VoidListener {
-    fn event(&self) -> (std::option::Option<RioEvent>, bool) {
-        (None, false)
-    }
-}
+impl EventListener for VoidListener {}
 
 #[derive(Debug, Clone)]
 #[cfg(feature = "rio-window")]
@@ -456,10 +450,6 @@ impl EventProxy {
 
 #[cfg(feature = "rio-window")]
 impl EventListener for EventProxy {
-    fn event(&self) -> (std::option::Option<RioEvent>, bool) {
-        (None, false)
-    }
-
     fn send_event(&self, event: RioEvent, id: WindowId) {
         let _ = self.proxy.send_event(EventPayload::new(event.into(), id));
     }


### PR DESCRIPTION
`EventListener::event()` was a required trait method with no callers anywhere in the workspace, and every implementor returned `(None, false)`: `VoidListener`, `EventProxy`, librio's `Listener`, both rio-vt examples, and the test listeners in rio-vt and rio-backend. Every other method on the trait already has a default body, so the one required method was the only thing forcing embedders to write code that does nothing.

This removes it. Downstream implementors will need to delete their own override, which is the whole migration.

Release Notes:

- N/A