### PR TITLE
fix(macos): restore titlebar double-click with hidden tab strip

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1622,17 +1622,17 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     route.request_redraw();
                 }
 
-                // Only force the default cursor while the island is
-                // visible — when it's hidden (hide_if_single + single
-                // tab on macOS) the band at the top has no tabs to
-                // hover, and the I-beam from the terminal grid below
-                // should stay during top-edge drags.
+                // The macOS full-size content view keeps this band as custom
+                // window chrome even when hide-if-single hides the island.
+                // Other platforms only reserve it while the island is drawn.
                 use crate::renderer::island::ISLAND_HEIGHT;
                 let scale_factor = route.window.screen.sugarloaf.scale_factor();
                 let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
                 let num_tabs = route.window.screen.ctx().len();
                 let nav = &route.window.screen.renderer.navigation;
-                if nav.island_visible(num_tabs) && y <= island_height_px {
+                let custom_chrome_visible = nav.island_visible(num_tabs)
+                    || (cfg!(target_os = "macos") && nav.is_enabled());
+                if custom_chrome_visible && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
                 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2837,9 +2837,11 @@ impl Screen<'_> {
 
         let mouse_x_unscaled = mouse_x as f32 / scale_factor;
 
-        // Island isn't painted (hide_if_single + single tab on macOS).
-        // Nothing to click on, so let the caller route the event to the
-        // grid for selection / double-click maximize at the OS title bar.
+        // Island isn't painted (hide_if_single + single tab). On macOS the
+        // terminal still starts below this band, so it remains custom window
+        // chrome and must keep the same drag/double-click behavior as a
+        // visible island. Other platforms render the terminal from the top
+        // when the island is hidden, so their clicks keep falling through.
         if !island_visible {
             // …unless a ×-close just hid the strip (2 tabs → 1 with
             // hide-if-single): the tail press of a double-click on the
@@ -2848,6 +2850,13 @@ impl Screen<'_> {
             if self.is_close_press_tail(mouse_x_unscaled) {
                 return true;
             }
+
+            #[cfg(target_os = "macos")]
+            if !is_right_click {
+                self.on_chrome_press(window, chrome_press);
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
Closes #1786.

## Summary
- Route clicks in the hidden single-tab chrome through the existing window drag and double-click handler.
- Use the default cursor over the reserved macOS chrome area.
- Preserve the existing behavior on Linux and Windows.

## Testing
- cargo fmt --all -- --check
- cargo test -p rioterm (183 passed)