### PR TITLE
release: Set the release body from the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,15 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+      # The release body cannot come from goreleaser's release.header, because
+      # changelog.disable skips the pipe that renders it, leaving the body
+      # empty. Set it here instead.
+      - name: Set release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG='${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'nightly' }}'
+          gh release edit "$TAG" --notes '**Full Changelog**: https://rioterm.com/changelog'
   librio-xcframework:
     needs: release
     runs-on: macos-latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -99,11 +99,9 @@ release:
   replace_existing_draft: false
   replace_existing_artifacts: true
   include_meta: false
-  header: |
-    **Full Changelog**: https://rioterm.com/changelog
-  footer: >-
-    ---
-    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
+  # No header or footer here: changelog.disable below skips the pipe that
+  # renders them, so they would never reach the release. The release workflow
+  # sets the body with `gh release edit` instead.
 
 nightly:
   version_template: "{{ incminor .Version }}-nightly"


### PR DESCRIPTION
Every release body has been empty, including v0.5.8, so the link to the changelog never showed up. The cause is that `changelog.disable: true` does more than empty the commit list: goreleaser assembles the body out of `release.header`, the changelog and `release.footer` in one pipe, and disabling the changelog skips that pipe before any of it runs. `Skip()` returns the value of `changelog.disable`, and it is `Run()` that loads the header and footer and joins them into the release notes. The configured header was dead the whole time, which is why the footer was missing from published releases too.

The workflow now sets the body with `gh release edit` right after `continue --merge`, using the same tag expression the xcframework upload already uses, so it covers tagged releases and nightly alike. The dead `header` and `footer` keys are gone, with a note in their place so the next person does not spend an afternoon working out why a configured header does not appear.

Release Notes:

- N/A