### PR TITLE
macos: decide IME key handling once per event, ghostty style

### DIFF
--- a/frontends/rioterm/src/bindings/mod.rs
+++ b/frontends/rioterm/src/bindings/mod.rs
@@ -749,7 +749,7 @@ pub fn default_key_bindings(config: &rio_backend::config::Config) -> Vec<KeyBind
     bindings.extend(platform_key_bindings(
         config.navigation.has_navigation_key_bindings(),
         config.navigation.use_split,
-        config.keyboard,
+        config.keyboard.clone(),
     ));
 
     // Add hint bindings

--- a/frontends/rioterm/src/router/window.rs
+++ b/frontends/rioterm/src/router/window.rs
@@ -201,6 +201,7 @@ pub fn configure_window(winit_window: &Window, config: &Config) {
         // OnlyRight - The right `Option` key is treated as `Alt`.
         // Both - Both `Option` keys are treated as `Alt`.
         // None - No special handling is applied for `Option` key.
+        use rio_window::keyboard::ModifiersState;
         use rio_window::platform::macos::{OptionAsAlt, WindowExtMacOS};
 
         match config.option_as_alt.to_lowercase().as_str() {
@@ -209,6 +210,20 @@ pub fn configure_window(winit_window: &Window, config: &Config) {
             "right" => winit_window.set_option_as_alt(OptionAsAlt::OnlyRight),
             _ => {}
         }
+
+        let mut mask = ModifiersState::empty();
+        for name in &config.keyboard.forward_to_ime_modifier_mask {
+            match name.to_lowercase().as_str() {
+                "shift" => mask |= ModifiersState::SHIFT,
+                "ctrl" | "control" => mask |= ModifiersState::CONTROL,
+                "alt" | "option" => mask |= ModifiersState::ALT,
+                "super" | "cmd" | "command" => mask |= ModifiersState::SUPER,
+                other => tracing::warn!(
+                    "ignoring unknown forward-to-ime-modifier-mask value: {other:?}"
+                ),
+            }
+        }
+        winit_window.set_forward_to_ime_modifier_mask(mask);
     }
 
     let is_transparent = config.window.opacity < 1.;

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -228,7 +228,7 @@ impl Screen<'_> {
             split_active_color: config.colors.split_active,
             panel: config.panel,
             title: config.title.clone(),
-            keyboard: config.keyboard,
+            keyboard: config.keyboard.clone(),
             scrollback_history_limit: config.scrollback_history_limit,
         };
 
@@ -502,7 +502,7 @@ impl Screen<'_> {
             .set_multiplier_and_divider(config.scroll.multiplier, config.scroll.divider);
 
         // Update keyboard config in context manager
-        self.context_manager.config.keyboard = config.keyboard;
+        self.context_manager.config.keyboard = config.keyboard.clone();
 
         // Re-evaluate the opaque flag — toggling `window.opacity` /
         // `window.blur` at runtime should flip the compositor mode.

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -148,6 +148,16 @@ pub fn default_ime_cursor_positioning() -> bool {
     true
 }
 
+#[inline]
+pub fn default_forward_to_ime_modifier_mask() -> Vec<String> {
+    vec![
+        String::from("shift"),
+        String::from("ctrl"),
+        String::from("alt"),
+        String::from("super"),
+    ]
+}
+
 pub fn default_config_file_content() -> String {
     String::from(
         "# See the full configuration reference: https://rioterm.com/docs/config\n",

--- a/rio-backend/src/config/keyboard.rs
+++ b/rio-backend/src/config/keyboard.rs
@@ -1,8 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use super::defaults::{default_disable_ctlseqs_alt, default_ime_cursor_positioning};
+use super::defaults::{
+    default_disable_ctlseqs_alt, default_forward_to_ime_modifier_mask,
+    default_ime_cursor_positioning,
+};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Keyboard {
     // Disable ctlseqs with ALT keys
     // For example: Terminal.app does not deal with ctlseqs with ALT keys
@@ -19,6 +22,20 @@ pub struct Keyboard {
         rename = "ime-cursor-positioning"
     )]
     pub ime_cursor_positioning: bool,
+
+    // Modifier mask deciding when a key event is forwarded to the macOS IME.
+    // A key event is forwarded when no modifier is pressed, or when the
+    // pressed modifiers intersect this mask. Otherwise the event is handled
+    // directly by the application without going through the IME.
+    //
+    // Accepted values (case-insensitive): "shift", "ctrl", "alt", "super".
+    // Useful for input methods like SKK that need to receive Ctrl+key
+    // combinations directly.
+    #[serde(
+        default = "default_forward_to_ime_modifier_mask",
+        rename = "forward-to-ime-modifier-mask"
+    )]
+    pub forward_to_ime_modifier_mask: Vec<String>,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -30,6 +47,7 @@ impl Default for Keyboard {
             #[cfg(not(target_os = "macos"))]
             disable_ctlseqs_alt: false,
             ime_cursor_positioning: default_ime_cursor_positioning(),
+            forward_to_ime_modifier_mask: default_forward_to_ime_modifier_mask(),
         }
     }
 }

