### PR TITLE
Render a hollow cursor in unfocused windows

### DIFF
--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -4301,7 +4301,7 @@ impl Screen<'_> {
                 let render_style = crate::grid_emit::cursor_render_style(
                     crate::grid_emit::CursorRenderInputs {
                         visible: p.cursor_visible,
-                        focused: p.is_active,
+                        focused: p.is_active && self.renderer.is_window_focused,
                         blink_visible: p.cursor_blink_visible,
                         blinking: p.cursor_blinking,
                         preedit: p.cursor_preedit,


### PR DESCRIPTION
An active panel kept drawing a solid cursor after its window lost focus because the cursor style only checked panel focus. It now checks the window too, so an unfocused window gets the hollow cursor as expected.

I tested this on my local build and it works.