### PR TITLE
Dim and bold no longer recolor a cell background

### DIFF
--- a/frontends/rioterm/src/grid_emit.rs
+++ b/frontends/rioterm/src/grid_emit.rs
@@ -2817,3 +2817,65 @@ mod cluster_text_tests {
         assert_eq!(out, [0, 0, 1]);
     }
 }
+
+#[cfg(test)]
+mod cell_bg_tests {
+    use super::*;
+    use rio_backend::config::colors::ColorRgb;
+    use rio_backend::config::Config;
+
+    /// End-to-end guard for the tmux faint-text regression.
+    ///
+    /// Inside tmux the pane background is not the terminal default:
+    /// tmux keeps OSC 11 per pane and re-emits it as an explicit
+    /// `\e[48;2;R;G;Bm` on every cell it draws. A faint cell therefore
+    /// arrives here as `Spec(bg) + DIM`, and used to be painted at
+    /// `bg * DIM_FACTOR`, a dark block behind the glyphs while the
+    /// untouched cells around it kept the real background.
+    #[test]
+    fn dim_cell_paints_its_explicit_background_unchanged() {
+        let renderer = Renderer::new(&Config::default());
+        let colors = TermColors::default();
+        let sq = Square::from_char('x');
+        let bg = ColorRgb {
+            r: 0x28,
+            g: 0x2c,
+            b: 0x34,
+        };
+        let style = Style {
+            bg: AnsiColor::Spec(bg),
+            ..Style::default()
+        };
+
+        let plain = cell_bg(sq, style, &renderer, &colors);
+        let dimmed = cell_bg(
+            sq,
+            Style {
+                flags: StyleFlags::DIM,
+                ..style
+            },
+            &renderer,
+            &colors,
+        );
+
+        assert_eq!(plain, [0x28, 0x2c, 0x34, 255]);
+        assert_eq!(dimmed, plain);
+    }
+
+    /// A faint cell that never had its background set still paints
+    /// nothing, so window transparency keeps showing through.
+    #[test]
+    fn dim_cell_with_default_background_stays_unpainted() {
+        let renderer = Renderer::new(&Config::default());
+        let colors = TermColors::default();
+        let style = Style {
+            flags: StyleFlags::DIM,
+            ..Style::default()
+        };
+
+        assert_eq!(
+            cell_bg(Square::from_char('x'), style, &renderer, &colors),
+            [0, 0, 0, 0]
+        );
+    }
+}

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -231,14 +231,30 @@ impl Renderer {
         }
     }
 
