### PR TITLE
fix: remove Windows startup window flash

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -2120,6 +2120,16 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
 
+                #[cfg(target_os = "windows")]
+                if !route.window.initial_frame_rendered {
+                    // Keep the native window cloaked until the first complete
+                    // render has been submitted. Uncloaking earlier can expose
+                    // the blank native surface during GPU/PTY startup.
+                    use rio_window::platform::windows::WindowExtWindows;
+                    route.window.winit_window.set_cloaked(false);
+                    route.window.initial_frame_rendered = true;
+                }
+
                 // let duration = start.elapsed();
                 // println!("Time elapsed in render() is: {:?}", duration);
                 // }

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -616,6 +616,8 @@ pub struct RouteWindow<'a> {
     pub is_focused: bool,
     pub is_occluded: bool,
     pub needs_render_after_occlusion: bool,
+    #[cfg(target_os = "windows")]
+    pub initial_frame_rendered: bool,
     pub render_timestamp: Instant,
     #[cfg_attr(target_os = "macos", allow(dead_code))]
     pub vblank_interval: Duration,
@@ -771,14 +773,6 @@ impl<'a> RouteWindow<'a> {
             }
         }
 
-        #[cfg(target_os = "windows")]
-        {
-            // On windows cloak (hide) the window initially, we later reveal it after the first draw.
-            // This is a workaround to hide the "white flash" that occurs during application startup.
-            use rio_window::platform::windows::WindowExtWindows;
-            winit_window.set_cloaked(false);
-        }
-
         // Get the display refresh rate and convert to frame interval
         // On macOS, CVDisplayLink handles VSync synchronization automatically,
         // so we don't need to calculate vblank intervals
@@ -804,6 +798,8 @@ impl<'a> RouteWindow<'a> {
             is_focused: true,
             is_occluded: false,
             needs_render_after_occlusion: false,
+            #[cfg(target_os = "windows")]
+            initial_frame_rendered: false,
             winit_window,
             screen,
         }

--- a/rio-window/src/platform_impl/windows/window.rs
+++ b/rio-window/src/platform_impl/windows/window.rs
@@ -1410,6 +1410,11 @@ impl InitData<'_> {
 
         win.set_cursor(attributes.cursor);
 
+        // Apply the cloak before making the native window visible. Doing this
+        // in the opposite order can expose one compositor frame before the
+        // cloak takes effect, which is visible as a startup flash.
+        win.set_cloaked(self.attributes.platform_specific.cloaked);
+
         // Set visible before setting the size to ensure the
         // attribute is correctly applied.
         win.set_visible(attributes.visible);
@@ -1457,7 +1462,6 @@ impl InitData<'_> {
         if let Some(corner) = self.attributes.platform_specific.corner_preference {
             win.set_corner_preference(corner);
         }
-        win.set_cloaked(self.attributes.platform_specific.cloaked);
     }
 }
 unsafe fn init(


### PR DESCRIPTION
On Windows, Rio could show a blank native window before the first frame was ready, causing a brief flash and making startup feel slower. The fix keeps the window cloaked until the first frame is rendered, eliminating the blink and improving perceived startup speed.

Related to #640, #1791