### PR TITLE
Position progress bar without a visible tab strip

### DIFF
--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -646,12 +646,13 @@ impl Island {
         }
     }
 
-    /// Render the progress bar below the island
+    /// Render the progress bar below the tab strip, or at the top when hidden.
     fn render_progress_bar(
         &mut self,
         sugarloaf: &mut Sugarloaf,
         window_width: f32,
         scale_factor: f32,
+        y_position: f32,
     ) {
         // Check for timeout first
         self.check_progress_timeout();
@@ -662,7 +663,6 @@ impl Island {
         };
 
         let width = window_width / scale_factor;
-        let y_position = ISLAND_HEIGHT;
 
         // Determine color based on state
         let color = match state {
@@ -751,7 +751,7 @@ impl Island {
             // tabs.
             self.drag = None;
             self.slide_springs.clear();
-            self.render_progress_bar(sugarloaf, window_width, scale_factor);
+            self.render_progress_bar(sugarloaf, window_width, scale_factor, 0.0);
             return;
         }
 
@@ -1035,7 +1035,7 @@ impl Island {
         }
 
         // Render the progress bar below the island
-        self.render_progress_bar(sugarloaf, window_width, scale_factor);
+        self.render_progress_bar(sugarloaf, window_width, scale_factor, ISLAND_HEIGHT);
     }
 
     /// Toggle the color picker for a given tab index


### PR DESCRIPTION
Supersedes #1839 with @mirsella's commit rebased onto current main for green CI (the original branch inherited the pre-#1842 failures). No code changes needed. Closes #1839.

The review confirmed the early-return branch in `Island::render` is exactly the hidden-strip case (`hide_if_single && num_tabs == 1`), where the OSC 9;4 progress bar was still drawn at `ISLAND_HEIGHT` — floating below a strip that isn't there. Pinning it to `0.0` there and `ISLAND_HEIGHT` on the normal path is right in both branches.

Worth noting: `hide-if-single` now defaults to `true` on macOS, so the previously rare hidden-strip case is the default single-tab state there — this fix covers the default path, not an edge case.