### PR TITLE
fix(macos): SKK direct input and IME mode-switch keys

### DIFF
--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -749,7 +749,7 @@ pub fn default_key_bindings(config: &rio_backend::config::Config) -> Vec<KeyBind
     bindings.extend(platform_key_bindings(
         config.navigation.has_navigation_key_bindings(),
         config.navigation.use_split,
-        config.keyboard,
+        config.keyboard.clone(),
     ));
 
     // Add hint bindings

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -201,6 +201,7 @@ pub fn configure_window(winit_window: &Window, config: &Config) {
         // OnlyRight - The right `Option` key is treated as `Alt`.
         // Both - Both `Option` keys are treated as `Alt`.
         // None - No special handling is applied for `Option` key.
+        use rio_window::keyboard::ModifiersState;
         use rio_window::platform::macos::{OptionAsAlt, WindowExtMacOS};
 
         match config.option_as_alt.to_lowercase().as_str() {
@@ -209,6 +210,20 @@ pub fn configure_window(winit_window: &Window, config: &Config) {
             "right" => winit_window.set_option_as_alt(OptionAsAlt::OnlyRight),
             _ => {}
         }
+
+        let mut mask = ModifiersState::empty();
+        for name in &config.keyboard.forward_to_ime_modifier_mask {
+            match name.to_lowercase().as_str() {
+                "shift" => mask |= ModifiersState::SHIFT,
+                "ctrl" | "control" => mask |= ModifiersState::CONTROL,
+                "alt" | "option" => mask |= ModifiersState::ALT,
+                "super" | "cmd" | "command" => mask |= ModifiersState::SUPER,
+                other => tracing::warn!(
+                    "ignoring unknown forward-to-ime-modifier-mask value: {other:?}"
+                ),
+            }
+        }
+        winit_window.set_forward_to_ime_modifier_mask(mask);
     }
 
     let is_transparent = config.window.opacity < 1.;

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -228,7 +228,7 @@ impl Screen<'_> {
             split_active_color: config.colors.split_active,
             panel: config.panel,
             title: config.title.clone(),
-            keyboard: config.keyboard,
+            keyboard: config.keyboard.clone(),
             scrollback_history_limit: config.scrollback_history_limit,
         };
 
@@ -502,7 +502,7 @@ impl Screen<'_> {
             .set_multiplier_and_divider(config.scroll.multiplier, config.scroll.divider);
 
         // Update keyboard config in context manager
-        self.context_manager.config.keyboard = config.keyboard;
+        self.context_manager.config.keyboard = config.keyboard.clone();
 
         // Re-evaluate the opaque flag — toggling `window.opacity` /
         // `window.blur` at runtime should flip the compositor mode.

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -148,6 +148,16 @@ pub fn default_ime_cursor_positioning() -> bool {
     true
 }
 
+#[inline]
+pub fn default_forward_to_ime_modifier_mask() -> Vec<String> {
+    vec![
+        String::from("shift"),
+        String::from("ctrl"),
+        String::from("alt"),
+        String::from("super"),
+    ]
+}
+
 pub fn default_config_file_content() -> String {
     String::from(
         "# See the full configuration reference: https://rioterm.com/docs/config\n",

--- a/rio-backend/src/config/keyboard.rs
+++ b/rio-backend/src/config/keyboard.rs
@@ -1,8 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use super::defaults::{default_disable_ctlseqs_alt, default_ime_cursor_positioning};
+use super::defaults::{
+    default_disable_ctlseqs_alt, default_forward_to_ime_modifier_mask,
+    default_ime_cursor_positioning,
+};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Keyboard {
     // Disable ctlseqs with ALT keys
     // For example: Terminal.app does not deal with ctlseqs with ALT keys
@@ -19,6 +22,20 @@ pub struct Keyboard {
         rename = "ime-cursor-positioning"
     )]
     pub ime_cursor_positioning: bool,
+
+    // Modifier mask deciding when a key event is forwarded to the macOS IME.
+    // A key event is forwarded when no modifier is pressed, or when the
+    // pressed modifiers intersect this mask. Otherwise the event is handled
+    // directly by the application without going through the IME.
+    //
+    // Accepted values (case-insensitive): "shift", "ctrl", "alt", "super".
+    // Useful for input methods like SKK that need to receive Ctrl+key
+    // combinations directly.
+    #[serde(
+        default = "default_forward_to_ime_modifier_mask",
+        rename = "forward-to-ime-modifier-mask"
+    )]
+    pub forward_to_ime_modifier_mask: Vec<String>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -30,6 +47,7 @@ impl Default for Keyboard {
             #[cfg(not(target_os = "macos"))]
             disable_ctlseqs_alt: false,
             ime_cursor_positioning: default_ime_cursor_positioning(),
+            forward_to_ime_modifier_mask: default_forward_to_ime_modifier_mask(),
         }
     }
 }

