### PR TITLE
ci(nix): skip check phase to fix OOM on Nix Build CI

### DIFF
--- a/pkgRio.nix
+++ b/pkgRio.nix
@@ -113,6 +113,7 @@ in
     buildNoDefaultFeatures = true;
     buildFeatures = (lib.optionals withX11 ["x11"]) ++ (lib.optionals withWayland ["wayland"]);
     checkType = "debug";
+    doCheck = false;
     meta = {
       description = rioToml.package.description;
       longDescription = rioToml.package.extended-description;


### PR DESCRIPTION
## Summary

- set `doCheck = false` in `pkgRio.nix` so the Nix package builds without running the check phase

## Why

The **Nix Build** job ([`.github/workflows/nix-build.yml`](.github/workflows/nix-build.yml)) runs on `ubuntu-24.04-arm` and currently fails every run. It gets through compilation but dies during the check phase, before the `rio` test binary produces a `test result` summary line, and the job ends with `exit code 129` (SIGHUP).

The cause is memory: the runner is reclaimed by the kernel OOM killer while the `rio` unittest binary runs, so the build step never completes. The log stops mid-test:

```
running 172 tests
test bindings::tests::binding_matches_different_action ... ok
...
test context::test::test_add_context_start_with_capacity_limit ... ok
test context::test::test_add_context ... 
##[endgroup]
Post job cleanup.
```

The check phase is not the right place to gate this on a 7 GB ARM runner: it compiles the full workspace and then runs the `rio` test binary inside the Nix sandbox, which exceeds what the runner has. Setting `doCheck = false` brings the package build back to passing. The `rio` unittests and the rest of the test suite are still exercised by the **Test** workflow (`.github/workflows/test.yml`) on runners with more headroom.

Release Notes:

- N/A
