### PR TITLE
hints: Stop opening matches through a shell on Windows

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2139,10 +2139,8 @@ impl Screen<'_> {
             hyperlinks: true,
             post_processing: true,
             persist: false,
-            action: rio_backend::config::hints::HintAction::Command {
-                command: rio_backend::config::hints::HintCommand::Simple(
-                    "xdg-open".to_string(),
-                ),
+            action: rio_backend::config::hints::HintAction::Action {
+                action: rio_backend::config::hints::HintInternalAction::Open,
             },
             mouse: rio_backend::config::hints::HintMouse::default(),
             binding: None,
@@ -2290,34 +2288,24 @@ impl Screen<'_> {
         // Apply post-processing to remove trailing delimiters and handle uneven brackets
         let processed_uri = post_process_hyperlink_uri(hyperlink.uri());
 
+        self.open_with_default_handler(&processed_uri);
+    }
+
+    /// Hand `target` to the platform's default handler.
+    ///
+    /// `target` comes from terminal output, so it is attacker-controlled and
+    /// must never reach a shell: `cmd /c start` would treat `&` in a URL as a
+    /// command separator, and on Unix a launcher gets it as a single argv
+    /// entry rather than a command line.
+    fn open_with_default_handler(&self, target: &str) {
         #[cfg(not(any(target_os = "macos", windows)))]
-        self.exec("xdg-open", [&processed_uri]);
+        self.exec("xdg-open", [target]);
 
         #[cfg(target_os = "macos")]
-        self.exec("open", [&processed_uri]);
+        self.exec("open", [target]);
 
-        // Going through `cmd /c start` re-quotes the argument and
-        // mangles URLs (metacharacters plus cmd.exe batch escaping);
-        // hand the URL to the default handler directly instead.
         #[cfg(windows)]
-        {
-            use std::os::windows::ffi::OsStrExt;
-            let uri: Vec<u16> = std::ffi::OsStr::new(&processed_uri)
-                .encode_wide()
-                .chain(std::iter::once(0))
-                .collect();
-            let operation: Vec<u16> = "open\0".encode_utf16().collect();
-            unsafe {
-                windows_sys::Win32::UI::Shell::ShellExecuteW(
-                    std::ptr::null_mut(),
-                    operation.as_ptr(),
-                    uri.as_ptr(),
-                    std::ptr::null(),
-                    std::ptr::null(),
-                    windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL,
-                );
-            }
-        }
+        shell_execute_open(target);
     }
 
     pub fn exec<I, S>(&self, program: &str, args: I)
@@ -2583,11 +2571,7 @@ impl Screen<'_> {
             let _ = std::process::Command::new("xdg-open").arg(url).spawn();
         }
         #[cfg(windows)]
-        {
-            let _ = std::process::Command::new("cmd")
-                .args(["/c", "start", "", url])
-                .spawn();
-        }
+        shell_execute_open(url);
     }
 
     pub fn handle_scrollbar_click(&mut self) -> bool {
@@ -4611,6 +4595,25 @@ impl Screen<'_> {
         self.mark_dirty();
     }
 
+    /// What a hint should hand to a launcher: the match text, or the path it
+    /// resolves to against the terminal's OSC 7 CWD when it names one that
+    /// exists. URLs and non-existent paths come back unchanged.
+    fn hint_open_target(&self, hint_match: &crate::hints::HintMatch) -> String {
+        // Cloned so the terminal lock is released before resolving, which
+        // goes to the filesystem.
+        let cwd = self
+            .context_manager
+            .current()
+            .terminal
+            .lock()
+            .current_directory
+            .clone();
+        match crate::hints::resolve_path_for_opening(&hint_match.text, cwd.as_deref()) {
+            Some(resolved) => resolved.to_string_lossy().into_owned(),
+            None => hint_match.text.clone(),
+        }
+    }
+
     /// Execute the action for a selected hint
     fn execute_hint_action(
         &mut self,
@@ -4646,26 +4649,13 @@ impl Screen<'_> {
                     drop(terminal);
                     self.mark_dirty();
                 }
+                HintInternalAction::Open => {
+                    let target = self.hint_open_target(hint_match);
+                    self.open_with_default_handler(&target);
+                }
             },
             HintAction::Command { command } => {
-                // If the match looks like a local path, resolve it against
-                // the terminal's OSC 7 CWD and fall back to the raw text if
-                // the path doesn't exist (or the text is a URL).
-                let arg_text = {
-                    let cwd = &self
-                        .context_manager
-                        .current()
-                        .terminal
-                        .lock()
-                        .current_directory;
-                    match crate::hints::resolve_path_for_opening(
-                        &hint_match.text,
-                        cwd.as_deref(),
-                    ) {
-                        Some(resolved) => resolved.to_string_lossy().into_owned(),
-                        None => hint_match.text.clone(),
-                    }
-                };
+                let arg_text = self.hint_open_target(hint_match);
 
                 match command {
                     HintCommand::Simple(program) => {
@@ -4900,6 +4890,37 @@ impl Screen<'_> {
         }
 
         Some((start_col, final_end.col))
+    }
+}
+
+/// Open `target` with whatever Windows has registered for it, without a
+/// shell in the middle. `ShellExecuteW` takes the target as one string
+/// rather than a command line, so metacharacters in it stay data.
+#[cfg(windows)]
+fn shell_execute_open(target: &str) {
+    use std::os::windows::ffi::OsStrExt;
+    let wide_target: Vec<u16> = std::ffi::OsStr::new(target)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let operation: Vec<u16> = "open\0".encode_utf16().collect();
+    let result = unsafe {
+        windows_sys::Win32::UI::Shell::ShellExecuteW(
+            std::ptr::null_mut(),
+            operation.as_ptr(),
+            wide_target.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL,
+        )
+    };
+
+    // A return at or below 32 is an error code rather than an instance
+    // handle. Worth logging, because the symptom of failing here is a click
+    // that appears to do nothing at all.
+    let code = result as isize;
+    if code <= 32 {
+        tracing::warn!("ShellExecuteW could not open {target}: code {code}");
     }
 }
 