+    /// Resolve the color painted as a cell's background.
+    ///
+    /// DIM (SGR 2) and BOLD (SGR 1) are *glyph* intensity attributes:
+    /// per ECMA-48 they change how the character is rendered, never
+    /// the area behind it. They only reach a background here when
+    /// INVERSE already swapped fg/bg in `cell_style`, in which case
+    /// the "background" is really the foreground color and keeps its
+    /// intensity.
+    ///
+    /// Without this gate, faint text over an explicitly-set
+    /// background (`\e[48;2;R;G;Bm`, or a palette index) paints a
+    /// darkened block behind the glyphs. tmux hits this constantly:
+    /// it tracks OSC 11 per pane, so it re-emits the pane background
+    /// as an explicit SGR 48 on every dim cell instead of leaving it
+    /// as the terminal default.
     #[inline]
     pub(crate) fn compute_bg_color(
         &self,
         cell_style: &CellStyle,
         term_colors: &TermColors,
     ) -> ColorArray {
-        let dim = cell_style.flags.contains(StyleFlags::DIM);
-        let bold = cell_style.flags.contains(StyleFlags::BOLD);
+        let inverse = cell_style.flags.contains(StyleFlags::INVERSE);
+        let dim = inverse && cell_style.flags.contains(StyleFlags::DIM);
+        let bold = inverse && cell_style.flags.contains(StyleFlags::BOLD);
         match cell_style.bg {
             AnsiColor::Named(ansi) => self.color(ansi as usize, term_colors),
             AnsiColor::Spec(rgb) => {
@@ -976,5 +992,116 @@ impl Renderer {
                 overlays.push(overlay);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod compute_bg_color_tests {
+    use super::*;
+    use rio_backend::config::colors::ColorRgb;
+
+    fn renderer(draw_bold_text_with_light_colors: bool) -> Renderer {
+        Renderer::new(&Config {
+            draw_bold_text_with_light_colors,
+            ..Config::default()
+        })
+    }
+
+    fn style(bg: AnsiColor, flags: StyleFlags) -> CellStyle {
+        CellStyle {
+            bg,
+            flags,
+            ..CellStyle::default()
+        }
+    }
+
+    /// The reported regression: faint text over an explicitly-set RGB
+    /// background painted a darker block behind the glyphs. tmux
+    /// tracks OSC 11 per pane and re-emits it as `\e[48;2;40;44;52m`
+    /// on every cell, so `SGR 2` used to scale the pane background by
+    /// `DIM_FACTOR` and break it out of the surrounding field.
+    #[test]
+    fn dim_leaves_an_explicit_rgb_background_alone() {
+        let r = renderer(false);
+        let colors = TermColors::default();
+        let bg = ColorRgb {
+            r: 0x28,
+            g: 0x2c,
+            b: 0x34,
+        };
+
+        let plain =
+            r.compute_bg_color(&style(AnsiColor::Spec(bg), StyleFlags::empty()), &colors);
+        let dimmed =
+            r.compute_bg_color(&style(AnsiColor::Spec(bg), StyleFlags::DIM), &colors);
+
+        assert_eq!(plain, bg.to_arr());
+        assert_eq!(dimmed, plain);
+    }
+
+    /// Same rule for the palette: `SGR 2` must not remap an indexed
+    /// background to its dim slot (0..=7) or to the non-bright half
+    /// of the pair (8..=15).
+    #[test]
+    fn dim_leaves_an_indexed_background_alone() {
+        let r = renderer(false);
+        let colors = TermColors::default();
+
+        for idx in [1u8, 9] {
+            let dimmed = r.compute_bg_color(
+                &style(AnsiColor::Indexed(idx), StyleFlags::DIM),
+                &colors,
+            );
+            assert_eq!(dimmed, r.colors[idx as usize], "index {idx}");
+        }
+    }
+
+    /// INVERSE is the one case where intensity legitimately reaches a
+    /// background: `cell_bg` swaps fg/bg before calling in, so the
+    /// "background" is really the foreground color and stays dim.
+    #[test]
+    fn inverse_still_dims_the_swapped_foreground() {
+        let r = renderer(false);
+        let colors = TermColors::default();
+        let fg = ColorRgb {
+            r: 0xab,
+            g: 0xb2,
+            b: 0xbf,
+        };
+
+        let spec = r.compute_bg_color(
+            &style(AnsiColor::Spec(fg), StyleFlags::DIM | StyleFlags::INVERSE),
+            &colors,
+        );
+        assert_eq!(spec, (fg * DIM_FACTOR).to_arr());
+
+        let indexed = r.compute_bg_color(
+            &style(AnsiColor::Indexed(1), StyleFlags::DIM | StyleFlags::INVERSE),
+            &colors,
+        );
+        assert_eq!(indexed, r.colors[NamedColor::DimBlack as usize + 1]);
+    }
+
+    /// `draw-bold-text-with-light-colors` is a rule about text. Bold
+    /// must not promote a cell's own background to the bright half of
+    /// the palette, but it still applies once INVERSE has made that
+    /// background the foreground color.
+    #[test]
+    fn bold_brightens_an_indexed_background_only_under_inverse() {
+        let r = renderer(true);
+        let colors = TermColors::default();
+
+        let plain =
+            r.compute_bg_color(&style(AnsiColor::Indexed(1), StyleFlags::BOLD), &colors);
+        assert_eq!(plain, r.colors[1]);
+
+        let inverted = r.compute_bg_color(
+            &style(
+                AnsiColor::Indexed(1),
+                StyleFlags::BOLD | StyleFlags::INVERSE,
+            ),
+            &colors,
+        );
+        assert_eq!(inverted, r.colors[9]);
     }
 }


### PR DESCRIPTION
Faint text drew a dark block behind itself whenever the cell's background had been set explicitly. `Renderer::compute_bg_color` read `StyleFlags::DIM` and `StyleFlags::BOLD` when resolving a *background*, so `SGR 2` scaled it by `DIM_FACTOR` and `SGR 1` promoted an indexed background to the bright half of the palette under `draw-bold-text-with-light-colors`. Per ECMA-48 both are glyph intensity attributes: they change how the character is rendered, never the area behind it.

Reported as a tmux-only artifact, and that is the reason it hid for so long. A cell that never had its background set keeps the `Named(Background)` sentinel, and `cell_bg` returns `[0, 0, 0, 0]` early without painting, so intensity never reaches a color. tmux tracks OSC 11 per pane rather than per window, so it re-emits the pane background as an explicit `\e[48;2;R;G;Bm` on every cell it draws. Captured from tmux 3.7b against a pty answering rio's queries:

```
no OSC 11 in the pane:   \E[H \E[2mFAINT \E(B\E[m NORM
after OSC 11 in the pane: \E[H \E[48;2;40;44;52m\E[2mFAINT \E(B\E[m\E[48;2;40;44;52m NORM
```

With `background = "#282c34"` that painted `#282c34 * 0.66 = #1a1d22`, which is what a screenshot of the original report measures behind the glyphs.

## The fix

Gate both flags on `INVERSE`. That is the one case where intensity legitimately reaches a background, because `cell_bg` has already swapped fg/bg and the "background" is really the foreground color:

```rust
let inverse = cell_style.flags.contains(StyleFlags::INVERSE);
let dim = inverse && cell_style.flags.contains(StyleFlags::DIM);
let bold = inverse && cell_style.flags.contains(StyleFlags::BOLD);
```

Two things fall out of this. The `Codepoint` path now agrees with `ContentTag::BgRgb` and `ContentTag::BgPalette`, which encode the background inline and never dimmed it, so the same background no longer renders differently depending on which encoding the cell took. And it matches upstream alacritty, whose `compute_bg_rgb` takes no flags at all and applies the inverse swap after resolving both colors.

## Manually verified

Built both binaries from this branch, one with the three-line change reverted, and ran the identical repro under the same tmux and config: `printf '\e]11;rgb:28/2c/34\e\\'` then faint, faint+inverse, and normal lines.

- **Before**: `FAINT ON PANE BG` sits in a visible dark block.
- **After**: it blends into the pane background.
- Both: `FAINT INVERSE` keeps its dimmed inverse block, `NORMAL TEXT` is unchanged.

## Tests

Six new tests, four of which fail without the change.

`renderer::compute_bg_color_tests`
- `dim_leaves_an_explicit_rgb_background_alone`
- `dim_leaves_an_indexed_background_alone`, covering both palette remaps (`0..=7` and `8..=15`)
- `inverse_still_dims_the_swapped_foreground`
- `bold_brightens_an_indexed_background_only_under_inverse`

`grid_emit::cell_bg_tests`, end to end through the real render path
- `dim_cell_paints_its_explicit_background_unchanged`, which reports `left: [26, 29, 34]` against `right: [40, 44, 52]` when the fix is reverted
- `dim_cell_with_default_background_stays_unpainted`, so window transparency is unaffected

`cargo test -p rioterm --bins` is 180 passed, `cargo fmt --check` and `cargo clippy -p rioterm --bins --tests` are clean.
