### PR TITLE
Add macOS local network usage description

### DIFF
--- a/misc/osx/Rio.app/Contents/Info.plist
+++ b/misc/osx/Rio.app/Contents/Info.plist
@@ -145,6 +145,8 @@
   <string>An application in Rio would like to access your location information.</string>
   <key>NSLocationWhenInUseUsageDescription</key>
   <string>An application in Rio would like to access your location information while active.</string>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>A program running inside Rio would like to access the local network.</string>
   <key>NSMicrophoneUsageDescription</key>
   <string>An application in Rio would like to access your microphone.</string>
   <key>NSLocationTemporaryUsageDescriptionDictionary</key>


### PR DESCRIPTION
## Summary

- add `NSLocalNetworkUsageDescription` to Rio's macOS app metadata
- explain that a program running inside Rio may need local network access

## Why

macOS attributes local-network operations from child processes such as `ssh` and `nc` to the responsible terminal application. Without this usage description, Rio does not present the Local Network permission prompt or appear in **System Settings → Privacy & Security → Local Network**.

This was observed with Rio 0.5.15 installed from the official DMG through Homebrew Cask on macOS 27.0 (build 26A5388g). The same LAN SSH connection works from Ghostty, whose app metadata includes this key.

Apple documents the responsible-application behavior in [TN3179: Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy).

## Validation

- `plutil -lint misc/osx/Rio.app/Contents/Info.plist`
- `xmllint --noout misc/osx/Rio.app/Contents/Info.plist`
- verified the value with `PlistBuddy`

disclaimer: I used AI to do this edit
