### PR TITLE
rio-notifier: present notifications while Rio is frontmost on macOS

### DIFF
--- a/rio-notifier/Cargo.toml
+++ b/rio-notifier/Cargo.toml
@@ -14,6 +14,7 @@ objc2 = "0.5.2"
 objc2-foundation = { version = "0.2.2", features = ["NSString"] }
 objc2-user-notifications = { version = "0.2.2", features = [
     "UNUserNotificationCenter",
+    "UNNotification",
     "UNNotificationContent",
     "UNNotificationRequest",
     "UNNotificationTrigger",

--- a/rio-notifier/src/lib.rs
+++ b/rio-notifier/src/lib.rs
@@ -28,16 +28,62 @@ pub fn send_notification(title: &str, body: &str) {
 
 #[cfg(target_os = "macos")]
 mod platform {
-    use block2::RcBlock;
+    use block2::{Block, RcBlock};
     use objc::runtime::Object;
     use objc::{class, msg_send, sel, sel_impl};
-    use objc2::runtime::Bool;
+    use objc2::rc::{Allocated, Retained};
+    use objc2::runtime::{Bool, NSObject, NSObjectProtocol, ProtocolObject};
+    use objc2::{declare_class, msg_send_id, mutability, ClassType, DeclaredClass};
     use objc2_foundation::{NSError, NSString};
     use objc2_user_notifications::{
-        UNAuthorizationOptions, UNMutableNotificationContent, UNNotificationRequest,
-        UNUserNotificationCenter,
+        UNAuthorizationOptions, UNMutableNotificationContent, UNNotification,
+        UNNotificationPresentationOptions, UNNotificationRequest,
+        UNUserNotificationCenter, UNUserNotificationCenterDelegate,
     };
     use std::sync::Once;
+
+    declare_class!(
+        struct NotificationDelegate;
+
+        // SAFETY:
+        // - The superclass NSObject does not have any subclassing requirements.
+        // - Interior mutability is a safe default.
+        // - `NotificationDelegate` does not implement `Drop`.
+        unsafe impl ClassType for NotificationDelegate {
+            type Super = NSObject;
+            type Mutability = mutability::InteriorMutable;
+            const NAME: &'static str = "RioNotificationDelegate";
+        }
+
+        impl DeclaredClass for NotificationDelegate {
+            type Ivars = ();
+        }
+
+        unsafe impl NotificationDelegate {
+            #[method_id(init)]
+            fn init(this: Allocated<Self>) -> Option<Retained<Self>> {
+                unsafe { msg_send_id![super(this.set_ivars(())), init] }
+            }
+        }
+
+        unsafe impl NSObjectProtocol for NotificationDelegate {}
+
+        unsafe impl UNUserNotificationCenterDelegate for NotificationDelegate {
+            #[method(userNotificationCenter:willPresentNotification:withCompletionHandler:)]
+            fn will_present(
+                &self,
+                _center: &UNUserNotificationCenter,
+                _notification: &UNNotification,
+                completion_handler: &Block<dyn Fn(UNNotificationPresentationOptions)>,
+            ) {
+                completion_handler.call((
+                    UNNotificationPresentationOptions::UNNotificationPresentationOptionBanner
+                        | UNNotificationPresentationOptions::UNNotificationPresentationOptionList
+                        | UNNotificationPresentationOptions::UNNotificationPresentationOptionSound,
+                ));
+            }
+        }
+    );
 
     pub(crate) fn request_authorization() {
         static INIT: Once = Once::new();
@@ -52,6 +98,20 @@ mod platform {
             }
 
             let center = UNUserNotificationCenter::currentNotificationCenter();
+
+            // macOS does not present a notification posted by the app that is
+            // currently frontmost unless the center's delegate asks it to.
+            // Terminal notifications are emitted by programs running inside
+            // Rio, so Rio is nearly always frontmost when one arrives, and
+            // without this every notification is delivered silently to
+            // Notification Center with no banner.
+            let delegate: Retained<NotificationDelegate> =
+                msg_send_id![NotificationDelegate::alloc(), init];
+            center.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+            // The center holds its delegate weakly, so keep ours alive for the
+            // lifetime of the process.
+            std::mem::forget(delegate);
+
             center.requestAuthorizationWithOptions_completionHandler(
                 UNAuthorizationOptions::UNAuthorizationOptionAlert
                     | UNAuthorizationOptions::UNAuthorizationOptionSound,


### PR DESCRIPTION
Fixes #1831.

On macOS, notifications triggered from inside Rio (OSC 9 / OSC 777) are delivered but never *presented*: no banner appears, and the notification is only discoverable by opening Notification Center.

A terminal notification is emitted by a program running inside the terminal, so Rio is the frontmost app at the moment it is posted. Under the UserNotifications framework a notification arriving while its own app is in the foreground is presented only if the center's delegate implements `userNotificationCenter(_:willPresent:withCompletionHandler:)` and calls the completion handler with presentation options. `rio-notifier` never installed a delegate, so every notification was delivered without being presented.

## The change

- `rio-notifier/src/lib.rs`: declare a minimal `UNUserNotificationCenterDelegate` that asks for `Banner | List | Sound`, and assign it with `setDelegate` inside the existing `Once` in `request_authorization()`. The center holds its delegate weakly, so the object is deliberately leaked for the lifetime of the process.
- `rio-notifier/Cargo.toml`: add `UNNotification` to the `objc2-user-notifications` features — `willPresentNotification` is gated on it and it is not implied by the features already enabled.

No dependency bumps: everything needed already exists in the pinned `objc2` 0.5.2 / `objc2-user-notifications` 0.2.2.

Apple's guidance is to assign the delegate before the app finishes launching. `request_authorization()` is called from `Application::new` (`frontends/rioterm/src/main.rs:242`), which runs before `application.run(window_event_loop)` on line 248, so this is satisfied without touching `rioterm`.

## Verification

Manually verified on macOS 26.6 (Apple Silicon), since there is no automated coverage for notification presentation.

A release build was bundled from `misc/osx/Rio.app`, given its own bundle identifier, signed, installed to `/Applications` and launched through LaunchServices, then driven with `printf '\033]777;notify;BannerTest N;patched delegate\a'` on a timer. The screen was captured every 3s and each frame checked for *both* the banner and the frontmost app in the menu bar.

With the patched build frontmost, every fire produced a banner. Frames where focus had moved to another Rio window were discarded — a backgrounded app banners regardless of the delegate, so those prove nothing.

Worth noting for anyone reproducing this: an ad-hoc signed bundle is refused by the notification daemon (`requestAuthorization` returns `granted=false` and every `addNotificationRequest` returns an error), so nothing is delivered at all and the result looks like a failure of the patch. A real signing identity is needed to test this.

## Notes

- Presentation is unconditional here, matching the behaviour of other terminals. Happy to put it behind a config key instead if you'd prefer.
- `didReceiveNotificationResponse` (focusing the window/tab when a notification is clicked) is deliberately out of scope; it seems better as a separate change.
