### PR TITLE
fix: do not signal PID 1 when dropping a dead context

### DIFF
--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -66,8 +66,12 @@ impl<T: rio_backend::event::EventListener> Drop for Context<T> {
         // Shutdown the terminal's PTY.
         let _ = self.messenger.channel.send(Msg::Shutdown);
 
+        // `create_dead_context` uses 1 as a placeholder PID, so guard against
+        // signalling init (1) or our own process group (0).
         #[cfg(not(target_os = "windows"))]
-        teletypewriter::kill_pid(self.shell_pid as i32);
+        if self.shell_pid > 1 {
+            teletypewriter::kill_pid(self.shell_pid as i32);
+        }
     }
 }
 

--- a/pkgRio.nix
+++ b/pkgRio.nix
@@ -113,7 +113,6 @@ in
     buildNoDefaultFeatures = true;
     buildFeatures = (lib.optionals withX11 ["x11"]) ++ (lib.optionals withWayland ["wayland"]);
     checkType = "debug";
-    doCheck = false;
     meta = {
       description = rioToml.package.description;
       longDescription = rioToml.package.extended-description;


### PR DESCRIPTION
Supersedes #1812, keeping @pinpox's original commit and adding the CI follow-through on top. Closes #1812.

## Original fix (@pinpox)

`create_dead_context` stores `1` as a placeholder `shell_pid`, and `Context::drop` unconditionally SIGHUPs `shell_pid` — so dropping a dead context signals PID 1. In the Nix build sandbox the builder shell *is* PID 1, so `cargo test` killed its own parent and the build died with exit code 129 partway through the context tests. This was blocking the rio 0.5.x update in nixpkgs. The fix guards the kill against placeholder PIDs (0/1), with an `unshare` repro in #1812.

## Added on top

Reverts #1828's `doCheck = false`. That workaround was merged on an OOM theory, but the failure signature — exit 129 (SIGHUP, not the OOM killer's SIGKILL), dying exactly at `test context::test::test_add_context` — matches this bug, not memory pressure. With the root cause fixed, the Nix package build can run its check phase again, and this PR's own Nix Build job doubles as the proof.

Tested with `cargo test -p rioterm context::` (15 passed).