### PR TITLE
Position progress bar without a visible tab strip

### DIFF
--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -646,12 +646,13 @@ impl Island {
         }
     }
 
-    /// Render the progress bar below the island
+    /// Render the progress bar below the tab strip, or at the top when hidden.
     fn render_progress_bar(
         &mut self,
         sugarloaf: &mut Sugarloaf,
         window_width: f32,
         scale_factor: f32,
+        y_position: f32,
     ) {
         // Check for timeout first
         self.check_progress_timeout();
@@ -662,7 +663,6 @@ impl Island {
         };
 
         let width = window_width / scale_factor;
-        let y_position = ISLAND_HEIGHT;
 
         // Determine color based on state
         let color = match state {
@@ -751,7 +751,7 @@ impl Island {
             // tabs.
             self.drag = None;
             self.slide_springs.clear();
-            self.render_progress_bar(sugarloaf, window_width, scale_factor);
+            self.render_progress_bar(sugarloaf, window_width, scale_factor, 0.0);
             return;
         }
 
@@ -1035,7 +1035,7 @@ impl Island {
         }
 
         // Render the progress bar below the island
-        self.render_progress_bar(sugarloaf, window_width, scale_factor);
+        self.render_progress_bar(sugarloaf, window_width, scale_factor, ISLAND_HEIGHT);
     }
 
     /// Toggle the color picker for a given tab index


### PR DESCRIPTION
When `hide-if-single` hides the only tab, the progress bar still used the full tab-strip height as its vertical offset. That left the blue bar floating over the terminal content. The hidden-strip path now draws it at the top of the window, while visible tabs keep the existing position below the strip.

I tested this on my local build and it works.