### PR TITLE
librio: drop the trailing blank line that breaks cargo fmt --check

### DIFF
--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -1092,4 +1092,3 @@ mod tests {
         assert_eq!(state.kitty_image_rgba(7, &mut buf), 16);
     }
 }
-


### PR DESCRIPTION
Test is currently red on `main`.

`c58a305a` ("take the pointer side when selecting") left a stray blank line at the end of `librio/src/lib.rs`, so `cargo fmt -- --check` fails — step 8 of the Test workflow. Because it fails there, `cargo clippy` and `cargo test` never run at all, on every platform and on every open PR.

```
Diff in librio/src/lib.rs:1092:
     }
 }
-
```

This removes the line (`cargo fmt -p librio`, one deletion). `cargo fmt -- --check` passes on the workspace afterwards.