--- a/rio-backend/src/config/keyboard.rs
+++ b/rio-backend/src/config/keyboard.rs
@@ -25,7 +25,7 @@ pub struct Keyboard {
 
     // Modifier mask deciding when a key event is forwarded to the macOS IME.
     // A key event is forwarded when no modifier is pressed, or when the
-    // pressed modifiers intersect this mask. Otherwise the event is handled
+    // pressed modifiers are all contained in this mask. Otherwise the event is handled
     // directly by the application without going through the IME.
     //
     // Accepted values (case-insensitive): "shift", "ctrl", "alt", "super".

--- a/rio-window/src/platform/macos.rs
+++ b/rio-window/src/platform/macos.rs
@@ -17,6 +17,7 @@
 use std::os::raw::c_void;
 
 use crate::event_loop::{ActiveEventLoop, EventLoopBuilder};
+use crate::keyboard::ModifiersState;
 use crate::monitor::MonitorHandle;
 use crate::window::{Window, WindowAttributes};
 
@@ -105,6 +106,21 @@ pub trait WindowExtMacOS {
 
     /// Getter for the [`WindowExtMacOS::set_option_as_alt`].
     fn option_as_alt(&self) -> OptionAsAlt;
+
+    /// Set which modifier keys cause a key event to be forwarded to the macOS
+    /// IME (`interpretKeyEvents:`).
+    ///
+    /// A key event is forwarded to the IME when no modifier is pressed, OR
+    /// when the pressed modifiers intersect this mask. Otherwise the event is
+    /// handled directly by the application without going through the IME.
+    ///
+    /// This is useful for input methods (e.g. SKK) that need to receive
+    /// `Ctrl`/`Shift` combinations directly instead of having them processed
+    /// as terminal control sequences.
+    fn set_forward_to_ime_modifier_mask(&self, mask: ModifiersState);
+
+    /// Getter for the [`WindowExtMacOS::set_forward_to_ime_modifier_mask`].
+    fn forward_to_ime_modifier_mask(&self) -> ModifiersState;
 
     /// Makes the titlebar bigger, effectively adding more space around the
     /// window controls if the titlebar is invisible.
@@ -218,6 +234,18 @@ impl WindowExtMacOS for Window {
     #[inline]
     fn option_as_alt(&self) -> OptionAsAlt {
         self.window.maybe_wait_on_main(|w| w.option_as_alt())
+    }
+
+    #[inline]
+    fn set_forward_to_ime_modifier_mask(&self, mask: ModifiersState) {
+        self.window
+            .maybe_queue_on_main(move |w| w.set_forward_to_ime_modifier_mask(mask))
+    }
+
+    #[inline]
+    fn forward_to_ime_modifier_mask(&self) -> ModifiersState {
+        self.window
+            .maybe_wait_on_main(|w| w.forward_to_ime_modifier_mask())
     }
 
     #[inline]

--- a/rio-window/src/platform/macos.rs
+++ b/rio-window/src/platform/macos.rs
@@ -111,7 +111,7 @@ pub trait WindowExtMacOS {
     /// IME (`interpretKeyEvents:`).
     ///
     /// A key event is forwarded to the IME when no modifier is pressed, OR
-    /// when the pressed modifiers intersect this mask. Otherwise the event is
+    /// when the pressed modifiers are all contained in this mask. Otherwise the event is
     /// handled directly by the application without going through the IME.
     ///
     /// This is useful for input methods (e.g. SKK) that need to receive

--- a/rio-window/src/platform_impl/macos/view.rs
+++ b/rio-window/src/platform_impl/macos/view.rs
@@ -138,6 +138,13 @@ pub struct ViewState {
     /// True if we're currently processing a key event
     in_key_event: Cell<bool>,
 
+    /// Characters of the currently-processed key event, as reported by
+    /// `NSEvent`. Tuple of (characters, charactersIgnoringModifiers).
+    /// Used by `insertText:` to distinguish IME direct commits (e.g. SKK
+    /// hiragana mode) from raw keyboard pass-through (where the IME echoes
+    /// the same characters).
+    current_key_event_chars: RefCell<Option<(String, String)>>,
+
     marked_text: RefCell<Retained<NSMutableAttributedString>>,
     accepts_first_mouse: bool,
     mouse_down_can_move_window: bool,
@@ -147,6 +154,11 @@ pub struct ViewState {
 
     /// The state of the `Option` as `Alt`.
     option_as_alt: Cell<OptionAsAlt>,
+
+    /// Modifier mask deciding when a key event is forwarded to the IME.
+    /// A key event is forwarded when no modifier is pressed, or when the
+    /// pressed modifiers intersect this mask.
+    forward_to_ime_modifier_mask: Cell<ModifiersState>,
 }
 
 declare_class!(
@@ -422,23 +434,55 @@ declare_class!(
             let has_marked_text = unsafe { self.hasMarkedText() };
             let is_in_key_event = self.ivars().in_key_event.get();
 
+            // Detect IME direct commits (e.g. SKK hiragana mode) that bypass
+            // preedit: an `insertText:` whose payload differs from the raw
+            // NSEvent characters is something the IME synthesised, not a
+            // pass-through of the pressed key.
+            let is_ime_direct_commit = is_in_key_event
+                && self
+                    .ivars()
+                    .current_key_event_chars
+                    .borrow()
+                    .as_ref()
+                    .is_some_and(|(chars, chars_unmod)| {
+                        string != chars.as_str() && string != chars_unmod.as_str()
+                    });
+
             if self.is_ime_enabled() {
                 if has_marked_text && !is_control {
                     // Clear preedit and commit the text (normal IME flow)
                     self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
                     self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                     self.ivars().ime_state.set(ImeState::Committed);
-                } else if !is_control && !string.is_empty() && !is_in_key_event {
-                    // Direct input not from keyboard (e.g., emoji picker)
+                } else if !is_control
+                    && !string.is_empty()
+                    && (!is_in_key_event || is_ime_direct_commit)
+                {
+                    // Direct input not from keyboard (e.g., emoji picker) or
+                    // an IME committing without preedit (e.g., SKK).
                     self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                     self.ivars().ime_state.set(ImeState::Committed);
+                } else if is_in_key_event && !is_ime_direct_commit {
+                    // The IME passed the raw key through unchanged (typical
+                    // when the active input source is ASCII-only or the IME
+                    // is in a passthrough mode, e.g. SKK ASCII/eisuu mode).
+                    // Treat this as "IME did not consume the key" so the key
+                    // event is forwarded to the application.
+                    self.ivars().forward_key_to_app.set(true);
                 }
-            } else if !is_control && !string.is_empty() && !is_in_key_event {
+            } else if !is_control
+                && !string.is_empty()
+                && (!is_in_key_event || is_ime_direct_commit)
+            {
                 // IME is disabled but we got non-keyboard input (e.g., emoji picker)
-                // Temporarily enable IME for this input
+                // or an IME-style direct commit. Temporarily enable IME for
+                // this input.
                 self.queue_event(WindowEvent::Ime(Ime::Enabled));
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                 self.ivars().ime_state.set(ImeState::Committed);
+            } else if is_in_key_event && !is_ime_direct_commit {
+                // IME disabled and the IME echoed the raw key — forward it.
+                self.ivars().forward_key_to_app.set(true);
             }
         }
 
@@ -491,13 +535,32 @@ declare_class!(
             self.ivars().forward_key_to_app.set(false);
             let event = replace_event(event, self.option_as_alt());
 
+            // Snapshot the NSEvent characters so `insertText:` can tell IME
+            // direct commits (e.g. SKK hiragana mode) from raw key pass-through.
+            let chars = unsafe { event.characters() }
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            let chars_unmod = unsafe { event.charactersIgnoringModifiers() }
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            *self.ivars().current_key_event_chars.borrow_mut() =
+                Some((chars, chars_unmod));
+
             // The `interpretKeyEvents` function might call
             // `setMarkedText`, `insertText`, and `doCommandBySelector`.
             // It's important that we call this before queuing the KeyboardInput, because
             // we must send the `KeyboardInput` event during IME if it triggered
             // `doCommandBySelector`. (doCommandBySelector means that the keyboard input
             // is not handled by IME and should be handled by the application)
-            if self.ivars().ime_allowed.get() {
+            //
+            // The IME is bypassed when modifiers are pressed that do not intersect the
+            // configured `forward_to_ime_modifier_mask`. Events with no modifiers are
+            // always forwarded.
+            let mods = event_mods(&event).state();
+            let mask = self.ivars().forward_to_ime_modifier_mask.get();
+            let forward_to_ime = mods.is_empty() || mods.intersects(mask);
+            let routed_to_ime = self.ivars().ime_allowed.get() && forward_to_ime;
+            if routed_to_ime {
                 let events_for_nsview = NSArray::from_slice(&[&*event]);
                 unsafe { self.interpretKeyEvents(&events_for_nsview) };
 
@@ -521,7 +584,20 @@ declare_class!(
                 _ => old_ime_state != self.ivars().ime_state.get(),
             };
 
-            if !had_ime_input || self.ivars().forward_key_to_app.get() {
+            // When the event was routed through the IME, only forward it to
+            // the application if `doCommandBySelector:` explicitly asked us to
+            // (`forward_key_to_app`). Otherwise the IME is assumed to have
+            // consumed the key — even when it produced no NSTextInputClient
+            // callbacks (e.g. SKK switching input mode via
+            // `IMKTextInput.selectMode()` on Ctrl+J or `q`). When the event
+            // was *not* routed to the IME, fall back to the historical
+            // behavior of forwarding it as long as no preedit/commit happened.
+            let should_forward_key = if routed_to_ime {
+                self.ivars().forward_key_to_app.get()
+            } else {
+                !had_ime_input
+            };
+            if should_forward_key {
                 let key_event = create_key_event(&event, true, unsafe { event.isARepeat() }, None);
                 self.queue_event(WindowEvent::KeyboardInput {
                     device_id: DEVICE_ID,
@@ -532,6 +608,7 @@ declare_class!(
 
             // Clear the flag after processing
             self.ivars().in_key_event.set(false);
+            *self.ivars().current_key_event_chars.borrow_mut() = None;
         }
 
         #[method(keyUp:)]
@@ -864,6 +941,8 @@ impl WinitView {
             mouse_down_can_move_window,
             _ns_window: WeakId::new(&window.retain()),
             option_as_alt: Cell::new(option_as_alt),
+            forward_to_ime_modifier_mask: Cell::new(ModifiersState::all()),
+            current_key_event_chars: RefCell::new(None),
         });
         let this: Retained<Self> = unsafe { msg_send_id![super(this), init] };
 
@@ -1029,6 +1108,14 @@ impl WinitView {
 
     pub(super) fn option_as_alt(&self) -> OptionAsAlt {
         self.ivars().option_as_alt.get()
+    }
+
+    pub(super) fn set_forward_to_ime_modifier_mask(&self, value: ModifiersState) {
+        self.ivars().forward_to_ime_modifier_mask.set(value)
+    }
+
+    pub(super) fn forward_to_ime_modifier_mask(&self) -> ModifiersState {
+        self.ivars().forward_to_ime_modifier_mask.get()
     }
 
     /// Update modifiers if `event` has something different

--- a/rio-window/src/platform_impl/macos/view.rs
+++ b/rio-window/src/platform_impl/macos/view.rs
@@ -560,6 +560,23 @@ declare_class!(
             let mask = self.ivars().forward_to_ime_modifier_mask.get();
             let forward_to_ime = mods.is_empty() || mask.contains(mods);
             let routed_to_ime = self.ivars().ime_allowed.get() && forward_to_ime;
+
+            // Snapshot the input source before the IME sees the key. Some
+            // IMEs (AquaSKK, macSKK) switch input mode on bare keys — Ctrl+J
+            // for hiragana, `q` for katakana — through `selectMode()`, with
+            // no NSTextInputClient callback to observe. Each mode is a
+            // distinct input source, so a source ID that changed across
+            // `interpretKeyEvents` means the IME captured the key. Only
+            // checked outside composition: during preedit those keys produce
+            // `setMarkedText` calls and are handled by the state machine.
+            // (Same detection ghostty ships since ghostty-org/ghostty#4609.)
+            let marked_before = unsafe { self.hasMarkedText() };
+            let source_before = if routed_to_ime && !marked_before {
+                Some(self.current_input_source())
+            } else {
+                None
+            };
+
             if routed_to_ime {
                 let events_for_nsview = NSArray::from_slice(&[&*event]);
                 unsafe { self.interpretKeyEvents(&events_for_nsview) };
@@ -570,6 +587,9 @@ declare_class!(
                     *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
                 }
             }
+
+            let ime_switched_source = source_before
+                .is_some_and(|source| source != self.current_input_source());
 
             self.update_modifiers(&event, false);
 
@@ -584,18 +604,16 @@ declare_class!(
                 _ => old_ime_state != self.ivars().ime_state.get(),
             };
 
-            // When the event was routed through the IME, only forward it to
-            // the application if `doCommandBySelector:` explicitly asked us to
-            // (`forward_key_to_app`). Otherwise the IME is assumed to have
-            // consumed the key — even when it produced no NSTextInputClient
-            // callbacks (e.g. SKK switching input mode via
-            // `IMKTextInput.selectMode()` on Ctrl+J or `q`). When the event
-            // was *not* routed to the IME, fall back to the historical
-            // behavior of forwarding it as long as no preedit/commit happened.
-            let should_forward_key = if routed_to_ime {
-                self.ivars().forward_key_to_app.get()
+            // A key that switched the input source belongs to the IME, never
+            // the application. Everything else keeps the historical rule —
+            // forward unless the IME produced preedit/commit activity, or
+            // `doCommandBySelector:` explicitly asked us to forward — so an
+            // IME quietly inspecting a key (Chinese and Korean IMEs do this
+            // with Ctrl combinations) can't swallow app-bound input.
+            let should_forward_key = if ime_switched_source {
+                false
             } else {
-                !had_ime_input
+                !had_ime_input || self.ivars().forward_key_to_app.get()
             };
             if should_forward_key {
                 let key_event = create_key_event(&event, true, unsafe { event.isARepeat() }, None);

--- a/rio-window/src/platform_impl/macos/view.rs
+++ b/rio-window/src/platform_impl/macos/view.rs
@@ -157,7 +157,7 @@ pub struct ViewState {
 
     /// Modifier mask deciding when a key event is forwarded to the IME.
     /// A key event is forwarded when no modifier is pressed, or when the
-    /// pressed modifiers intersect this mask.
+    /// pressed modifiers are all contained in this mask.
     forward_to_ime_modifier_mask: Cell<ModifiersState>,
 }
 
@@ -553,12 +553,12 @@ declare_class!(
             // `doCommandBySelector`. (doCommandBySelector means that the keyboard input
             // is not handled by IME and should be handled by the application)
             //
-            // The IME is bypassed when modifiers are pressed that do not intersect the
+            // The IME is bypassed when any pressed modifier falls outside the
             // configured `forward_to_ime_modifier_mask`. Events with no modifiers are
             // always forwarded.
             let mods = event_mods(&event).state();
             let mask = self.ivars().forward_to_ime_modifier_mask.get();
-            let forward_to_ime = mods.is_empty() || mods.intersects(mask);
+            let forward_to_ime = mods.is_empty() || mask.contains(mods);
             let routed_to_ime = self.ivars().ime_allowed.get() && forward_to_ime;
             if routed_to_ime {
                 let events_for_nsview = NSArray::from_slice(&[&*event]);

--- a/rio-window/src/platform_impl/macos/view.rs
+++ b/rio-window/src/platform_impl/macos/view.rs
@@ -135,15 +135,13 @@ pub struct ViewState {
     /// to the application, even during IME
     forward_key_to_app: Cell<bool>,
 
-    /// True if we're currently processing a key event
-    in_key_event: Cell<bool>,
-
-    /// Characters of the currently-processed key event, as reported by
-    /// `NSEvent`. Tuple of (characters, charactersIgnoringModifiers).
-    /// Used by `insertText:` to distinguish IME direct commits (e.g. SKK
-    /// hiragana mode) from raw keyboard pass-through (where the IME echoes
-    /// the same characters).
-    current_key_event_chars: RefCell<Option<(String, String)>>,
+    /// Text the IME committed during the current `keyDown` event.
+    /// `Some` doubles as "we are inside a key event": while it is set,
+    /// `insertText:` only records into it and `keyDown` decides afterwards
+    /// what each string means (echo, direct commit, preedit commit) with
+    /// the whole `interpretKeyEvents` round trip visible. `None` outside
+    /// key events, where `insertText:` means picker/dictation input.
+    key_text_accumulator: RefCell<Option<Vec<String>>>,
 
     marked_text: RefCell<Retained<NSMutableAttributedString>>,
     accepts_first_mouse: bool,
@@ -430,60 +428,33 @@ declare_class!(
                 unsafe { &*string }.to_string()
             };
 
-            let is_control = string.chars().next().is_some_and(|c| c.is_control());
-            let has_marked_text = unsafe { self.hasMarkedText() };
-            let is_in_key_event = self.ivars().in_key_event.get();
-
-            // Detect IME direct commits (e.g. SKK hiragana mode) that bypass
-            // preedit: an `insertText:` whose payload differs from the raw
-            // NSEvent characters is something the IME synthesised, not a
-            // pass-through of the pressed key.
-            let is_ime_direct_commit = is_in_key_event
-                && self
-                    .ivars()
-                    .current_key_event_chars
-                    .borrow()
-                    .as_ref()
-                    .is_some_and(|(chars, chars_unmod)| {
-                        string != chars.as_str() && string != chars_unmod.as_str()
-                    });
-
-            if self.is_ime_enabled() {
-                if has_marked_text && !is_control {
-                    // Clear preedit and commit the text (normal IME flow)
-                    self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
-                    self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
-                    self.ivars().ime_state.set(ImeState::Committed);
-                } else if !is_control
-                    && !string.is_empty()
-                    && (!is_in_key_event || is_ime_direct_commit)
-                {
-                    // Direct input not from keyboard (e.g., emoji picker) or
-                    // an IME committing without preedit (e.g., SKK).
-                    self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
-                    self.ivars().ime_state.set(ImeState::Committed);
-                } else if is_in_key_event && !is_ime_direct_commit {
-                    // The IME passed the raw key through unchanged (typical
-                    // when the active input source is ASCII-only or the IME
-                    // is in a passthrough mode, e.g. SKK ASCII/eisuu mode).
-                    // Treat this as "IME did not consume the key" so the key
-                    // event is forwarded to the application.
-                    self.ivars().forward_key_to_app.set(true);
-                }
-            } else if !is_control
-                && !string.is_empty()
-                && (!is_in_key_event || is_ime_direct_commit)
+            // Inside a key event: record the text and return. `keyDown`
+            // decides what it means — echo, direct commit, preedit commit —
+            // once `interpretKeyEvents` has fully run and preedit history,
+            // input-source switches and the raw event are all visible.
+            if let Some(accumulator) =
+                self.ivars().key_text_accumulator.borrow_mut().as_mut()
             {
-                // IME is disabled but we got non-keyboard input (e.g., emoji picker)
-                // or an IME-style direct commit. Temporarily enable IME for
-                // this input.
-                self.queue_event(WindowEvent::Ime(Ime::Enabled));
-                self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
-                self.ivars().ime_state.set(ImeState::Committed);
-            } else if is_in_key_event && !is_ime_direct_commit {
-                // IME disabled and the IME echoed the raw key — forward it.
-                self.ivars().forward_key_to_app.set(true);
+                accumulator.push(string);
+                return;
             }
+
+            // Input arriving outside any key event: emoji picker, character
+            // viewer, dictation, or an IME candidate-window click.
+            let is_control = string.chars().next().is_some_and(|c| c.is_control());
+            if string.is_empty() || is_control {
+                return;
+            }
+            if unsafe { self.hasMarkedText() } {
+                // A candidate click commits the composition it replaces.
+                self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
+            }
+            if !self.is_ime_enabled() {
+                // Temporarily enable IME so the commit is deliverable.
+                self.queue_event(WindowEvent::Ime(Ime::Enabled));
+            }
+            self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
+            self.ivars().ime_state.set(ImeState::Committed);
         }
 
         // Basically, we're sent this message whenever a keyboard event that doesn't generate a "human
@@ -491,9 +462,20 @@ declare_class!(
         #[method(doCommandBySelector:)]
         fn do_command_by_selector(&self, _command: Sel) {
             trace_scope!("doCommandBySelector:");
-            // We shouldn't forward any character from just committed text, since we'll end up sending
-            // it twice with some IMEs like Korean one. We'll also always send `Enter` in that case,
-            // which is not desired given it was used to confirm IME input.
+            // A selector arriving after the IME already committed text within
+            // this same key event (Korean Enter) is the IME confirming that
+            // commit; forwarding the key too would type it twice.
+            if self
+                .ivars()
+                .key_text_accumulator
+                .borrow()
+                .as_ref()
+                .is_some_and(|accumulator| !accumulator.is_empty())
+            {
+                return;
+            }
+            // Same protection when the commit landed outside a key event
+            // (candidate-window click) right before this key.
             if self.ivars().ime_state.get() == ImeState::Committed {
                 return;
             }
@@ -516,8 +498,9 @@ declare_class!(
             // Mark input received for 1-second presentation window
             self.mark_input_received();
 
-            // Set flag to indicate we're in a key event
-            self.ivars().in_key_event.set(true);
+            // Non-None marks "inside a key event": `insertText:` records
+            // committed text here instead of interpreting it.
+            *self.ivars().key_text_accumulator.borrow_mut() = Some(Vec::new());
 
             {
                 let mut prev_input_source = self.ivars().input_source.borrow_mut();
@@ -530,21 +513,17 @@ declare_class!(
                 }
             }
 
+            // A commit that landed outside any key event (candidate-window
+            // click) can leave stale marked text behind; drop it before
+            // reading the preedit state for this key.
+            if self.ivars().ime_state.get() == ImeState::Committed {
+                *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
+            }
+
             // Get the characters from the event.
             let old_ime_state = self.ivars().ime_state.get();
             self.ivars().forward_key_to_app.set(false);
             let event = replace_event(event, self.option_as_alt());
-
-            // Snapshot the NSEvent characters so `insertText:` can tell IME
-            // direct commits (e.g. SKK hiragana mode) from raw key pass-through.
-            let chars = unsafe { event.characters() }
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-            let chars_unmod = unsafe { event.charactersIgnoringModifiers() }
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-            *self.ivars().current_key_event_chars.borrow_mut() =
-                Some((chars, chars_unmod));
 
             // The `interpretKeyEvents` function might call
             // `setMarkedText`, `insertText`, and `doCommandBySelector`.
@@ -580,12 +559,6 @@ declare_class!(
             if routed_to_ime {
                 let events_for_nsview = NSArray::from_slice(&[&*event]);
                 unsafe { self.interpretKeyEvents(&events_for_nsview) };
-
-                // If the text was committed we must treat the next keyboard event as IME related.
-                if self.ivars().ime_state.get() == ImeState::Committed {
-                    // Remove any marked text, so normal input can continue.
-                    *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
-                }
             }
 
             let ime_switched_source = source_before
@@ -593,28 +566,99 @@ declare_class!(
 
             self.update_modifiers(&event, false);
 
-            let had_ime_input = match self.ivars().ime_state.get() {
-                ImeState::Committed => {
-                    // Allow normal input after the commit.
-                    self.ivars().ime_state.set(ImeState::Ground);
-                    true
-                }
-                ImeState::Preedit => true,
-                // `key_down` could result in preedit clear, so compare old and current state.
-                _ => old_ime_state != self.ivars().ime_state.get(),
-            };
+            let committed_text = self
+                .ivars()
+                .key_text_accumulator
+                .borrow_mut()
+                .take()
+                .unwrap_or_default();
 
-            // A key that switched the input source belongs to the IME, never
-            // the application. Everything else keeps the historical rule —
-            // forward unless the IME produced preedit/commit activity, or
-            // `doCommandBySelector:` explicitly asked us to forward — so an
-            // IME quietly inspecting a key (Chinese and Korean IMEs do this
-            // with Ctrl combinations) can't swallow app-bound input.
-            let should_forward_key = if ime_switched_source {
-                false
-            } else {
-                !had_ime_input || self.ivars().forward_key_to_app.get()
-            };
+            // A key that switched the input source belongs to the IME
+            // entirely, text and all: mode-switch keys never reach the
+            // application.
+            if ime_switched_source {
+                return;
+            }
+
+            // Deliver whatever the IME committed during this key event,
+            // deciding here — with preedit history and the raw event both
+            // known — what each string means.
+            let chars = unsafe { event.characters() }
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            let chars_unmod = unsafe { event.charactersIgnoringModifiers() }
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            let composing = marked_before || unsafe { self.hasMarkedText() };
+            let mut forward_echo = false;
+            let mut committed_any = false;
+            for text in committed_text {
+                if text.is_empty() {
+                    continue;
+                }
+                // A bare C0 control accumulated while composing (ctrl+h
+                // cancelling romaji) is the IME editing its own preedit,
+                // not terminal input.
+                if composing
+                    && text.chars().count() == 1
+                    && text.chars().next().is_some_and(|c| (c as u32) < 0x20)
+                {
+                    continue;
+                }
+                // The IME echoed the raw key through unchanged (ASCII/eisuu
+                // passthrough): encode it as the key event below, not as
+                // committed text.
+                if !marked_before && (text == chars || text == chars_unmod) {
+                    forward_echo = true;
+                    continue;
+                }
+                // A preedit commit or a direct commit (SKK hiragana).
+                if !committed_any {
+                    // Clear the preedit the commit consumed — unless the IME
+                    // already started a fresh one this event (continuous
+                    // conversion), which `setMarkedText` reported itself.
+                    if marked_before && self.ivars().ime_state.get() != ImeState::Preedit
+                    {
+                        self.queue_event(WindowEvent::Ime(Ime::Preedit(
+                            String::new(),
+                            None,
+                        )));
+                    }
+                    if !self.is_ime_enabled() {
+                        self.queue_event(WindowEvent::Ime(Ime::Enabled));
+                    }
+                }
+                self.queue_event(WindowEvent::Ime(Ime::Commit(text)));
+                committed_any = true;
+            }
+            if committed_any && self.ivars().ime_state.get() != ImeState::Preedit {
+                // The commit consumed the composition; reset to ground so
+                // the next key starts clean. When the IME began a fresh
+                // preedit in the same event, that state stays untouched.
+                *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
+                self.ivars().ime_state.set(ImeState::Ground);
+            }
+
+            let had_ime_input = committed_any
+                || match self.ivars().ime_state.get() {
+                    ImeState::Committed => {
+                        // An external commit right before this key: allow
+                        // normal input again after swallowing this one.
+                        self.ivars().ime_state.set(ImeState::Ground);
+                        true
+                    }
+                    ImeState::Preedit => true,
+                    // `key_down` could result in preedit clear, so compare old and current state.
+                    _ => old_ime_state != self.ivars().ime_state.get(),
+                };
+
+            // Forward unless the IME produced preedit/commit activity this
+            // event; `doCommandBySelector:` and an echoed passthrough both
+            // override, so an IME quietly inspecting a key (Chinese and
+            // Korean IMEs do this with Ctrl combinations) can't swallow
+            // app-bound input.
+            let should_forward_key =
+                forward_echo || !had_ime_input || self.ivars().forward_key_to_app.get();
             if should_forward_key {
                 let key_event = create_key_event(&event, true, unsafe { event.isARepeat() }, None);
                 self.queue_event(WindowEvent::KeyboardInput {
@@ -623,18 +667,16 @@ declare_class!(
                     is_synthetic: false,
                 });
             }
-
-            // Clear the flag after processing
-            self.ivars().in_key_event.set(false);
-            *self.ivars().current_key_event_chars.borrow_mut() = None;
         }
 
         #[method(keyUp:)]
         fn key_up(&self, event: &NSEvent) {
             trace_scope!("keyUp:");
 
-            // Set flag to indicate we're in a key event
-            self.ivars().in_key_event.set(true);
+            // Mark "inside a key event" so a stray `insertText:` during
+            // key-up is not mistaken for picker/dictation input; anything
+            // accumulated here is dropped.
+            *self.ivars().key_text_accumulator.borrow_mut() = Some(Vec::new());
 
             let event = replace_event(event, self.option_as_alt());
             self.update_modifiers(&event, false);
@@ -651,8 +693,7 @@ declare_class!(
                 });
             }
 
-            // Clear the flag after processing
-            self.ivars().in_key_event.set(false);
+            *self.ivars().key_text_accumulator.borrow_mut() = None;
         }
 
         #[method(flagsChanged:)]
@@ -953,14 +994,13 @@ impl WinitView {
             input_source: Default::default(),
             ime_allowed: Default::default(),
             forward_key_to_app: Default::default(),
-            in_key_event: Default::default(),
+            key_text_accumulator: RefCell::new(None),
             marked_text: Default::default(),
             accepts_first_mouse,
             mouse_down_can_move_window,
             _ns_window: WeakId::new(&window.retain()),
             option_as_alt: Cell::new(option_as_alt),
             forward_to_ime_modifier_mask: Cell::new(ModifiersState::all()),
-            current_key_event_chars: RefCell::new(None),
         });
         let this: Retained<Self> = unsafe { msg_send_id![super(this), init] };
 

--- a/rio-window/src/platform_impl/macos/window_delegate.rs
+++ b/rio-window/src/platform_impl/macos/window_delegate.rs
@@ -2257,6 +2257,14 @@ impl WindowExtMacOS for WindowDelegate {
         self.view().option_as_alt()
     }
 
+    fn set_forward_to_ime_modifier_mask(&self, mask: crate::keyboard::ModifiersState) {
+        self.view().set_forward_to_ime_modifier_mask(mask);
+    }
+
+    fn forward_to_ime_modifier_mask(&self) -> crate::keyboard::ModifiersState {
+        self.view().forward_to_ime_modifier_mask()
+    }
+
     fn set_unified_titlebar(&self, unified_titlebar: bool) {
         let window = self.window();
         if unified_titlebar {


### PR DESCRIPTION
Stacked on #1845 (base branch is `macos-skk-ime-mask`) — structural follow-up, not a behavior fix. Draft until it gets hardware IME testing.

## What this does

Ports ghostty's control-flow shape for `NSTextInputClient`: during a key event, `insertText:` only **accumulates** committed strings; `keyDown` classifies everything afterwards, when `interpretKeyEvents` has fully run and every fact is known (preedit before/after, input-source switch, the raw event characters). Decisions that were scattered across five callbacks now happen in one place.

Deleted state: `in_key_event` (the accumulator's `None`/`Some` is that flag, ghostty's nil pattern) and `current_key_event_chars` (the echo-vs-commit comparison moves into keyDown where it no longer needs a smuggled snapshot). The `insert_text` six-branch tree becomes "in a key event? record : picker/dictation path".

## Behavior preserved (traced case by case)

- **Korean Enter double-commit** (winit#2147): `doCommandBySelector:` now checks the accumulator — a selector following committed text in the same event is the IME confirming the commit and is not forwarded. The `ImeState::Committed` guard stays for commits landing outside key events (candidate-window click), which also get their stale marked text dropped at the next keyDown.
- **Continuous conversion** (commit + fresh `setMarkedText` in one event): the preedit-clear is only queued when the IME did *not* start a new preedit this event, so the fresh preedit survives; event order matches the old callback-time interleaving.
- SKK direct commits, ASCII/eisuu echo passthrough, preedit cancel via Escape, the input-source-switch swallow, and the modifier mask all behave as on #1845.

## One deliberate change

A bare C0 control the IME commits **while composing** (ctrl+h editing romaji) now stays with the IME instead of being forwarded — previously the echo path forwarded it, which could delete terminal characters mid-composition. This mirrors ghostty's `shouldSuppressComposingControlInput`.

Verified: `cargo check`/`clippy` zero warnings, fmt clean, 172 rioterm tests. Needs manual verification with Japanese (romaji + SKK), Korean, and dead-key layouts before leaving draft.