### PR TITLE
Restore titlebar double-click with hidden tab strip

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1630,9 +1630,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
                 let num_tabs = route.window.screen.ctx().len();
                 let nav = &route.window.screen.renderer.navigation;
-                let custom_chrome_visible = nav.island_visible(num_tabs)
-                    || (cfg!(target_os = "macos") && nav.is_enabled());
-                if custom_chrome_visible && y <= island_height_px {
+                if nav.chrome_band_reserved(num_tabs) && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
                 }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1622,17 +1622,17 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     route.request_redraw();
                 }
 
-                // Only force the default cursor while the island is
-                // visible — when it's hidden (hide_if_single + single
-                // tab on macOS) the band at the top has no tabs to
-                // hover, and the I-beam from the terminal grid below
-                // should stay during top-edge drags.
+                // The macOS full-size content view keeps this band as custom
+                // window chrome even when hide-if-single hides the island.
+                // Other platforms only reserve it while the island is drawn.
                 use crate::renderer::island::ISLAND_HEIGHT;
                 let scale_factor = route.window.screen.sugarloaf.scale_factor();
                 let island_height_px = (ISLAND_HEIGHT * scale_factor) as f64;
                 let num_tabs = route.window.screen.ctx().len();
                 let nav = &route.window.screen.renderer.navigation;
-                if nav.island_visible(num_tabs) && y <= island_height_px {
+                let custom_chrome_visible = nav.island_visible(num_tabs)
+                    || (cfg!(target_os = "macos") && nav.is_enabled());
+                if custom_chrome_visible && y <= island_height_px {
                     route.window.winit_window.set_cursor(CursorIcon::Default);
                     return;
                 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2837,9 +2837,11 @@ impl Screen<'_> {
 
         let mouse_x_unscaled = mouse_x as f32 / scale_factor;
 
-        // Island isn't painted (hide_if_single + single tab on macOS).
-        // Nothing to click on, so let the caller route the event to the
-        // grid for selection / double-click maximize at the OS title bar.
+        // Island isn't painted (hide_if_single + single tab). On macOS the
+        // terminal still starts below this band, so it remains custom window
+        // chrome and must keep the same drag/double-click behavior as a
+        // visible island. Other platforms render the terminal from the top
+        // when the island is hidden, so their clicks keep falling through.
         if !island_visible {
             // …unless a ×-close just hid the strip (2 tabs → 1 with
             // hide-if-single): the tail press of a double-click on the
@@ -2848,6 +2850,13 @@ impl Screen<'_> {
             if self.is_close_press_tail(mouse_x_unscaled) {
                 return true;
             }
+
+            #[cfg(target_os = "macos")]
+            if !is_right_click {
+                self.on_chrome_press(window, chrome_press);
+                return true;
+            }
+
             return false;
         }
 

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2851,9 +2851,15 @@ impl Screen<'_> {
                 return true;
             }
 
-            #[cfg(target_os = "macos")]
-            if !is_right_click {
-                self.on_chrome_press(window, chrome_press);
+            if self.renderer.navigation.chrome_band_reserved(num_tabs) {
+                // Same contract as the visible island's chrome regions:
+                // left starts a drag / validates a double-click, right
+                // is consumed without an action. Letting a right-click
+                // fall through would act on the first terminal row
+                // while the pointer is over window chrome.
+                if !is_right_click {
+                    self.on_chrome_press(window, chrome_press);
+                }
                 return true;
             }
 

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -271,10 +271,17 @@ mod tests {
         assert_eq!(nav.chrome_band_reserved(1), cfg!(target_os = "macos"));
 
         // Non-Tab modes never reserve the band.
-        nav.mode = NavigationMode::NativeTab;
+        nav.mode = NavigationMode::Plain;
         assert!(!nav.island_visible(1));
         assert!(!nav.chrome_band_reserved(1));
         assert!(!nav.chrome_band_reserved(2));
+
+        #[cfg(target_os = "macos")]
+        {
+            nav.mode = NavigationMode::NativeTab;
+            assert!(!nav.chrome_band_reserved(1));
+            assert!(!nav.chrome_band_reserved(2));
+        }
     }
 
     use crate::config::colors::hex_to_color_arr;

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -230,10 +230,53 @@ impl Navigation {
     pub fn island_visible(&self, num_tabs: usize) -> bool {
         self.is_enabled() && !(self.hide_if_single && num_tabs == 1)
     }
+
+    /// Whether the top band is reserved as custom window chrome this
+    /// frame, painted island or not. On macOS the full-size content
+    /// view keeps the band whenever Tab navigation is enabled, even
+    /// with `hide-if-single` hiding the strip; other platforms render
+    /// the terminal from the top when the island is hidden. Must agree
+    /// with `padding_top_from_config`, which reserves the band's
+    /// height under the same condition.
+    #[inline]
+    pub fn chrome_band_reserved(&self, num_tabs: usize) -> bool {
+        if cfg!(target_os = "macos") {
+            self.is_enabled()
+        } else {
+            self.island_visible(num_tabs)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn chrome_band_follows_padding_contract() {
+        use crate::config::navigation::{Navigation, NavigationMode};
+
+        let mut nav = Navigation {
+            mode: NavigationMode::Tab,
+            hide_if_single: true,
+            ..Navigation::default()
+        };
+
+        // Visible island: band reserved everywhere.
+        assert!(nav.island_visible(2));
+        assert!(nav.chrome_band_reserved(2));
+
+        // Hidden island (single tab): macOS keeps the band as chrome,
+        // other platforms hand it to the terminal, matching
+        // padding_top_from_config.
+        assert!(!nav.island_visible(1));
+        assert_eq!(nav.chrome_band_reserved(1), cfg!(target_os = "macos"));
+
+        // Non-Tab modes never reserve the band.
+        nav.mode = NavigationMode::NativeTab;
+        assert!(!nav.island_visible(1));
+        assert!(!nav.chrome_band_reserved(1));
+        assert!(!nav.chrome_band_reserved(2));
+    }
+
     use crate::config::colors::hex_to_color_arr;
     use crate::config::navigation::{Navigation, NavigationMode};
     use serde::Deserialize;


### PR DESCRIPTION
Supersedes and closes #1866 by @jxdones, keeping their commit. The original fix is right: on macOS with hide-if-single, the full-size content view keeps the top band as custom window chrome (padding_top_from_config reserves ISLAND_HEIGHT whenever Tab navigation is enabled), so clicks there belong to the window drag and double-click handler, not the grid.

On top of it, the two review notes applied:

- The chrome-band predicate now lives in one place. `Navigation::chrome_band_reserved` encodes "macOS reserves the band whenever Tab navigation is enabled, other platforms only while the island is painted", and both input layers (the cursor override in application.rs, the click routing in screen/mod.rs) call it instead of re-deriving the condition. It must agree with padding_top_from_config, and the doc comment plus a unit test pin that contract.

- Right-clicks in the hidden band are consumed like the visible island's chrome regions instead of falling through to the grid, where they acted on the first terminal row while the pointer was over window chrome.

The UCRT64 failure on the original PR was our CI lane building workspace cdylibs in debug, which exceeds the PE export-ordinal limit on windows-gnu; fixed on main and this branch includes it.
