### PR TITLE
fix: do not signal PID 1 when dropping a dead context

### DIFF
--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -66,8 +66,12 @@ impl<T: rio_backend::event::EventListener> Drop for Context<T> {
         // Shutdown the terminal's PTY.
         let _ = self.messenger.channel.send(Msg::Shutdown);
 
+        // `create_dead_context` uses 1 as a placeholder PID, so guard against
+        // signalling init (1) or our own process group (0).
         #[cfg(not(target_os = "windows"))]
-        teletypewriter::kill_pid(self.shell_pid as i32);
+        if self.shell_pid > 1 {
+            teletypewriter::kill_pid(self.shell_pid as i32);
+        }
     }
 }
 


### PR DESCRIPTION
 `create_dead_context` stores `1` as a placeholder `shell_pid`, and `Context::drop`
   unconditionally SIGHUPs `shell_pid` — so dropping a dead context signals PID 1.

   Since #1735 the context tests reach that path via `dead_pty`. In the Nix build sandbox
   the builder shell *is* PID 1, so `cargo test` kills its own parent and the build fails
   with exit code 129. That's currently blocking the rio 0.5.x update in nixpkgs.

   Repro:

   ```sh
   cargo test -p rioterm --no-run
   unshare -rpf --mount-proc bash -c "trap : EXIT; target/debug/deps/rio-* context::"
   echo $?   # 129 before, 0 after
 ```

 Fix: skip the kill for PIDs that can't be a forked child — 0 is the caller's process
 group, 1 is init.