### PR TITLE
sugarloaf: Skip Vulkan when picking a backend on Windows

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -170,7 +170,9 @@ impl Screen<'_> {
                     wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
                 ),
                 #[cfg(all(feature = "wgpu", not(target_arch = "wasm32")))]
-                Backend::Webgpu => SugarloafBackend::Wgpu(wgpu::Backends::all()),
+                Backend::Webgpu => SugarloafBackend::Wgpu(
+                    rio_backend::sugarloaf::context::webgpu::default_backends(),
+                ),
                 #[cfg(not(feature = "wgpu"))]
                 Backend::Webgpu => SugarloafBackend::Cpu,
             }

--- a/sugarloaf/src/context/webgpu.rs
+++ b/sugarloaf/src/context/webgpu.rs
@@ -16,6 +16,25 @@ pub struct WgpuContext<'a> {
     pub max_texture_dimension_2d: u32,
 }
 
+/// The backends to offer wgpu when the config asks it to pick for itself.
+///
+/// Everywhere except Windows this is every backend wgpu was built with. On
+/// Windows Vulkan is left out: wgpu ranks the Vulkan adapter above the DX12
+/// one for the same GPU, and Intel's Vulkan driver faults inside
+/// `vkCreateDevice` on some integrated parts, which takes the process with it
+/// before anything is drawn (https://github.com/raphamorim/rio/issues/1804).
+/// DX12 is the natively supported path there, with GL behind it.
+///
+/// This only moves the automatic choice. `WGPU_BACKEND=vulkan` still wins,
+/// and `renderer.backend = "Vulkan"` still asks for Vulkan by name.
+pub fn default_backends() -> wgpu::Backends {
+    if cfg!(target_os = "windows") {
+        wgpu::Backends::DX12 | wgpu::Backends::GL
+    } else {
+        wgpu::Backends::all()
+    }
+}
+
 impl<'a> WgpuContext<'a> {
     pub fn new(
         sugarloaf_window: SugarloafWindow,

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -166,7 +166,8 @@ impl Default for SugarloafRenderer {
             not(target_os = "linux"),
             feature = "wgpu",
         ))]
-        let default_backend = SugarloafBackend::Wgpu(wgpu::Backends::all());
+        let default_backend =
+            SugarloafBackend::Wgpu(crate::context::webgpu::default_backends());
 
         #[cfg(all(
             not(target_arch = "wasm32"),


### PR DESCRIPTION
Rio dies on startup with an access violation (0xC0000005) on some Windows machines: a white window for a second, then nothing, and no output at all because the process is gone rather than exiting. The trace log in #1804 stops on wgpu-core's entry trace for `Adapter::create_device`, on the Vulkan backend, on an Intel UHD Graphics part with driver 31.0.101.2135. The INFO lines that follow a successful device are absent, and the file logger writes each event straight to the file, so the tail is where execution actually stopped. The reporter confirmed that `WGPU_BACKEND=dx12` and `WGPU_BACKEND=gl` both start normally.

wgpu was offered `Backends::all()` and ranked the Vulkan adapter above the DX12 adapter for the very same GPU, so a working DX12 path sat second in the sorted list and went unused. Automatic selection on Windows is now DX12 with GL behind it. `WGPU_BACKEND` still overrides and `renderer.backend = "Vulkan"` still asks for Vulkan by name, so anyone relying on it keeps it.

Two things this is not. It is not a fix for a regression: `sugarloaf/src/context/webgpu.rs` is byte-identical between v0.4.9 and main, the Windows default has been `Backends::all()` across the whole 0.4 and 0.5 line, and wgpu has been 30.0.0 since v0.4.9, so 0.4.9 crashes the same way. If the reporter last had this working on v0.4.5 or earlier, the candidate is the wgpu 28 to 30 bump that landed in between, which I have not verified, and a driver or OS update on their side is just as plausible. And it is not a repair of a rio defect: device creation passes `DeviceDescriptor::default()`, so faulting inside `vkCreateDevice` on a default descriptor is a driver bug. This declines to walk into it.

The tradeoff worth reviewing: this moves every Windows user, to protect the subset with a faulting Vulkan driver. A machine where DX12 faults and Vulkan is fine would break instead, and the GL in the set would not save it, because `request_adapter` returns a single adapter and the existing retry only lowers limits on that same adapter. DX12 being the platform-native path on Windows is what makes the trade worth it, and there is no runtime detection available for either fault.

Release Notes:

- Fixed a crash on startup on Windows machines whose Vulkan driver faults during device creation, by preferring DX12 when rio picks the graphics backend itself.