### PR TITLE
rio-vt: Support X10 mouse reporting (CSI ? 9 h)

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3382,6 +3382,24 @@ impl Screen<'_> {
             return;
         }
 
+        // X10 reports presses of the left, middle and right buttons only, and
+        // never carries modifiers. Motion never reaches here under X10 because
+        // it is gated on MOUSE_MOTION and MOUSE_DRAG, but releases and the
+        // wheel codes (64 and up) do, and neither is reportable. Both are
+        // dropped rather than falling back to local scrolling, since the
+        // protocol still owns the wheel while it is active.
+        if mode.contains(Mode::MOUSE_REPORT_X10) {
+            if state == ElementState::Pressed && button <= 2 {
+                if mode.contains(Mode::SGR_MOUSE) {
+                    self.sgr_mouse_report(pos, button, state);
+                } else {
+                    self.normal_mouse_report(pos, button);
+                }
+            }
+
+            return;
+        }
+
         // Calculate modifiers value.
         let mut mods = 0;
         let mod_state = self.modifiers.state();

--- a/rio-vt/src/ansi/mode.rs
+++ b/rio-vt/src/ansi/mode.rs
@@ -56,6 +56,7 @@ impl PrivateMode {
             3 => Self::Named(NamedPrivateMode::ColumnMode),
             6 => Self::Named(NamedPrivateMode::Origin),
             7 => Self::Named(NamedPrivateMode::LineWrap),
+            9 => Self::Named(NamedPrivateMode::ReportX10MouseClicks),
             12 => Self::Named(NamedPrivateMode::BlinkingCursor),
             25 => Self::Named(NamedPrivateMode::ShowCursor),
             1000 => Self::Named(NamedPrivateMode::ReportMouseClicks),
@@ -106,6 +107,12 @@ pub enum NamedPrivateMode {
     ColumnMode = 3,
     Origin = 6,
     LineWrap = 7,
+    /// X10 mouse reporting.
+    ///
+    /// Reports button presses only: no releases, no motion, and no modifier
+    /// bits. Superseded by [`Self::ReportMouseClicks`], and mutually exclusive
+    /// with it.
+    ReportX10MouseClicks = 9,
     BlinkingCursor = 12,
     ShowCursor = 25,
     ReportMouseClicks = 1000,

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -97,7 +97,8 @@ bitflags! {
         const REPORT_ALTERNATE_KEYS   = 1 << 20;
         const REPORT_ALL_KEYS_AS_ESC  = 1 << 21;
         const REPORT_ASSOCIATED_TEXT  = 1 << 22;
-        const MOUSE_MODE = Self::MOUSE_REPORT_CLICK.bits() | Self::MOUSE_MOTION.bits() | Self::MOUSE_DRAG.bits();
+        const MOUSE_REPORT_X10        = 1 << 23;
+        const MOUSE_MODE = Self::MOUSE_REPORT_CLICK.bits() | Self::MOUSE_MOTION.bits() | Self::MOUSE_DRAG.bits() | Self::MOUSE_REPORT_X10.bits();
         const KITTY_KEYBOARD_PROTOCOL = Self::DISAMBIGUATE_ESC_CODES.bits()
                                       | Self::REPORT_EVENT_TYPES.bits()
                                       | Self::REPORT_ALTERNATE_KEYS.bits()
@@ -2520,6 +2521,12 @@ impl<U: EventListener> Handler for Crosswords<U> {
             NamedPrivateMode::ShowCursor => self.mode.insert(Mode::SHOW_CURSOR),
             NamedPrivateMode::CursorKeys => self.mode.insert(Mode::APP_CURSOR),
             // Mouse protocols are mutually exclusive.
+            NamedPrivateMode::ReportX10MouseClicks => {
+                self.mode.remove(Mode::MOUSE_MODE);
+                self.mode.insert(Mode::MOUSE_REPORT_X10);
+                self.event_proxy
+                    .send_event(RioEvent::MouseCursorDirty, self.window_id);
+            }
             NamedPrivateMode::ReportMouseClicks => {
                 self.mode.remove(Mode::MOUSE_MODE);
                 self.mode.insert(Mode::MOUSE_REPORT_CLICK);
@@ -2602,6 +2609,11 @@ impl<U: EventListener> Handler for Crosswords<U> {
             }
             NamedPrivateMode::ShowCursor => self.mode.remove(Mode::SHOW_CURSOR),
             NamedPrivateMode::CursorKeys => self.mode.remove(Mode::APP_CURSOR),
+            NamedPrivateMode::ReportX10MouseClicks => {
+                self.mode.remove(Mode::MOUSE_REPORT_X10);
+                self.event_proxy
+                    .send_event(RioEvent::MouseCursorDirty, self.window_id);
+            }
             NamedPrivateMode::ReportMouseClicks => {
                 self.mode.remove(Mode::MOUSE_REPORT_CLICK);
                 self.event_proxy
@@ -2647,6 +2659,9 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 NamedPrivateMode::BlinkingCursor => self.blinking_cursor.into(),
                 NamedPrivateMode::ShowCursor => {
                     self.mode.contains(Mode::SHOW_CURSOR).into()
+                }
+                NamedPrivateMode::ReportX10MouseClicks => {
+                    self.mode.contains(Mode::MOUSE_REPORT_X10).into()
                 }
                 NamedPrivateMode::ReportMouseClicks => {
                     self.mode.contains(Mode::MOUSE_REPORT_CLICK).into()
@@ -8007,5 +8022,91 @@ mod tests {
         }
         Processor::default().advance(&mut term, "世".as_bytes());
         term.resize(CrosswordsSize::new(4, 3));
+    }
+
+    /// The mouse protocols are one setting with four states, not four
+    /// independent flags, so the last mode set wins and clears the rest.
+    #[test]
+    fn x10_mouse_mode_displaces_the_other_protocols() {
+        use crate::performer::handler::Processor;
+
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(10, 10),
+            CursorShape::Block,
+            VoidListener,
+            WindowId::from(0),
+            0,
+            10,
+        );
+        let mut parser = Processor::default();
+
+        parser.advance(&mut term, b"\x1b[?9h");
+        assert!(term.mode().contains(Mode::MOUSE_REPORT_X10));
+        assert!(term.mode().intersects(Mode::MOUSE_MODE));
+
+        // 1000 supersedes X10.
+        parser.advance(&mut term, b"\x1b[?1000h");
+        assert!(!term.mode().contains(Mode::MOUSE_REPORT_X10));
+        assert!(term.mode().contains(Mode::MOUSE_REPORT_CLICK));
+
+        // And X10 displaces 1000 in turn.
+        parser.advance(&mut term, b"\x1b[?9h");
+        assert!(term.mode().contains(Mode::MOUSE_REPORT_X10));
+        assert!(!term.mode().contains(Mode::MOUSE_REPORT_CLICK));
+
+        parser.advance(&mut term, b"\x1b[?9l");
+        assert!(!term.mode().intersects(Mode::MOUSE_MODE));
+    }
+
+    /// DECRQM has to answer for mode 9 now that it is tracked, otherwise
+    /// programs cannot tell that their request took effect.
+    #[test]
+    fn x10_mouse_mode_answers_decrqm() {
+        use crate::performer::handler::Processor;
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        #[derive(Clone)]
+        struct TestListener {
+            events: Rc<RefCell<Vec<RioEvent>>>,
+        }
+
+        impl EventListener for TestListener {
+            fn send_event(&self, event: RioEvent, _id: WindowId) {
+                self.events.borrow_mut().push(event);
+            }
+        }
+
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(10, 10),
+            CursorShape::Block,
+            TestListener {
+                events: events.clone(),
+            },
+            WindowId::from(0),
+            0,
+            10,
+        );
+        let mut parser = Processor::default();
+
+        let replies = |events: &Rc<RefCell<Vec<RioEvent>>>| -> Vec<String> {
+            events
+                .borrow()
+                .iter()
+                .filter_map(|event| match event {
+                    RioEvent::PtyWrite(_, text) => Some(text.clone()),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        // Reset (2) before it is set, set (1) after.
+        parser.advance(&mut term, b"\x1b[?9$p");
+        assert_eq!(replies(&events), vec!["\x1b[?9;2$y".to_string()]);
+
+        events.borrow_mut().clear();
+        parser.advance(&mut term, b"\x1b[?9h\x1b[?9$p");
+        assert_eq!(replies(&events), vec!["\x1b[?9;1$y".to_string()]);
     }
 }

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -2609,23 +2609,14 @@ impl<U: EventListener> Handler for Crosswords<U> {
             }
             NamedPrivateMode::ShowCursor => self.mode.remove(Mode::SHOW_CURSOR),
             NamedPrivateMode::CursorKeys => self.mode.remove(Mode::APP_CURSOR),
-            NamedPrivateMode::ReportX10MouseClicks => {
-                self.mode.remove(Mode::MOUSE_REPORT_X10);
-                self.event_proxy
-                    .send_event(RioEvent::MouseCursorDirty, self.window_id);
-            }
-            NamedPrivateMode::ReportMouseClicks => {
-                self.mode.remove(Mode::MOUSE_REPORT_CLICK);
-                self.event_proxy
-                    .send_event(RioEvent::MouseCursorDirty, self.window_id);
-            }
-            NamedPrivateMode::ReportCellMouseMotion => {
-                self.mode.remove(Mode::MOUSE_DRAG);
-                self.event_proxy
-                    .send_event(RioEvent::MouseCursorDirty, self.window_id);
-            }
-            NamedPrivateMode::ReportAllMouseMotion => {
-                self.mode.remove(Mode::MOUSE_MOTION);
+            // The mouse protocols are one setting, so resetting any of them
+            // turns reporting off. There is no protocol underneath to fall
+            // back to: setting one already cleared the others.
+            NamedPrivateMode::ReportX10MouseClicks
+            | NamedPrivateMode::ReportMouseClicks
+            | NamedPrivateMode::ReportCellMouseMotion
+            | NamedPrivateMode::ReportAllMouseMotion => {
+                self.mode.remove(Mode::MOUSE_MODE);
                 self.event_proxy
                     .send_event(RioEvent::MouseCursorDirty, self.window_id);
             }
@@ -8056,6 +8047,43 @@ mod tests {
 
         parser.advance(&mut term, b"\x1b[?9l");
         assert!(!term.mode().intersects(Mode::MOUSE_MODE));
+    }
+
+    /// Resetting one protocol while another is active turns reporting off
+    /// rather than leaving the active one running, because the four are one
+    /// setting and a reset cannot name a protocol to fall back to.
+    #[test]
+    fn resetting_any_mouse_protocol_clears_reporting() {
+        use crate::performer::handler::Processor;
+
+        let sequences: [&[u8]; 4] =
+            [b"\x1b[?9l", b"\x1b[?1000l", b"\x1b[?1002l", b"\x1b[?1003l"];
+        for reset in sequences {
+            let sets: [&[u8]; 4] =
+                [b"\x1b[?9h", b"\x1b[?1000h", b"\x1b[?1002h", b"\x1b[?1003h"];
+            for set in sets {
+                let mut term = Crosswords::new(
+                    CrosswordsSize::new(10, 10),
+                    CursorShape::Block,
+                    VoidListener,
+                    WindowId::from(0),
+                    0,
+                    10,
+                );
+                let mut parser = Processor::default();
+
+                parser.advance(&mut term, set);
+                assert!(term.mode().intersects(Mode::MOUSE_MODE));
+
+                parser.advance(&mut term, reset);
+                assert!(
+                    !term.mode().intersects(Mode::MOUSE_MODE),
+                    "{:?} left reporting on after {:?}",
+                    String::from_utf8_lossy(reset),
+                    String::from_utf8_lossy(set),
+                );
+            }
+        }
     }
 
     /// DECRQM has to answer for mode 9 now that it is tracked, otherwise


### PR DESCRIPTION
Mode 9 was parsed as an unknown private mode and dropped, so a program that asked for X10 mouse reporting got silence and no way to find out why: DECRQM answered 0 (not recognized). It is now tracked as a fourth mouse protocol alongside 1000, 1002 and 1003, and answers DECRQM. The four share one setting rather than four independent flags, which is how ghostty models it, so the last mode set wins and clears the others. rio already did that for the existing three, so mode 9 joins the `MOUSE_MODE` mask and inherits it.

X10 predates the mode that replaced it and reports much less: presses of the left, middle and right buttons only, with no release event, no motion, and no modifier bits in the button code. The encoder in rioterm gets a branch for that. Motion never reaches it, since motion is already gated on 1002 and 1003, but releases and the wheel codes do, and neither is reportable, so both are dropped rather than falling back to local scrolling. Setting 1006 or 1005 alongside 9 still selects the SGR or UTF-8 wire format, because the format and the event mode are tracked independently.

The second commit follows from treating the four as one setting. Resetting a protocol used to clear only its own bit, so `CSI ? 9 h` followed by `CSI ? 1000 l` left X10 reporting active even though the program had just asked for reporting to stop. A reset now turns reporting off whichever protocol it names, since setting one already cleared the others and there is nothing underneath to fall back to. Sequences that reset the protocol they set are unaffected, which covers what programs actually send.

Release Notes:

- Added support for X10 mouse reporting (`CSI ? 9 h`).
- Fixed mouse reporting staying active when a program reset a mouse protocol other than the one it had set.