--- a/rio-backend/src/config/keyboard.rs
+++ b/rio-backend/src/config/keyboard.rs
@@ -25,7 +25,7 @@ pub struct Keyboard {
 
     // Modifier mask deciding when a key event is forwarded to the macOS IME.
     // A key event is forwarded when no modifier is pressed, or when the
-    // pressed modifiers intersect this mask. Otherwise the event is handled
+    // pressed modifiers are all contained in this mask. Otherwise the event is handled
     // directly by the application without going through the IME.
     //
     // Accepted values (case-insensitive): "shift", "ctrl", "alt", "super".

--- a/rio-window/src/platform/macos.rs
+++ b/rio-window/src/platform/macos.rs
@@ -17,6 +17,7 @@
 use std::os::raw::c_void;
 
 use crate::event_loop::{ActiveEventLoop, EventLoopBuilder};
+use crate::keyboard::ModifiersState;
 use crate::monitor::MonitorHandle;
 use crate::window::{Window, WindowAttributes};
 
@@ -105,6 +106,21 @@ pub trait WindowExtMacOS {
 
     /// Getter for the [`WindowExtMacOS::set_option_as_alt`].
     fn option_as_alt(&self) -> OptionAsAlt;
+
+    /// Set which modifier keys cause a key event to be forwarded to the macOS
+    /// IME (`interpretKeyEvents:`).
+    ///
+    /// A key event is forwarded to the IME when no modifier is pressed, OR
+    /// when the pressed modifiers intersect this mask. Otherwise the event is
+    /// handled directly by the application without going through the IME.
+    ///
+    /// This is useful for input methods (e.g. SKK) that need to receive
+    /// `Ctrl`/`Shift` combinations directly instead of having them processed
+    /// as terminal control sequences.
+    fn set_forward_to_ime_modifier_mask(&self, mask: ModifiersState);
+
+    /// Getter for the [`WindowExtMacOS::set_forward_to_ime_modifier_mask`].
+    fn forward_to_ime_modifier_mask(&self) -> ModifiersState;
 
     /// Makes the titlebar bigger, effectively adding more space around the
     /// window controls if the titlebar is invisible.
@@ -218,6 +234,18 @@ impl WindowExtMacOS for Window {
     #[inline]
     fn option_as_alt(&self) -> OptionAsAlt {
         self.window.maybe_wait_on_main(|w| w.option_as_alt())
+    }
+
+    #[inline]
+    fn set_forward_to_ime_modifier_mask(&self, mask: ModifiersState) {
+        self.window
+            .maybe_queue_on_main(move |w| w.set_forward_to_ime_modifier_mask(mask))
+    }
+
+    #[inline]
+    fn forward_to_ime_modifier_mask(&self) -> ModifiersState {
+        self.window
+            .maybe_wait_on_main(|w| w.forward_to_ime_modifier_mask())
     }
 
     #[inline]

--- a/rio-window/src/platform/macos.rs
+++ b/rio-window/src/platform/macos.rs
@@ -111,7 +111,7 @@ pub trait WindowExtMacOS {
     /// IME (`interpretKeyEvents:`).
     ///
     /// A key event is forwarded to the IME when no modifier is pressed, OR
-    /// when the pressed modifiers intersect this mask. Otherwise the event is
+    /// when the pressed modifiers are all contained in this mask. Otherwise the event is
     /// handled directly by the application without going through the IME.
     ///
     /// This is useful for input methods (e.g. SKK) that need to receive

--- a/rio-window/src/platform_impl/macos/view.rs
+++ b/rio-window/src/platform_impl/macos/view.rs
@@ -138,6 +138,13 @@ pub struct ViewState {
     /// True if we're currently processing a key event
     in_key_event: Cell<bool>,
 
+    /// Characters of the currently-processed key event, as reported by
+    /// `NSEvent`. Tuple of (characters, charactersIgnoringModifiers).
+    /// Used by `insertText:` to distinguish IME direct commits (e.g. SKK
+    /// hiragana mode) from raw keyboard pass-through (where the IME echoes
+    /// the same characters).
+    current_key_event_chars: RefCell<Option<(String, String)>>,
+
     marked_text: RefCell<Retained<NSMutableAttributedString>>,
     accepts_first_mouse: bool,
     mouse_down_can_move_window: bool,
@@ -147,6 +154,11 @@ pub struct ViewState {
 
     /// The state of the `Option` as `Alt`.
     option_as_alt: Cell<OptionAsAlt>,
+
+    /// Modifier mask deciding when a key event is forwarded to the IME.
+    /// A key event is forwarded when no modifier is pressed, or when the
+    /// pressed modifiers intersect this mask.
+    forward_to_ime_modifier_mask: Cell<ModifiersState>,
 }
 
 declare_class!(
@@ -422,23 +434,55 @@ declare_class!(
             let has_marked_text = unsafe { self.hasMarkedText() };
             let is_in_key_event = self.ivars().in_key_event.get();
 
+            // Detect IME direct commits (e.g. SKK hiragana mode) that bypass
+            // preedit: an `insertText:` whose payload differs from the raw
+            // NSEvent characters is something the IME synthesised, not a
+            // pass-through of the pressed key.
+            let is_ime_direct_commit = is_in_key_event
+                && self
+                    .ivars()
+                    .current_key_event_chars
+                    .borrow()
+                    .as_ref()
+                    .is_some_and(|(chars, chars_unmod)| {
+                        string != chars.as_str() && string != chars_unmod.as_str()
+                    });
+
             if self.is_ime_enabled() {
                 if has_marked_text && !is_control {
                     // Clear preedit and commit the text (normal IME flow)
                     self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
                     self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                     self.ivars().ime_state.set(ImeState::Committed);
-                } else if !is_control && !string.is_empty() && !is_in_key_event {
-                    // Direct input not from keyboard (e.g., emoji picker)
+                } else if !is_control
+                    && !string.is_empty()
+                    && (!is_in_key_event || is_ime_direct_commit)
+                {
+                    // Direct input not from keyboard (e.g., emoji picker) or
+                    // an IME committing without preedit (e.g., SKK).
                     self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                     self.ivars().ime_state.set(ImeState::Committed);
+                } else if is_in_key_event && !is_ime_direct_commit {
+                    // The IME passed the raw key through unchanged (typical
+                    // when the active input source is ASCII-only or the IME
+                    // is in a passthrough mode, e.g. SKK ASCII/eisuu mode).
+                    // Treat this as "IME did not consume the key" so the key
+                    // event is forwarded to the application.
+                    self.ivars().forward_key_to_app.set(true);
                 }
-            } else if !is_control && !string.is_empty() && !is_in_key_event {
+            } else if !is_control
+                && !string.is_empty()
+                && (!is_in_key_event || is_ime_direct_commit)
+            {
                 // IME is disabled but we got non-keyboard input (e.g., emoji picker)
-                // Temporarily enable IME for this input
+                // or an IME-style direct commit. Temporarily enable IME for
+                // this input.
                 self.queue_event(WindowEvent::Ime(Ime::Enabled));
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                 self.ivars().ime_state.set(ImeState::Committed);
+            } else if is_in_key_event && !is_ime_direct_commit {
+                // IME disabled and the IME echoed the raw key — forward it.
+                self.ivars().forward_key_to_app.set(true);
             }
         }
 
@@ -491,13 +535,32 @@ declare_class!(
             self.ivars().forward_key_to_app.set(false);
             let event = replace_event(event, self.option_as_alt());
 
+            // Snapshot the NSEvent characters so `insertText:` can tell IME
+            // direct commits (e.g. SKK hiragana mode) from raw key pass-through.
+            let chars = unsafe { event.characters() }
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            let chars_unmod = unsafe { event.charactersIgnoringModifiers() }
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            *self.ivars().current_key_event_chars.borrow_mut() =
+                Some((chars, chars_unmod));
+
             // The `interpretKeyEvents` function might call
             // `setMarkedText`, `insertText`, and `doCommandBySelector`.
             // It's important that we call this before queuing the KeyboardInput, because
             // we must send the `KeyboardInput` event during IME if it triggered
             // `doCommandBySelector`. (doCommandBySelector means that the keyboard input
             // is not handled by IME and should be handled by the application)
-            if self.ivars().ime_allowed.get() {
+            //
+            // The IME is bypassed when modifiers are pressed that do not intersect the
+            // configured `forward_to_ime_modifier_mask`. Events with no modifiers are
+            // always forwarded.
+            let mods = event_mods(&event).state();
+            let mask = self.ivars().forward_to_ime_modifier_mask.get();
+            let forward_to_ime = mods.is_empty() || mods.intersects(mask);
+            let routed_to_ime = self.ivars().ime_allowed.get() && forward_to_ime;
+            if routed_to_ime {
                 let events_for_nsview = NSArray::from_slice(&[&*event]);
                 unsafe { self.interpretKeyEvents(&events_for_nsview) };
 
@@ -521,7 +584,20 @@ declare_class!(
                 _ => old_ime_state != self.ivars().ime_state.get(),
             };
 
-            if !had_ime_input || self.ivars().forward_key_to_app.get() {
+            // When the event was routed through the IME, only forward it to
+            // the application if `doCommandBySelector:` explicitly asked us to
+            // (`forward_key_to_app`). Otherwise the IME is assumed to have
+            // consumed the key — even when it produced no NSTextInputClient
+            // callbacks (e.g. SKK switching input mode via
+            // `IMKTextInput.selectMode()` on Ctrl+J or `q`). When the event
+            // was *not* routed to the IME, fall back to the historical
+            // behavior of forwarding it as long as no preedit/commit happened.
+            let should_forward_key = if routed_to_ime {
+                self.ivars().forward_key_to_app.get()
+            } else {
+                !had_ime_input
+            };
+            if should_forward_key {
                 let key_event = create_key_event(&event, true, unsafe { event.isARepeat() }, None);
                 self.queue_event(WindowEvent::KeyboardInput {
                     device_id: DEVICE_ID,
@@ -532,6 +608,7 @@ declare_class!(
 
             // Clear the flag after processing
             self.ivars().in_key_event.set(false);
+            *self.ivars().current_key_event_chars.borrow_mut() = None;
         }
 
         #[method(keyUp:)]
@@ -864,6 +941,8 @@ impl WinitView {
             mouse_down_can_move_window,
             _ns_window: WeakId::new(&window.retain()),
             option_as_alt: Cell::new(option_as_alt),
+            forward_to_ime_modifier_mask: Cell::new(ModifiersState::all()),
+            current_key_event_chars: RefCell::new(None),
         });
         let this: Retained<Self> = unsafe { msg_send_id![super(this), init] };
 
@@ -1029,6 +1108,14 @@ impl WinitView {
 
     pub(super) fn option_as_alt(&self) -> OptionAsAlt {
         self.ivars().option_as_alt.get()
+    }
+
+    pub(super) fn set_forward_to_ime_modifier_mask(&self, value: ModifiersState) {
+        self.ivars().forward_to_ime_modifier_mask.set(value)
+    }
+
+    pub(super) fn forward_to_ime_modifier_mask(&self) -> ModifiersState {
+        self.ivars().forward_to_ime_modifier_mask.get()
     }
 
     /// Update modifiers if `event` has something different

--- a/rio-window/src/platform_impl/macos/view.rs
+++ b/rio-window/src/platform_impl/macos/view.rs
@@ -560,6 +560,23 @@ declare_class!(
             let mask = self.ivars().forward_to_ime_modifier_mask.get();
             let forward_to_ime = mods.is_empty() || mask.contains(mods);
             let routed_to_ime = self.ivars().ime_allowed.get() && forward_to_ime;
+
+            // Snapshot the input source before the IME sees the key. Some
+            // IMEs (AquaSKK, macSKK) switch input mode on bare keys — Ctrl+J
+            // for hiragana, `q` for katakana — through `selectMode()`, with
+            // no NSTextInputClient callback to observe. Each mode is a
+            // distinct input source, so a source ID that changed across
+            // `interpretKeyEvents` means the IME captured the key. Only
+            // checked outside composition: during preedit those keys produce
+            // `setMarkedText` calls and are handled by the state machine.
+            // (Same detection ghostty ships since ghostty-org/ghostty#4609.)
+            let marked_before = unsafe { self.hasMarkedText() };
+            let source_before = if routed_to_ime && !marked_before {
+                Some(self.current_input_source())
+            } else {
+                None
+            };
+
             if routed_to_ime {
                 let events_for_nsview = NSArray::from_slice(&[&*event]);
                 unsafe { self.interpretKeyEvents(&events_for_nsview) };
@@ -570,6 +587,9 @@ declare_class!(
                     *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
                 }
             }
+
+            let ime_switched_source = source_before
+                .is_some_and(|source| source != self.current_input_source());
 
             self.update_modifiers(&event, false);
 
@@ -584,18 +604,16 @@ declare_class!(
                 _ => old_ime_state != self.ivars().ime_state.get(),
             };
 
-            // When the event was routed through the IME, only forward it to
-            // the application if `doCommandBySelector:` explicitly asked us to
-            // (`forward_key_to_app`). Otherwise the IME is assumed to have
-            // consumed the key — even when it produced no NSTextInputClient
-            // callbacks (e.g. SKK switching input mode via
-            // `IMKTextInput.selectMode()` on Ctrl+J or `q`). When the event
-            // was *not* routed to the IME, fall back to the historical
-            // behavior of forwarding it as long as no preedit/commit happened.
-            let should_forward_key = if routed_to_ime {
-                self.ivars().forward_key_to_app.get()
+            // A key that switched the input source belongs to the IME, never
+            // the application. Everything else keeps the historical rule —
+            // forward unless the IME produced preedit/commit activity, or
+            // `doCommandBySelector:` explicitly asked us to forward — so an
+            // IME quietly inspecting a key (Chinese and Korean IMEs do this
+            // with Ctrl combinations) can't swallow app-bound input.
+            let should_forward_key = if ime_switched_source {
+                false
             } else {
-                !had_ime_input
+                !had_ime_input || self.ivars().forward_key_to_app.get()
             };
             if should_forward_key {
                 let key_event = create_key_event(&event, true, unsafe { event.isARepeat() }, None);

--- a/rio-window/src/platform_impl/macos/view.rs
+++ b/rio-window/src/platform_impl/macos/view.rs
@@ -157,7 +157,7 @@ pub struct ViewState {
 
     /// Modifier mask deciding when a key event is forwarded to the IME.
     /// A key event is forwarded when no modifier is pressed, or when the
-    /// pressed modifiers intersect this mask.
+    /// pressed modifiers are all contained in this mask.
     forward_to_ime_modifier_mask: Cell<ModifiersState>,
 }
 
@@ -553,12 +553,12 @@ declare_class!(
             // `doCommandBySelector`. (doCommandBySelector means that the keyboard input
             // is not handled by IME and should be handled by the application)
             //
-            // The IME is bypassed when modifiers are pressed that do not intersect the
+            // The IME is bypassed when any pressed modifier falls outside the
             // configured `forward_to_ime_modifier_mask`. Events with no modifiers are
             // always forwarded.
             let mods = event_mods(&event).state();
             let mask = self.ivars().forward_to_ime_modifier_mask.get();
-            let forward_to_ime = mods.is_empty() || mods.intersects(mask);
+            let forward_to_ime = mods.is_empty() || mask.contains(mods);
             let routed_to_ime = self.ivars().ime_allowed.get() && forward_to_ime;
             if routed_to_ime {
                 let events_for_nsview = NSArray::from_slice(&[&*event]);

--- a/rio-window/src/platform_impl/macos/window_delegate.rs
+++ b/rio-window/src/platform_impl/macos/window_delegate.rs
@@ -2257,6 +2257,14 @@ impl WindowExtMacOS for WindowDelegate {
         self.view().option_as_alt()
     }
 
+    fn set_forward_to_ime_modifier_mask(&self, mask: crate::keyboard::ModifiersState) {
+        self.view().set_forward_to_ime_modifier_mask(mask);
+    }
+
+    fn forward_to_ime_modifier_mask(&self) -> crate::keyboard::ModifiersState {
+        self.view().forward_to_ime_modifier_mask()
+    }
+
     fn set_unified_titlebar(&self, unified_titlebar: bool) {
         let window = self.window();
         if unified_titlebar {


### PR DESCRIPTION
Supersedes #1561, keeping @shiena's commit rebased onto current main, plus two review commits. Closes #1561.

## Original fix (@shiena)

Two SKK problems on macOS: direct-commit input (hiragana mode commits without preedit) was lost, and IME mode-switch keys (Ctrl+J, `q`) leaked to the shell as control sequences. The direct-commit detection (comparing the `insertText:` payload against the raw NSEvent characters) and the `keyboard.forward-to-ime-modifier-mask` config are kept as authored.

## Review commits on top

**1. Mode-switch keys are now detected by input-source change, not by swallowing quiet keys.** The original approach — treat any IME-routed key that produced no NSTextInputClient callback as consumed — is the pattern that bit ghostty after their SKK fix: Chinese and Korean IMEs quietly inspect Ctrl/Alt combinations without callbacks, so blanket swallowing kills app-bound keys like Ctrl+C during Hangul composition (ghostty-org/ghostty#10775, #10310). Ghostty's production fix (ghostty-org/ghostty#4609, shipped since Jan 2025 and still at HEAD) observes that AquaSKK/macSKK register each mode as a distinct macOS input source: snapshot the input-source ID before `interpretKeyEvents`, and swallow only when it changed during the event and no composition was active. This PR ports exactly that, reusing rio-window's existing `NSTextInputContext.selectedKeyboardInputSource()` wrapper — every other key keeps the historical forwarding rule, so quiet IME inspection can't eat app input.

**2. The modifier mask matches subsets, not intersections.** With `forward-to-ime-modifier-mask = ["ctrl"]`, Cmd+Ctrl+J now stays an app shortcut instead of routing to the IME because Ctrl overlapped. The default `all()` mask behaves identically under both semantics.

Tested: `cargo check`/`clippy` clean on rio-window, 172 rioterm tests pass, fmt clean. Manual SKK verification on a real macOS session is still worthwhile before merge — mode switching (Ctrl+J, q, l), hiragana direct commit, and Ctrl+C behavior under a Korean input source.