### PR TITLE
Extend edge-cell backgrounds into terminal padding

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -2077,14 +2077,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 let focus_changed = route.window.is_focused != focused;
                 route.window.is_focused = focused;
 
-                // Focus is a cheap checkpoint to catch backing-scale changes
-                // whose ScaleFactorChanged never arrived (sleep/wake display
-                // reconfiguration).
+                // Focus is a cheap checkpoint to catch backing-scale or
+                // physical-size changes whose events were missed or arrived
+                // out of order during display reconfiguration.
                 if focused
                     && route
                         .window
                         .screen
-                        .reconcile_scale(&route.window.winit_window)
+                        .reconcile_window_metrics(&route.window.winit_window)
                 {
                     route.window.update_vblank_interval();
                     route.request_redraw();
@@ -2107,7 +2107,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     if route
                         .window
                         .screen
-                        .reconcile_scale(&route.window.winit_window)
+                        .reconcile_window_metrics(&route.window.winit_window)
                     {
                         route.window.update_vblank_interval();
                     }
@@ -2141,6 +2141,20 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             }
 
             WindowEvent::Resized(new_size) => {
+                // A frame-change callback can queue a resize using the old
+                // backing scale immediately before macOS moves the window to
+                // a screen with a different scale. By the time this event is
+                // handled, the window's live physical size is authoritative.
+                #[cfg(target_os = "macos")]
+                let new_size = {
+                    let live_size = route.window.winit_window.inner_size();
+                    if live_size.width > 0 && live_size.height > 0 {
+                        live_size
+                    } else {
+                        new_size
+                    }
+                };
+
                 if new_size.width == 0 || new_size.height == 0 {
                     return;
                 }

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -222,7 +222,8 @@ fn contrast_ratio(a: [f32; 4], b: [f32; 4]) -> f32 {
 #[inline]
 fn readable_tab_text(preferred: [f32; 4], background: [f32; 4]) -> [f32; 4] {
     const MIN_TEXT_CONTRAST: f32 = 4.5;
-    if preferred[3] > 0.0 && contrast_ratio(preferred, background) >= MIN_TEXT_CONTRAST {
+    let rendered_preferred = over(background, preferred);
+    if contrast_ratio(rendered_preferred, background) >= MIN_TEXT_CONTRAST {
         return preferred;
     }
 
@@ -1654,6 +1655,15 @@ mod tests {
         assert_eq!(
             readable_tab_text(preferred, [0.04, 0.04, 0.04, 1.0]),
             preferred
+        );
+    }
+
+    #[test]
+    fn tab_text_replaces_translucent_color_when_composited_contrast_is_too_low() {
+        let translucent_black = [0.0, 0.0, 0.0, 0.1];
+        assert_eq!(
+            readable_tab_text(translucent_black, [1.0, 1.0, 1.0, 1.0]),
+            [0.0, 0.0, 0.0, 1.0]
         );
     }
 

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -195,6 +195,59 @@ fn over(dst: [f32; 4], src: [f32; 4]) -> [f32; 4] {
     ]
 }
 
+#[inline]
+fn relative_luminance(color: [f32; 4]) -> f32 {
+    let linear = |channel: f32| {
+        let channel = channel.clamp(0.0, 1.0);
+        if channel <= 0.04045 {
+            channel / 12.92
+        } else {
+            ((channel + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    0.2126 * linear(color[0]) + 0.7152 * linear(color[1]) + 0.0722 * linear(color[2])
+}
+
+#[inline]
+fn contrast_ratio(a: [f32; 4], b: [f32; 4]) -> f32 {
+    let a = relative_luminance(a);
+    let b = relative_luminance(b);
+    (a.max(b) + 0.05) / (a.min(b) + 0.05)
+}
+
+/// Keep the configured tab color when it remains legible, otherwise choose
+/// the higher-contrast monochrome foreground. The tab strip can now inherit
+/// a TUI's extended top-row background, so a color selected against Rio's
+/// configured background is no longer guaranteed to be visible.
+#[inline]
+fn readable_tab_text(preferred: [f32; 4], background: [f32; 4]) -> [f32; 4] {
+    const MIN_TEXT_CONTRAST: f32 = 4.5;
+    if preferred[3] > 0.0 && contrast_ratio(preferred, background) >= MIN_TEXT_CONTRAST {
+        return preferred;
+    }
+
+    let dark = [0.0, 0.0, 0.0, 1.0];
+    let light = [1.0, 1.0, 1.0, 1.0];
+    if contrast_ratio(dark, background) >= contrast_ratio(light, background) {
+        dark
+    } else {
+        light
+    }
+}
+
+#[inline]
+fn tab_text_color(
+    preferred: [f32; 4],
+    background: [f32; 4],
+    adaptive_contrast: bool,
+) -> [f32; 4] {
+    if adaptive_contrast {
+        readable_tab_text(preferred, background)
+    } else {
+        preferred
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn draw_island(
     sugarloaf: &mut Sugarloaf,
@@ -736,6 +789,7 @@ impl Island {
         dimensions: (f32, f32, f32),
         context_manager: &ContextManager<EventProxy>,
         bg_color: [f32; 4],
+        adaptive_text_contrast: bool,
     ) {
         let (window_width, _window_height, scale_factor) = dimensions;
         let num_tabs = context_manager.len();
@@ -846,7 +900,26 @@ impl Island {
             };
             let title = fit_title_to_width(sugarloaf, &raw_title, max_text_width);
 
-            let text_color = if single {
+            let fill = if single {
+                None
+            } else {
+                Some(match context_manager.custom_color(tab_index) {
+                    Some(mut custom) => {
+                        if !is_active {
+                            custom[3] *= INACTIVE_CUSTOM_MUTE;
+                        }
+                        custom
+                    }
+                    None => {
+                        if is_active {
+                            fills.active
+                        } else {
+                            fills.inactive
+                        }
+                    }
+                })
+            };
+            let preferred_text_color = if single {
                 match context_manager.custom_color(tab_index) {
                     Some(mut custom) => {
                         custom[3] = 1.0;
@@ -859,6 +932,12 @@ impl Island {
             } else {
                 self.inactive_text_color
             };
+            let text_background = fill.map_or(bg_color, |fill| over(bg_color, fill));
+            let text_color = tab_text_color(
+                preferred_text_color,
+                text_background,
+                adaptive_text_contrast,
+            );
 
             let title_opts = DrawOpts {
                 font_size: TITLE_FONT_SIZE,
@@ -903,21 +982,7 @@ impl Island {
             // bleach custom colors to pastel on light themes, so the
             // hierarchy is carried by the mute instead.
             let (ix, iy, iw, ih, radius) = island_rect(tab_x, tab_width);
-            let fill = match context_manager.custom_color(tab_index) {
-                Some(mut custom) => {
-                    if !is_active {
-                        custom[3] *= INACTIVE_CUSTOM_MUTE;
-                    }
-                    custom
-                }
-                None => {
-                    if is_active {
-                        fills.active
-                    } else {
-                        fills.inactive
-                    }
-                }
-            };
+            let fill = fill.expect("multi-tab islands always have a fill");
             draw_island(
                 sugarloaf,
                 ix,
@@ -946,13 +1011,7 @@ impl Island {
                             1,
                         );
                     }
-                    draw_close_button(
-                        sugarloaf,
-                        cx,
-                        self.active_text_color,
-                        self.close_hover,
-                        2,
-                    );
+                    draw_close_button(sugarloaf, cx, text_color, self.close_hover, 2);
                 }
             }
 
@@ -989,6 +1048,8 @@ impl Island {
                     over(base, fills.active)
                 }
             };
+            let floating_text_color =
+                tab_text_color(self.active_text_color, fill, adaptive_text_contrast);
             draw_island(
                 sugarloaf,
                 ix,
@@ -1003,7 +1064,7 @@ impl Island {
             );
 
             if let Some(cx) = close_button_center(ix, iw) {
-                draw_close_button(sugarloaf, cx, self.active_text_color, false, 12);
+                draw_close_button(sugarloaf, cx, floating_text_color, false, 12);
             }
 
             let raw_title = self.get_title_for_tab(context_manager, drag_idx);
@@ -1012,7 +1073,7 @@ impl Island {
                 let title = fit_title_to_width(sugarloaf, &raw_title, max_text_width);
                 let title_opts = DrawOpts {
                     font_size: TITLE_FONT_SIZE,
-                    color: color_u8(self.active_text_color),
+                    color: color_u8(floating_text_color),
                     ..DrawOpts::default()
                 };
                 let ui = sugarloaf.text_mut();
@@ -1573,6 +1634,36 @@ mod tests {
         // Zero-alpha source is a no-op; full-alpha replaces.
         assert_eq!(over(dst, [0.9, 0.1, 0.3, 0.0]), dst);
         assert_eq!(over(dst, [0.9, 0.1, 0.3, 1.0]), [0.9, 0.1, 0.3, 1.0]);
+    }
+
+    #[test]
+    fn tab_text_switches_to_dark_on_light_extended_background() {
+        let color = readable_tab_text([1.0, 1.0, 1.0, 1.0], [0.95, 0.93, 0.88, 1.0]);
+        assert_eq!(color, [0.0, 0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn tab_text_switches_to_light_on_dark_extended_background() {
+        let color = readable_tab_text([0.26, 0.25, 0.25, 1.0], [0.06, 0.05, 0.04, 1.0]);
+        assert_eq!(color, [1.0, 1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn tab_text_keeps_configured_color_when_readable() {
+        let preferred = [0.9, 0.75, 0.25, 1.0];
+        assert_eq!(
+            readable_tab_text(preferred, [0.04, 0.04, 0.04, 1.0]),
+            preferred
+        );
+    }
+
+    #[test]
+    fn tab_text_keeps_configured_color_when_adaptive_contrast_is_disabled() {
+        let preferred = [1.0, 1.0, 1.0, 1.0];
+        assert_eq!(
+            tab_text_color(preferred, [0.95, 0.93, 0.88, 1.0], false),
+            preferred
+        );
     }
 
     #[test]

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -177,6 +177,7 @@ pub struct Renderer {
     pub option_as_alt: String,
     #[allow(unused)]
     pub macos_use_unified_titlebar: bool,
+    pub extend_terminal_background_into_titlebar: bool,
     // Dynamic background keep track of the original bg color and
     // the same r,g,b with the mutated alpha channel.
     pub dynamic_background: ([f32; 4], rio_backend::sugarloaf::Color, bool),
@@ -238,6 +239,9 @@ impl Renderer {
             use_drawable_chars: config.fonts.use_drawable_chars,
             draw_bold_text_with_light_colors: config.draw_bold_text_with_light_colors,
             macos_use_unified_titlebar: config.window.macos_use_unified_titlebar,
+            extend_terminal_background_into_titlebar: config
+                .window
+                .extend_terminal_background_into_titlebar,
             config_blinking_interval: config.cursor.blinking_interval.clamp(350, 1200),
             option_as_alt: config.option_as_alt.to_lowercase(),
             is_vi_mode_enabled: false,
@@ -432,6 +436,56 @@ impl Renderer {
             && !self.command_palette.is_enabled()
             && !self.search.is_active()
             && !self.confirm_quit.is_active()
+    }
+
+    /// Dominant background painted by the top row of the topmost terminal
+    /// panel(s). With edge-cell extension enabled, this is the color that
+    /// actually sits behind the unified-titlebar tab strip; the configured
+    /// window background is only the fallback for transparent cells.
+    fn top_edge_background(
+        &self,
+        context_manager: &ContextManager<EventProxy>,
+        fallback: [f32; 4],
+    ) -> [f32; 4] {
+        let grid = context_manager.current_grid();
+        let min_top = grid
+            .contexts()
+            .values()
+            .map(|item| item.layout_rect[1])
+            .fold(f32::INFINITY, f32::min);
+        if !min_top.is_finite() {
+            return fallback;
+        }
+
+        let mut counts = rustc_hash::FxHashMap::<[u8; 4], usize>::default();
+        for item in grid.contexts().values() {
+            if (item.layout_rect[1] - min_top).abs() > 0.5 {
+                continue;
+            }
+            let rc = &item.val.renderable_content;
+            let Some(row) = rc.visible_rows.first() else {
+                continue;
+            };
+            for &sq in row.inner.iter().take(rc.columns) {
+                let style = crate::grid_emit::resolve_style(&rc.style_table, sq);
+                let rgba = crate::grid_emit::cell_bg(sq, style, self, &rc.term_colors);
+                *counts.entry(rgba).or_default() += 1;
+            }
+        }
+
+        let Some((rgba, _)) = counts.into_iter().max_by_key(|(_, count)| *count) else {
+            return fallback;
+        };
+        let alpha = rgba[3] as f32 / 255.0;
+        if alpha <= 0.0 {
+            return fallback;
+        }
+        [
+            rgba[0] as f32 / 255.0 * alpha + fallback[0] * (1.0 - alpha),
+            rgba[1] as f32 / 255.0 * alpha + fallback[1] * (1.0 - alpha),
+            rgba[2] as f32 / 255.0 * alpha + fallback[2] * (1.0 - alpha),
+            alpha + fallback[3] * (1.0 - alpha),
+        ]
     }
 
     #[inline]
@@ -818,16 +872,22 @@ impl Renderer {
             }
         }
 
+        let island_bg = self
+            .last_window_bg
+            .map(|c| [c.r as f32, c.g as f32, c.b as f32, c.a as f32])
+            .unwrap_or(self.named_colors.background.0);
+        let island_bg = if self.extend_terminal_background_into_titlebar {
+            self.top_edge_background(context_manager, island_bg)
+        } else {
+            island_bg
+        };
         if let Some(island) = &mut self.island {
-            let island_bg = self
-                .last_window_bg
-                .map(|c| [c.r as f32, c.g as f32, c.b as f32, c.a as f32])
-                .unwrap_or(self.named_colors.background.0);
             island.render(
                 sugarloaf,
                 (window_size.width, window_size.height, scale_factor),
                 context_manager,
                 island_bg,
+                self.extend_terminal_background_into_titlebar,
             );
         }
 

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -193,6 +193,42 @@ pub struct ScreenWindowProperties {
     pub window_id: rio_window::window::WindowId,
 }
 
+#[derive(Debug, PartialEq)]
+enum WindowMetricsUpdate {
+    None,
+    Resize(rio_window::dpi::PhysicalSize<u32>),
+    Rescale {
+        scale: f32,
+        size: rio_window::dpi::PhysicalSize<u32>,
+    },
+}
+
+fn window_metrics_update(
+    rendered_size: SugarloafWindowSize,
+    rendered_scale: f32,
+    live_size: rio_window::dpi::PhysicalSize<u32>,
+    live_scale: f32,
+) -> WindowMetricsUpdate {
+    if live_scale <= 0.0 || live_size.width == 0 || live_size.height == 0 {
+        return WindowMetricsUpdate::None;
+    }
+
+    if (live_scale - rendered_scale).abs() > f32::EPSILON {
+        return WindowMetricsUpdate::Rescale {
+            scale: live_scale,
+            size: live_size,
+        };
+    }
+
+    if rendered_size.width != live_size.width as f32
+        || rendered_size.height != live_size.height as f32
+    {
+        return WindowMetricsUpdate::Resize(live_size);
+    }
+
+    WindowMetricsUpdate::None
+}
+
 #[inline]
 fn window_should_be_opaque(config: &rio_backend::config::Config) -> bool {
     config.window.opacity >= 1.0 && !config.window.blur.is_glass()
@@ -662,22 +698,33 @@ impl Screen<'_> {
         self
     }
 
-    /// Re-read the window's live scale factor and re-run the rescale path
-    /// when it diverged from the one being rendered with. Display
-    /// reconfiguration during sleep/wake can change the backing scale
-    /// without a `ScaleFactorChanged` ever being delivered (the macOS
-    /// producer de-dupes on the numeric value and wake notifications
-    /// coalesce), so cheap checkpoints call this instead of trusting
-    /// event delivery. Returns whether a rescale ran.
-    pub fn reconcile_scale(&mut self, winit_window: &rio_window::window::Window) -> bool {
+    /// Re-read the window's live scale and physical size, then repair any
+    /// divergence from the values used by the renderer. Display changes can
+    /// leave a stale `Resized` event queued at the old backing scale even when
+    /// `ScaleFactorChanged` was delivered correctly. Checking scale alone
+    /// misses that half-sized drawable/grid state.
+    pub fn reconcile_window_metrics(
+        &mut self,
+        winit_window: &rio_window::window::Window,
+    ) -> bool {
         let live_scale = winit_window.scale_factor() as f32;
-        if live_scale > 0.0
-            && (live_scale - self.sugarloaf.scale_factor()).abs() > f32::EPSILON
-        {
-            self.set_scale(live_scale, winit_window.inner_size());
-            return true;
+        let live_size = winit_window.inner_size();
+        match window_metrics_update(
+            self.sugarloaf.window_size(),
+            self.sugarloaf.scale_factor(),
+            live_size,
+            live_scale,
+        ) {
+            WindowMetricsUpdate::None => false,
+            WindowMetricsUpdate::Resize(size) => {
+                self.resize(size);
+                true
+            }
+            WindowMetricsUpdate::Rescale { scale, size } => {
+                self.set_scale(scale, size);
+                true
+            }
         }
-        false
     }
 
     #[inline]
@@ -686,6 +733,15 @@ impl Screen<'_> {
         new_scale: f32,
         new_size: rio_window::dpi::PhysicalSize<u32>,
     ) -> &mut Self {
+        #[cfg(target_os = "macos")]
+        let scale_changed =
+            (new_scale - self.sugarloaf.scale_factor()).abs() > f32::EPSILON;
+        #[cfg(target_os = "macos")]
+        if scale_changed {
+            // Finish frames submitted for the previous display before
+            // changing the drawable's scale and physical dimensions.
+            self.sugarloaf.wait_for_gpu_idle();
+        }
         self.sugarloaf.rescale(new_scale);
         self.sugarloaf.resize(new_size.width, new_size.height);
 
@@ -5043,6 +5099,45 @@ fn post_process_hyperlink_uri(uri: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn window_metrics_reconcile_stale_physical_size_at_current_scale() {
+        let update = window_metrics_update(
+            SugarloafWindowSize {
+                width: 1120.0,
+                height: 720.0,
+            },
+            2.0,
+            rio_window::dpi::PhysicalSize::new(2240, 1440),
+            2.0,
+        );
+
+        assert_eq!(
+            update,
+            WindowMetricsUpdate::Resize(rio_window::dpi::PhysicalSize::new(2240, 1440))
+        );
+    }
+
+    #[test]
+    fn window_metrics_rescale_uses_live_physical_size() {
+        let update = window_metrics_update(
+            SugarloafWindowSize {
+                width: 1120.0,
+                height: 720.0,
+            },
+            1.0,
+            rio_window::dpi::PhysicalSize::new(2240, 1440),
+            2.0,
+        );
+
+        assert_eq!(
+            update,
+            WindowMetricsUpdate::Rescale {
+                scale: 2.0,
+                size: rio_window::dpi::PhysicalSize::new(2240, 1440),
+            }
+        );
+    }
 
     #[test]
     fn panel_clip_rects_extend_only_outer_split_edges() {

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -65,14 +65,14 @@ const MAX_SEARCH_HISTORY_SIZE: usize = 255;
 /// Compute the physical-pixel clip owned by each terminal panel.
 ///
 /// Interior bounds stop at the panel's Taffy allocation. Outermost panels own
-/// the left, right, and bottom window margins, but the top bound always stays
-/// at the terminal viewport so edge-cell colors cannot paint through Rio's
-/// unified titlebar. This also keeps splits from painting over siblings or
-/// configured gutters.
+/// the left, right, and bottom window margins. The top stays at the terminal
+/// viewport by default, but can opt into owning the titlebar too. Splits never
+/// paint over siblings or configured gutters in either mode.
 fn panel_clip_rects(
     layout_rects: &[[f32; 4]],
     scaled_margin: Margin,
     window_size: [f32; 2],
+    extend_into_titlebar: bool,
 ) -> Vec<[f32; 4]> {
     if layout_rects.is_empty() {
         return Vec::new();
@@ -81,6 +81,10 @@ fn panel_clip_rects(
     let min_left = layout_rects
         .iter()
         .map(|rect| rect[0])
+        .fold(f32::INFINITY, f32::min);
+    let min_top = layout_rects
+        .iter()
+        .map(|rect| rect[1])
         .fold(f32::INFINITY, f32::min);
     let max_right = layout_rects
         .iter()
@@ -107,12 +111,12 @@ fn panel_clip_rects(
                 (scaled_margin.left + rect[0]).round()
             }
             .clamp(0.0, window_width);
-            // Unlike the other outer edges, the top never expands to the
-            // drawable edge: on macOS that area contains the unified
-            // titlebar and tab strip rather than terminal padding.
-            let top = (scaled_margin.top + rect[1])
-                .round()
-                .clamp(0.0, window_height);
+            let top = if extend_into_titlebar && same_edge(rect[1], min_top) {
+                0.0
+            } else {
+                (scaled_margin.top + rect[1]).round()
+            }
+            .clamp(0.0, window_height);
             let right = if same_edge(layout_right, max_right) {
                 window_width
             } else {
@@ -4203,6 +4207,7 @@ impl Screen<'_> {
                 &layout_rects,
                 scaled_margin,
                 [window_size.width, window_size.height],
+                self.renderer.extend_terminal_background_into_titlebar,
             );
             for (panel, clip) in panels.iter_mut().zip(clips) {
                 panel.panel_clip = clip;
@@ -4531,9 +4536,9 @@ impl Screen<'_> {
                             window_size.height,
                         ),
                     // grid_padding anchors the terminal cells. The bg
-                    // pass extends left/right/bottom edge cells, while
-                    // panel_clip bounds the fill to this pane and keeps
-                    // its top at the terminal viewport below the titlebar.
+                    // pass extends left/right/bottom edge cells. The
+                    // titlebar direction is opt-in; panel_clip keeps every
+                    // fill bounded to the area owned by this pane.
                     grid_padding: [panel_top, 0.0, 0.0, panel_left],
                     cursor_color: cursor_col_u,
                     cursor_bg_color: cursor_bg_u,
@@ -4545,7 +4550,12 @@ impl Screen<'_> {
                     flags: 0,
                     padding_extend: rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_LEFT
                         | rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_RIGHT
-                        | rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_DOWN,
+                        | rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_DOWN
+                        | if renderer_ref.extend_terminal_background_into_titlebar {
+                            rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_UP
+                        } else {
+                            0
+                        },
                     input_colorspace,
                     panel_clip: p.panel_clip,
                 };
@@ -5037,7 +5047,7 @@ mod tests {
     #[test]
     fn panel_clip_rects_extend_only_outer_split_edges() {
         let rects = [[2.0, 2.0, 390.0, 576.0], [408.0, 2.0, 390.0, 576.0]];
-        let clips = panel_clip_rects(&rects, Margin::all(2.0), [800.0, 580.0]);
+        let clips = panel_clip_rects(&rects, Margin::all(2.0), [800.0, 580.0], false);
 
         assert_eq!(clips[0], [4.0, 394.0, 580.0, 0.0]);
         assert_eq!(clips[1], [4.0, 800.0, 580.0, 410.0]);
@@ -5049,6 +5059,7 @@ mod tests {
             &[[2.0, 2.0, 794.0, 574.0]],
             Margin::all(2.0),
             [800.0, 580.0],
+            false,
         );
 
         assert_eq!(clips, vec![[4.0, 800.0, 580.0, 0.0]]);
@@ -5057,9 +5068,18 @@ mod tests {
     #[test]
     fn panel_clip_rects_keep_stacked_panels_below_titlebar() {
         let rects = [[2.0, 2.0, 794.0, 280.0], [2.0, 298.0, 794.0, 278.0]];
-        let clips = panel_clip_rects(&rects, Margin::all(2.0), [800.0, 580.0]);
+        let clips = panel_clip_rects(&rects, Margin::all(2.0), [800.0, 580.0], false);
 
         assert_eq!(clips[0], [4.0, 800.0, 284.0, 0.0]);
+        assert_eq!(clips[1], [300.0, 800.0, 580.0, 0.0]);
+    }
+
+    #[test]
+    fn panel_clip_rects_optionally_extend_topmost_panels_into_titlebar() {
+        let rects = [[2.0, 2.0, 794.0, 280.0], [2.0, 298.0, 794.0, 278.0]];
+        let clips = panel_clip_rects(&rects, Margin::all(2.0), [800.0, 580.0], true);
+
+        assert_eq!(clips[0], [0.0, 800.0, 284.0, 0.0]);
         assert_eq!(clips[1], [300.0, 800.0, 580.0, 0.0]);
     }
 

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -62,6 +62,75 @@ const MAX_SEARCH_WHILE_TYPING: Option<usize> = Some(1000);
 /// Maximum number of search terms stored in the history.
 const MAX_SEARCH_HISTORY_SIZE: usize = 255;
 
+/// Compute the physical-pixel clip owned by each terminal panel.
+///
+/// Interior bounds stop at the panel's Taffy allocation. Outermost panels own
+/// the left, right, and bottom window margins, but the top bound always stays
+/// at the terminal viewport so edge-cell colors cannot paint through Rio's
+/// unified titlebar. This also keeps splits from painting over siblings or
+/// configured gutters.
+fn panel_clip_rects(
+    layout_rects: &[[f32; 4]],
+    scaled_margin: Margin,
+    window_size: [f32; 2],
+) -> Vec<[f32; 4]> {
+    if layout_rects.is_empty() {
+        return Vec::new();
+    }
+
+    let min_left = layout_rects
+        .iter()
+        .map(|rect| rect[0])
+        .fold(f32::INFINITY, f32::min);
+    let max_right = layout_rects
+        .iter()
+        .map(|rect| rect[0] + rect[2])
+        .fold(f32::NEG_INFINITY, f32::max);
+    let max_bottom = layout_rects
+        .iter()
+        .map(|rect| rect[1] + rect[3])
+        .fold(f32::NEG_INFINITY, f32::max);
+
+    let same_edge = |a: f32, b: f32| (a - b).abs() <= 0.5;
+    let window_width = window_size[0].max(0.0);
+    let window_height = window_size[1].max(0.0);
+
+    layout_rects
+        .iter()
+        .map(|rect| {
+            let layout_right = rect[0] + rect[2];
+            let layout_bottom = rect[1] + rect[3];
+
+            let left = if same_edge(rect[0], min_left) {
+                0.0
+            } else {
+                (scaled_margin.left + rect[0]).round()
+            }
+            .clamp(0.0, window_width);
+            // Unlike the other outer edges, the top never expands to the
+            // drawable edge: on macOS that area contains the unified
+            // titlebar and tab strip rather than terminal padding.
+            let top = (scaled_margin.top + rect[1])
+                .round()
+                .clamp(0.0, window_height);
+            let right = if same_edge(layout_right, max_right) {
+                window_width
+            } else {
+                (scaled_margin.left + layout_right).round()
+            }
+            .clamp(left, window_width);
+            let bottom = if same_edge(layout_bottom, max_bottom) {
+                window_height
+            } else {
+                (scaled_margin.top + layout_bottom).round()
+            }
+            .clamp(top, window_height);
+
+            [top, right, bottom, left]
+        })
+        .collect()
+}
+
 pub struct Screen<'screen> {
     bindings: crate::bindings::KeyBindings,
     mouse_bindings: Vec<MouseBinding>,
@@ -3912,6 +3981,7 @@ impl Screen<'_> {
             struct PanelFrame {
                 route_id: usize,
                 layout_rect: [f32; 4],
+                panel_clip: [f32; 4],
                 cols: u32,
                 rows: u32,
                 cell_w: f32,
@@ -4092,6 +4162,7 @@ impl Screen<'_> {
                 panels.push(PanelFrame {
                     route_id: ctx.route_id,
                     layout_rect: item.layout_rect,
+                    panel_clip: [0.0; 4],
                     cols: ctx.renderable_content.columns.max(1) as u32,
                     rows: ctx.renderable_content.screen_lines.max(1) as u32,
                     cell_w,
@@ -4127,6 +4198,15 @@ impl Screen<'_> {
 
             // --- emit cells + build uniforms per panel ---
             let window_size = self.sugarloaf.window_size();
+            let layout_rects: Vec<_> = panels.iter().map(|p| p.layout_rect).collect();
+            let clips = panel_clip_rects(
+                &layout_rects,
+                scaled_margin,
+                [window_size.width, window_size.height],
+            );
+            for (panel, clip) in panels.iter_mut().zip(clips) {
+                panel.panel_clip = clip;
+            }
             let font_library = self.sugarloaf.font_library().clone();
             let bg_col = self.renderer.named_colors.background.0;
             // Same `input_colorspace` value the Metal quad pipeline
@@ -4450,15 +4530,10 @@ impl Screen<'_> {
                             window_size.width,
                             window_size.height,
                         ),
-                    // grid_padding = (top, right, bottom, left). The
-                    // bg shader only reads `.w` (left) + `.x` (top)
-                    // to anchor the grid, so right/bottom can stay
-                    // 0. padding_extend is 0 too — each panel's
-                    // grid must stay bounded to its own rect so
-                    // sibling panels / the window margin aren't
-                    // painted by this grid. The full-window bg fill
-                    // (re-enabled in sugarloaf's render_metal) now
-                    // handles the space outside all panels.
+                    // grid_padding anchors the terminal cells. The bg
+                    // pass extends left/right/bottom edge cells, while
+                    // panel_clip bounds the fill to this pane and keeps
+                    // its top at the terminal viewport below the titlebar.
                     grid_padding: [panel_top, 0.0, 0.0, panel_left],
                     cursor_color: cursor_col_u,
                     cursor_bg_color: cursor_bg_u,
@@ -4468,8 +4543,11 @@ impl Screen<'_> {
                     _pad_cursor: [0; 2],
                     min_contrast: 0.0,
                     flags: 0,
-                    padding_extend: 0,
+                    padding_extend: rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_LEFT
+                        | rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_RIGHT
+                        | rio_backend::sugarloaf::grid::GridUniforms::PADDING_EXTEND_DOWN,
                     input_colorspace,
+                    panel_clip: p.panel_clip,
                 };
 
                 frame_grids.push((grid, uniforms));
@@ -4955,6 +5033,35 @@ fn post_process_hyperlink_uri(uri: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn panel_clip_rects_extend_only_outer_split_edges() {
+        let rects = [[2.0, 2.0, 390.0, 576.0], [408.0, 2.0, 390.0, 576.0]];
+        let clips = panel_clip_rects(&rects, Margin::all(2.0), [800.0, 580.0]);
+
+        assert_eq!(clips[0], [4.0, 394.0, 580.0, 0.0]);
+        assert_eq!(clips[1], [4.0, 800.0, 580.0, 410.0]);
+    }
+
+    #[test]
+    fn panel_clip_rects_extend_single_panel_sides_and_bottom() {
+        let clips = panel_clip_rects(
+            &[[2.0, 2.0, 794.0, 574.0]],
+            Margin::all(2.0),
+            [800.0, 580.0],
+        );
+
+        assert_eq!(clips, vec![[4.0, 800.0, 580.0, 0.0]]);
+    }
+
+    #[test]
+    fn panel_clip_rects_keep_stacked_panels_below_titlebar() {
+        let rects = [[2.0, 2.0, 794.0, 280.0], [2.0, 298.0, 794.0, 278.0]];
+        let clips = panel_clip_rects(&rects, Margin::all(2.0), [800.0, 580.0]);
+
+        assert_eq!(clips[0], [4.0, 800.0, 284.0, 0.0]);
+        assert_eq!(clips[1], [300.0, 800.0, 580.0, 0.0]);
+    }
 
     #[test]
     fn chrome_press_validates_double_click() {

--- a/rio-backend/src/config/defaults.rs
+++ b/rio-backend/src/config/defaults.rs
@@ -160,6 +160,11 @@ pub fn default_forward_to_ime_modifier_mask() -> Vec<String> {
 
 pub fn default_config_file_content() -> String {
     String::from(
-        "# See the full configuration reference: https://rioterm.com/docs/config\n",
+        "# See the full configuration reference: https://rioterm.com/docs/config\n\
+#\n\
+# Extend terminal edge backgrounds through the transparent titlebar.\n\
+# Disabled by default.\n\
+# [window]\n\
+# extend-terminal-background-into-titlebar = true\n",
     )
 }

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -546,6 +546,11 @@ impl Config {
             if let Some(macos_unified) = window_overwrite.macos_use_unified_titlebar {
                 self.window.macos_use_unified_titlebar = macos_unified;
             }
+            if let Some(extend_titlebar) =
+                window_overwrite.extend_terminal_background_into_titlebar
+            {
+                self.window.extend_terminal_background_into_titlebar = extend_titlebar;
+            }
             if let Some(macos_shadow) = window_overwrite.macos_use_shadow {
                 self.window.macos_use_shadow = macos_shadow;
             }
@@ -1006,6 +1011,21 @@ mod tests {
         assert_eq!(result.colors.foreground, colors::defaults::foreground());
         assert_eq!(result.colors.tabs_active, colors::defaults::tabs_active());
         assert_eq!(result.colors.cursor, colors::defaults::cursor());
+    }
+
+    #[test]
+    fn test_titlebar_background_extension_is_opt_in() {
+        let default = create_temporary_config("titlebar-background-default", "");
+        assert!(!default.window.extend_terminal_background_into_titlebar);
+
+        let enabled = create_temporary_config(
+            "titlebar-background-enabled",
+            r#"
+            [window]
+            extend-terminal-background-into-titlebar = true
+        "#,
+        );
+        assert!(enabled.window.extend_terminal_background_into_titlebar);
     }
 
     #[test]

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -777,7 +777,11 @@ mod tests {
 
     #[test]
     fn test_if_explicit_defaults_match() {
-        let result = create_temporary_config("defaults", &default_config_file_content());
+        let default_config = default_config_file_content();
+        assert!(
+            default_config.contains("extend-terminal-background-into-titlebar = true")
+        );
+        let result = create_temporary_config("defaults", &default_config);
 
         let env_vars: Vec<String> = vec![];
         assert_eq!(result.env_vars, env_vars);

--- a/rio-backend/src/config/platform.rs
+++ b/rio-backend/src/config/platform.rs
@@ -56,6 +56,11 @@ pub struct PlatformWindow {
     pub decorations: Option<window::Decorations>,
     #[serde(default = "Option::default", rename = "macos-use-unified-titlebar")]
     pub macos_use_unified_titlebar: Option<bool>,
+    #[serde(
+        default = "Option::default",
+        rename = "extend-terminal-background-into-titlebar"
+    )]
+    pub extend_terminal_background_into_titlebar: Option<bool>,
     #[serde(default = "Option::default", rename = "macos-use-shadow")]
     pub macos_use_shadow: Option<bool>,
     #[serde(default = "Option::default", rename = "macos-traffic-light-position-x")]

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -210,6 +210,11 @@ pub struct Window {
     pub macos_use_unified_titlebar: bool,
     /// Let the topmost terminal cells paint through the transparent titlebar.
     /// Off by default so terminal backgrounds stop at the viewport boundary.
+    ///
+    /// ```toml
+    /// [window]
+    /// extend-terminal-background-into-titlebar = true
+    /// ```
     #[serde(
         default = "bool::default",
         rename = "extend-terminal-background-into-titlebar"

--- a/rio-backend/src/config/window.rs
+++ b/rio-backend/src/config/window.rs
@@ -208,6 +208,13 @@ pub struct Window {
     pub decorations: Decorations,
     #[serde(default = "bool::default", rename = "macos-use-unified-titlebar")]
     pub macos_use_unified_titlebar: bool,
+    /// Let the topmost terminal cells paint through the transparent titlebar.
+    /// Off by default so terminal backgrounds stop at the viewport boundary.
+    #[serde(
+        default = "bool::default",
+        rename = "extend-terminal-background-into-titlebar"
+    )]
+    pub extend_terminal_background_into_titlebar: bool,
     #[serde(rename = "macos-use-shadow", default = "default_bool_true")]
     pub macos_use_shadow: bool,
     #[serde(rename = "macos-traffic-light-position-x", default = "Option::default")]
@@ -258,6 +265,7 @@ impl Default for Window {
             decorations: Decorations::default(),
             blur: WindowBlur::default(),
             macos_use_unified_titlebar: false,
+            extend_terminal_background_into_titlebar: false,
             macos_use_shadow: true,
             macos_traffic_light_position_x: None,
             macos_traffic_light_position_y: None,

--- a/sugarloaf/src/grid/cell.rs
+++ b/sugarloaf/src/grid/cell.rs
@@ -106,7 +106,7 @@ const _: () = {
 /// - Group scalars into 16-byte blocks or add explicit `_pad` fields.
 /// - Struct size must be a multiple of 16 bytes.
 ///
-/// Current layout: 144 bytes, 16-byte aligned.
+/// Current layout: 176 bytes, 16-byte aligned.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct GridUniforms {
@@ -162,6 +162,12 @@ pub struct GridUniforms {
     /// grid bg appears brighter/more saturated than the window bg
     /// fill, which runs through `prepare_output_rgb`.
     pub input_colorspace: u32,
+    // --- 16-byte block: panel_clip (vec4) at offset 160 ---
+    /// Physical-pixel clip bounds for this panel (top, right, bottom, left).
+    /// The cell-bg shader draws a fullscreen triangle, so this keeps padding
+    /// extension inside the panel that owns the edge cells. Outermost panels
+    /// may expand their corresponding bounds to the drawable edge.
+    pub panel_clip: [f32; 4],
 }
 
 impl GridUniforms {

--- a/sugarloaf/src/grid/cpu.rs
+++ b/sugarloaf/src/grid/cpu.rs
@@ -392,6 +392,17 @@ impl CpuGridRenderer {
         let cursor_y = uniforms.cursor_pos[1];
         let cursor_bg_active = uniforms.cursor_bg_color[3] > 0.0;
         let cursor_bg = normalize_color(uniforms.cursor_bg_color);
+        let clip_top = uniforms.panel_clip[0].round() as i32;
+        let clip_right = uniforms.panel_clip[1].round() as i32;
+        let clip_bottom = uniforms.panel_clip[2].round() as i32;
+        let clip_left = uniforms.panel_clip[3].round() as i32;
+        let extend_left =
+            uniforms.padding_extend & GridUniforms::PADDING_EXTEND_LEFT != 0;
+        let extend_right =
+            uniforms.padding_extend & GridUniforms::PADDING_EXTEND_RIGHT != 0;
+        let extend_up = uniforms.padding_extend & GridUniforms::PADDING_EXTEND_UP != 0;
+        let extend_down =
+            uniforms.padding_extend & GridUniforms::PADDING_EXTEND_DOWN != 0;
 
         let buf_cols = self.cols as usize;
         let row_count = (rows as usize).min(self.rows as usize);
@@ -399,19 +410,55 @@ impl CpuGridRenderer {
         for row in 0..row_count {
             let row_off = row * buf_cols;
             for col in 0..col_count {
-                let mut rgba = self.bg_cells[row_off + col].rgba;
-                if cursor_bg_active && cursor_x == col as u32 && cursor_y == row as u32 {
-                    rgba = cursor_bg;
+                let cell_x0 = (pad_left + (col as f32) * cell_w).round() as i32;
+                let cell_y0 = (pad_top + (row as f32) * cell_h).round() as i32;
+                let cell_x1 = (pad_left + ((col + 1) as f32) * cell_w).round() as i32;
+                let cell_y1 = (pad_top + ((row + 1) as f32) * cell_h).round() as i32;
+
+                let x0 = if col == 0 && extend_left {
+                    clip_left
+                } else {
+                    cell_x0
                 }
-                if rgba[3] == 0 {
-                    continue;
+                .max(clip_left);
+                let y0 = if row == 0 && extend_up {
+                    clip_top
+                } else {
+                    cell_y0
+                }
+                .max(clip_top);
+                let x1 = if col + 1 == col_count && extend_right {
+                    clip_right
+                } else {
+                    cell_x1
+                }
+                .min(clip_right);
+                let y1 = if row + 1 == row_count && extend_down {
+                    clip_bottom
+                } else {
+                    cell_y1
+                }
+                .min(clip_bottom);
+
+                let rgba = self.bg_cells[row_off + col].rgba;
+                if rgba[3] != 0 {
+                    fill_rect(buf, buf_w_i, buf_h_i, x0, y0, x1, y1, rgba);
                 }
 
-                let x0 = (pad_left + (col as f32) * cell_w).round() as i32;
-                let y0 = (pad_top + (row as f32) * cell_h).round() as i32;
-                let x1 = (pad_left + ((col + 1) as f32) * cell_w).round() as i32;
-                let y1 = (pad_top + ((row + 1) as f32) * cell_h).round() as i32;
-                fill_rect(buf, buf_w_i, buf_h_i, x0, y0, x1, y1, rgba);
+                // Match the GPU shader: the block cursor paints only the
+                // real cell and never inherits edge extension.
+                if cursor_bg_active && cursor_x == col as u32 && cursor_y == row as u32 {
+                    fill_rect(
+                        buf,
+                        buf_w_i,
+                        buf_h_i,
+                        cell_x0.max(clip_left),
+                        cell_y0.max(clip_top),
+                        cell_x1.min(clip_right),
+                        cell_y1.min(clip_bottom),
+                        cursor_bg,
+                    );
+                }
             }
         }
     }
@@ -715,5 +762,56 @@ fn blit_color(
             let idx = buf_row + (dst_x as usize);
             buf[idx] = blend_over(src, buf[idx]);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytemuck::Zeroable;
+
+    #[test]
+    fn edge_backgrounds_fill_panel_clip_without_extending_cursor() {
+        let mut grid = CpuGridRenderer::new(2, 1);
+        grid.write_row(
+            0,
+            &[
+                CellBg {
+                    rgba: [255, 0, 0, 255],
+                },
+                CellBg {
+                    rgba: [0, 0, 255, 255],
+                },
+            ],
+            &[],
+        );
+
+        let mut uniforms = GridUniforms::zeroed();
+        uniforms.grid_padding = [1.0, 0.0, 0.0, 2.0];
+        uniforms.cell_size = [2.0, 2.0];
+        uniforms.grid_size = [2, 1];
+        uniforms.cursor_pos = [1, 0];
+        uniforms.cursor_bg_color = [0.0, 1.0, 0.0, 1.0];
+        uniforms.padding_extend = GridUniforms::PADDING_EXTEND_LEFT
+            | GridUniforms::PADDING_EXTEND_RIGHT
+            | GridUniforms::PADDING_EXTEND_UP
+            | GridUniforms::PADDING_EXTEND_DOWN;
+        uniforms.panel_clip = [0.0, 8.0, 4.0, 0.0];
+
+        let mut buf = vec![0; 8 * 4];
+        grid.render_bg(&mut buf, 8, 4, &uniforms);
+
+        let extended = [
+            0xff0000, 0xff0000, 0xff0000, 0xff0000, 0x0000ff, 0x0000ff, 0x0000ff,
+            0x0000ff,
+        ];
+        let cursor_row = [
+            0xff0000, 0xff0000, 0xff0000, 0xff0000, 0x00ff00, 0x00ff00, 0x0000ff,
+            0x0000ff,
+        ];
+        assert_eq!(&buf[0..8], &extended);
+        assert_eq!(&buf[8..16], &cursor_row);
+        assert_eq!(&buf[16..24], &cursor_row);
+        assert_eq!(&buf[24..32], &extended);
     }
 }

--- a/sugarloaf/src/grid/metal.rs
+++ b/sugarloaf/src/grid/metal.rs
@@ -79,6 +79,19 @@ pub fn release_frame_permit(p: &FramePermits) {
     c.notify_one();
 }
 
+/// Wait until every submitted Metal frame has completed.
+///
+/// Scale transitions replace the drawable geometry while command buffers
+/// from the previous display may still be using it. The main thread is the
+/// only permit consumer, so observing the full count is an idle barrier.
+pub fn wait_for_all_frame_permits(p: &FramePermits) {
+    let (m, c) = &**p;
+    let mut g = m.lock();
+    while *g < FRAMES_IN_FLIGHT {
+        c.wait(&mut g);
+    }
+}
+
 /// Extra slots appended to the per-row fg storage for cursor glyphs.
 /// `rows + 2` layout (block cursor at slot 0,
 /// non-block-style cursor at the tail).

--- a/sugarloaf/src/grid/shaders/grid.metal
+++ b/sugarloaf/src/grid/shaders/grid.metal
@@ -36,7 +36,8 @@ struct Uniforms {
     float    min_contrast;     //       144
     uint     flags;            //       148
     uint     padding_extend;   //       152
-    uint     input_colorspace; //       156 → total 160
+    uint     input_colorspace; //       156
+    float4   panel_clip;       //       160 → total 176
 };
 
 //-------------------------------------------------------------------
@@ -138,6 +139,16 @@ fragment float4 grid_bg_fragment(
     constant Uniforms&   uniforms [[buffer(0)]],
     constant uchar4*     cells    [[buffer(1)]]
 ) {
+ // Keep this fullscreen pass inside the panel that owns the grid.
+ // Bounds are (top, right, bottom, left) in physical pixels.
+    if (in.position.x < uniforms.panel_clip.w
+        || in.position.x >= uniforms.panel_clip.y
+        || in.position.y < uniforms.panel_clip.x
+        || in.position.y >= uniforms.panel_clip.z)
+    {
+        return float4(0.0);
+    }
+
  // `in.position.xy` is the pixel's center in framebuffer pixels.
  // `grid_padding` is (top, right, bottom, left) — we only need
  // left (.w) and top (.x) to locate the grid origin.

--- a/sugarloaf/src/grid/shaders/grid.wgsl
+++ b/sugarloaf/src/grid/shaders/grid.wgsl
@@ -14,7 +14,7 @@
 // come in already sRGB-encoded from the CPU).
 //
 // Bindings:
-// @group(0) @binding(0) Uniforms (140+4 = 144 bytes)
+// @group(0) @binding(0) Uniforms (176 bytes)
 // @group(0) @binding(1) CellBg[] (cols * rows entries)
 //
 // Must match `WgpuGridRenderer`'s bind group layout in
@@ -33,6 +33,7 @@ struct Uniforms {
     flags:            u32,           //       148
     padding_extend:   u32,           //       152
     input_colorspace: u32,           //       156
+    panel_clip:       vec4<f32>,     //       160
 };
 
 // Color space / transfer curve helpers. Matrices match the Metal
@@ -124,6 +125,15 @@ fn load_cell_bg(idx: u32) -> vec4<f32> {
 
 @fragment
 fn grid_bg_fragment(in: VsOut) -> @location(0) vec4<f32> {
+ // Keep this fullscreen pass inside the panel that owns the grid.
+ // Bounds are (top, right, bottom, left) in physical pixels.
+    if (in.position.x < uniforms.panel_clip.w
+        || in.position.x >= uniforms.panel_clip.y
+        || in.position.y < uniforms.panel_clip.x
+        || in.position.y >= uniforms.panel_clip.z) {
+        return vec4<f32>(0.0);
+    }
+
  // `grid_padding` is (top, right, bottom, left).
  // Use .w (left) + .x (top) to find the grid origin, same as Metal port.
     let cell_fx = (in.position.xy - vec2<f32>(uniforms.grid_padding.w, uniforms.grid_padding.x))
@@ -309,4 +319,3 @@ fn grid_text_fragment(in: TextVsOut) -> @location(0) vec4<f32> {
         return textureLoad(atlas_color, ic, 0);
     }
 }
-

--- a/sugarloaf/src/grid/shaders/grid_bg.frag.glsl
+++ b/sugarloaf/src/grid/shaders/grid_bg.frag.glsl
@@ -11,8 +11,8 @@
 // Metal `Uniforms` struct in grid.metal — std140 layout naturally
 // matches the hand-packed byte layout used over there.
 
-// `Uniforms` mirrors `GridUniforms` (144B + pad to 160B = 10 × vec4
-// blocks under std140). See cell.rs for offsets / sizes; the fields
+// `Uniforms` mirrors `GridUniforms` (176B = 11 × vec4 blocks under
+// std140). See cell.rs for offsets / sizes; the fields
 // here are listed in the same order.
 layout(set = 0, binding = 0, std140) uniform Uniforms {
     mat4 projection;        // offset   0
@@ -27,6 +27,7 @@ layout(set = 0, binding = 0, std140) uniform Uniforms {
     uint flags;             // offset 148
     uint padding_extend;    // offset 152
     uint input_colorspace;  // offset 156
+    vec4 panel_clip;        // offset 160  (top, right, bottom, left)
 } uniforms;
 
 // `CellBg` is 4 bytes (uchar4 rgba) in cell.rs. We expose the storage
@@ -85,6 +86,16 @@ vec3 grid_prepare_output_rgb(vec3 srgb, uint input_colorspace) {
 }
 
 void main() {
+    // Keep this fullscreen pass inside the panel that owns the grid.
+    if (gl_FragCoord.x < uniforms.panel_clip.w
+        || gl_FragCoord.x >= uniforms.panel_clip.y
+        || gl_FragCoord.y < uniforms.panel_clip.x
+        || gl_FragCoord.y >= uniforms.panel_clip.z)
+    {
+        out_color = vec4(0.0);
+        return;
+    }
+
     // `gl_FragCoord.xy` is the pixel center in framebuffer pixels.
     // Locate the owning grid cell relative to the grid origin
     // (top-left = grid_padding.w / .x).

--- a/sugarloaf/src/grid/shaders/grid_text.vert.glsl
+++ b/sugarloaf/src/grid/shaders/grid_text.vert.glsl
@@ -37,6 +37,7 @@ layout(set = 0, binding = 0, std140) uniform Uniforms {
     uint flags;
     uint padding_extend;
     uint input_colorspace;
+    vec4 panel_clip;
 } uniforms;
 
 layout(location = 0) in uvec2 in_glyph_pos;

--- a/sugarloaf/src/renderer/mod.rs
+++ b/sugarloaf/src/renderer/mod.rs
@@ -997,6 +997,11 @@ fn upload_background_image_texture(
 }
 
 impl Renderer {
+    #[cfg(target_os = "macos")]
+    pub fn wait_for_gpu_idle(&self) {
+        crate::grid::metal::wait_for_all_frame_permits(&self.metal_frame_permits);
+    }
+
     pub fn new(context: &Context, colorspace: crate::sugarloaf::Colorspace) -> Self {
         // `colorspace` only matters to the Metal path (macOS); on other
         // platforms the shader doesn't know the sRGB→P3 matrix yet so we

--- a/sugarloaf/src/renderer/mod.rs
+++ b/sugarloaf/src/renderer/mod.rs
@@ -2239,14 +2239,10 @@ impl Renderer {
             let has_images = !self.image_draws.is_empty();
 
             let ok = (|| {
-                // Always draw the window bg fill. With the grid
-                // owning per-cell bg, `padding_extend` in the grid
-                // shader was initially used to extend edge cell
-                // colors into the window margin — but that only
-                // works for a single full-window grid. Once splits
-                // exist, each panel's grid covers only its own rect,
-                // so the window margin + gutters between panels
-                // rely on this fullscreen fill again.
+                // Always draw the window bg fill. Grid backgrounds
+                // extend edge-cell colors inside their panel clips;
+                // transparent edge cells and configured split gutters
+                // still reveal this fill underneath.
                 if let Some(rgba) = bg_color {
                     if !Self::draw_bg_fill_metal(
                         brush,

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -827,6 +827,11 @@ impl Sugarloaf<'_> {
         self.state.style.scale_factor
     }
 
+    #[cfg(target_os = "macos")]
+    pub fn wait_for_gpu_idle(&self) {
+        self.renderer.wait_for_gpu_idle();
+    }
+
     #[inline]
     pub fn resize(&mut self, width: u32, height: u32) {
         self.ctx.resize(width, height);


### PR DESCRIPTION
## Summary

- extend outer edge-cell backgrounds through left, right, and bottom terminal padding while keeping split panes clipped to their owned regions
- keep the titlebar boundary conservative by default and provide an opt-in full-window treatment with adaptive tab text contrast
- keep Metal, WebGPU, Vulkan, and CPU rendering behavior aligned and document the new configuration

## Configuration

```toml
[window]
extend-terminal-background-into-titlebar = true
```

The option defaults to `false`.

## Testing

- `cargo test -p rio-backend` (219 passed)
- `cargo test -p rioterm --no-default-features` (192 passed)
- `cargo test -p sugarloaf --no-default-features` (134 passed, 7 ignored)
- bundled WGSL shader validation passed
- manual testing (screenshots below)

<img width="1045" height="726" alt="Screenshot 2026-08-13 at 15 39 59" src="https://github.com/user-attachments/assets/c92aa44b-0c98-4a8a-9373-2e3a3b49aa4c" />
<img width="1045" height="726" alt="Screenshot 2026-08-13 at 15 39 41" src="https://github.com/user-attachments/assets/c79e0b7c-d207-465a-ae40-a24ffafb9a5f" />
<img width="1045" height="726" alt="Screenshot 2026-08-13 at 15 39 32" src="https://github.com/user-attachments/assets/cee5770a-bc04-4627-a123-02c80fffe163" />
<img width="1045" height="726" alt="Screenshot 2026-08-13 at 15 39 20" src="https://github.com/user-attachments/assets/4a4ae221-78f8-49f7-b945-25426759e7c2" />


Closes #1815