### PR TITLE
Fix librio Windows CI failure on main

### DIFF
--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -998,6 +998,10 @@ impl Surface {
     /// integration.
     #[cfg(feature = "pty")]
     pub fn foreground_process_name(&self) -> String {
+        #[cfg(target_os = "windows")]
+        return String::new();
+
+        #[cfg(not(target_os = "windows"))]
         teletypewriter::foreground_process_name(self.main_fd, self.shell_pid)
     }
 


### PR DESCRIPTION
The Windows `test-native` job is currently failing on `main` because `Surface::foreground_process_name` compiles there even though its teletypewriter helper and the `main_fd` and `shell_pid` fields only exist on Unix. This keeps the current lookup on Unix and returns an empty name on Windows, preserving the public Rust and C APIs and matching the existing unavailable-result behavior.

I tested this locally with `cargo clippy --all-targets --all-features` and `cargo test -p librio --all-features`. The previously failing Windows CI job also passes on this PR.