--- a/rio-backend/src/config/hints.rs
+++ b/rio-backend/src/config/hints.rs
@@ -196,6 +196,12 @@ pub enum HintInternalAction {
     Select,
     /// Move vi mode cursor to hint
     MoveViModeCursor,
+    /// Hand the hint text to the platform's default handler.
+    ///
+    /// Preferred over naming an opener as a command, because the match
+    /// comes from terminal output and is therefore attacker-controlled:
+    /// the launcher must not be anything that parses metacharacters.
+    Open,
 }
 
 /// Custom command configuration
@@ -265,8 +271,8 @@ fn default_hints_enabled() -> Vec<Hint> {
         hyperlinks: true,
         post_processing: true,
         persist: false,
-        action: HintAction::Command {
-            command: default_url_command(),
+        action: HintAction::Action {
+            action: HintInternalAction::Open,
         },
         mouse: HintMouse::default(),
         binding: Some(HintBinding {
@@ -275,20 +281,6 @@ fn default_hints_enabled() -> Vec<Hint> {
             mode: Vec::new(),
         }),
     }]
-}
-
-fn default_url_command() -> HintCommand {
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    return HintCommand::Simple("xdg-open".to_string());
-
-    #[cfg(target_os = "macos")]
-    return HintCommand::Simple("open".to_string());
-
-    #[cfg(target_os = "windows")]
-    return HintCommand::WithArgs {
-        program: "cmd".to_string(),
-        args: vec!["/c".to_string(), "start".to_string(), "".to_string()],
-    };
 }
 
 fn default_bool_true() -> bool {
@@ -314,6 +306,47 @@ mod tests {
         assert!(default_hint.hyperlinks);
         assert!(default_hint.post_processing);
         assert!(!default_hint.persist);
+    }
+
+    /// The default hint must not launch anything through a shell. Hint text
+    /// comes from terminal output, so it is attacker-controlled, and a
+    /// `cmd /c start` default made `&` in a URL a command separator.
+    #[test]
+    fn test_default_hint_does_not_go_through_a_shell() {
+        let hints = Hints::default();
+        assert_eq!(
+            hints.rules[0].action,
+            HintAction::Action {
+                action: HintInternalAction::Open
+            },
+        );
+
+        let serialized = toml::to_string(&hints).unwrap();
+        assert!(
+            !serialized.contains("program") && !serialized.contains("cmd"),
+            "defaults must name no launcher program: {serialized}"
+        );
+    }
+
+    /// `Open` has to survive a config write/read cycle, so that writing the
+    /// default config back out cannot produce something unparseable.
+    #[test]
+    fn test_open_action_roundtrips_through_toml() {
+        let hint = Hint {
+            regex: None,
+            hyperlinks: true,
+            post_processing: true,
+            persist: false,
+            action: HintAction::Action {
+                action: HintInternalAction::Open,
+            },
+            mouse: HintMouse::default(),
+            binding: None,
+        };
+
+        let serialized = toml::to_string(&hint).unwrap();
+        let deserialized: Hint = toml::from_str(&serialized).unwrap();
+        assert_eq!(hint, deserialized);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1811, reported by @lalvarezt.

The default URL hint on Windows was `cmd` with args `/c start ""`, and `execute_hint_action` appends the matched text as the final argument. Rust's std only quotes arguments that contain whitespace or a quote character, so `&` in a match arrived at cmd's parser unquoted and everything after it ran as a separate command. The std escaping added for CVE-2024-24576 does not apply, because the program is cmd.exe itself rather than a `.bat` or `.cmd` file. Reachable in a default install: the shipped hint has `hyperlinks = true`, a ctrl+shift+O binding, and mouse hints enabled with alt, so displaying attacker-controlled text and one click is the whole chain.

The fix is to stop naming a launcher program for the default. `HintInternalAction::Open` hands the match to the platform's default handler: `ShellExecuteW` on Windows, which takes the target as a single string rather than a command line, and `open` / `xdg-open` through argv elsewhere, where there is no shell to begin with. This is the same API the hyperlink-click path already used after #1740 and the same one the `opener` crate uses on Windows; the ShellExecuteW call is now shared by all three callers instead of living in one branch. Also in here, two smaller things the report did not cover: `open_docs_url` used the same `cmd /c start` shape (with a hardcoded URL, so not exploitable, but the pattern invites copying), and the synthetic hover-hint config hardcoded `xdg-open` on every platform, which never worked on Windows or macOS.

Worth noting for triage. The same pattern was published as a High severity advisory against Ghidra, GHSA-5c38-3rf3-gp75, at CVSS 7.0 to 8.8 with `AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H`, where Java's process implementation escapes only whitespace and quotes exactly as Rust's does. Those metrics fit this case too. Alacritty carries the identical default in `ui_config.rs` and appends the match the same way in `event.rs`, which is where rio inherited it, so it looks affected as well and may deserve a heads-up.

This does not address a second, separate issue: an OSC 8 URI bypasses the regex entirely and reaches the handler with no scheme validation, so any registered protocol handler is still reachable, and a path hint that resolves to an executable still opens as one. That is the class behind CVE-2023-46321 and CVE-2023-46322 in iTerm2. A scheme allowlist belongs in its own change, since it will reject exotic schemes that work today.

Release Notes:

- Fixed a command injection on Windows where opening a hint whose text came from terminal output could run arbitrary commands (reported by @lalvarezt).