### PR TITLE
Rework cursor trail: exact easing, visibility fade, config surface

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1754,6 +1754,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             delta,
                             &mut route.window.screen.sugarloaf,
                         );
+                    // Dragging a split divider displaces panel origins;
+                    // that is layout, not cursor travel.
+                    route.window.screen.renderer.trail_cursor.snap();
                     let cursor = match border.direction {
                         crate::layout::BorderDirection::Vertical => CursorIcon::ColResize,
                         crate::layout::BorderDirection::Horizontal => {

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -167,7 +167,17 @@ impl Renderer {
             is_game_mode_enabled: config.renderer.strategy.is_game(),
             custom_mouse_cursor: config.effects.custom_mouse_cursor,
             trail_cursor_enabled: config.effects.trail_cursor,
-            trail_cursor: trail_cursor::TrailCursor::new(),
+            trail_cursor: trail_cursor::TrailCursor::new(trail_cursor::TrailSettings {
+                color: config
+                    .effects
+                    .trail_cursor_color
+                    .as_deref()
+                    .map(rio_backend::config::colors::hex_to_color_arr),
+                opacity: config.effects.trail_cursor_opacity,
+                decay_fast: config.effects.trail_cursor_decay[0] as f32 / 1000.0,
+                decay_slow: config.effects.trail_cursor_decay[1] as f32 / 1000.0,
+                start_threshold: config.effects.trail_cursor_start_threshold as f32,
+            }),
         }
     }
 

--- a/frontends/rioterm/src/renderer/trail_cursor.rs
+++ b/frontends/rioterm/src/renderer/trail_cursor.rs
@@ -1,378 +1,501 @@
-// This file was heavily inspired by neovide implementation.
+// Cursor trail: the four corners of one quad chase the cursor rect
+// with exponential ease-out, corners on the leading side of the motion
+// faster than trailing ones, which is what stretches the quad into a
+// smear. The model is kitty's (kitty/cursor_trail.c): the easing
+// `1 - 2^(-10 * dt / decay)` is exact for any frame gap, so an
+// event-driven renderer with irregular frame timing animates the same
+// path a fixed-cadence one would, no sub-stepping or frame-rate
+// normalization required.
 
-use crate::renderer::helpers::spring::Spring;
+use rio_backend::ansi::CursorShape;
 use rio_backend::sugarloaf::Sugarloaf;
 use std::time::Instant;
 
-/// Animation duration for long jumps (seconds).
-const ANIMATION_LENGTH: f32 = 0.15;
-
-/// Animation duration for short (≤2 cell horizontal) movements.
-const SHORT_ANIMATION_LENGTH: f32 = 0.04;
-
-/// Trail size 0.0–1.0.
-/// 1.0 = max stretch (leading edge jumps instantly,
-/// trailing edge lags most).
-const TRAIL_SIZE: f32 = 1.0;
 const DEPTH: f32 = 0.0;
 
-#[derive(Clone)]
-struct Corner {
-    spring_x: Spring,
-    spring_y: Spring,
-    /// Current animated pixel position.
-    x: f32,
-    y: f32,
-    /// Offset relative to cursor center (shape-aware).
-    rel_x: f32,
-    rel_y: f32,
-    prev_dest_x: f32,
-    prev_dest_y: f32,
-    anim_length: f32,
+/// A corner is settled within half a physical pixel of its target.
+const SETTLE_EPSILON_PX: f32 = 0.5;
+
+/// Beam and underline thickness as a fraction of the cell width.
+const THIN_SHAPE_FRACTION: f32 = 0.15;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TrailSettings {
+    /// Overrides the cursor color when set.
+    pub color: Option<[f32; 4]>,
+    /// Peak opacity multiplier, 0.0 to 1.0.
+    pub opacity: f32,
+    /// Catch-up time of the fastest corner, seconds.
+    pub decay_fast: f32,
+    /// Catch-up time of the slowest corner, seconds. Also the fade
+    /// time when the cursor hides.
+    pub decay_slow: f32,
+    /// Jumps at or under this many cells (both axes) from rest snap
+    /// instead of starting a trail.
+    pub start_threshold: f32,
 }
 
-impl Corner {
-    fn new(rel_x: f32, rel_y: f32) -> Self {
+impl Default for TrailSettings {
+    fn default() -> Self {
         Self {
-            spring_x: Spring::new(),
-            spring_y: Spring::new(),
-            x: 0.0,
-            y: 0.0,
-            rel_x,
-            rel_y,
-            prev_dest_x: -1e6,
-            prev_dest_y: -1e6,
-            anim_length: 0.0,
+            color: None,
+            opacity: 1.0,
+            decay_fast: 0.1,
+            decay_slow: 0.4,
+            start_threshold: 2.0,
         }
     }
+}
 
-    #[inline]
-    fn destination(
-        &self,
-        center_x: f32,
-        center_y: f32,
-        cell_w: f32,
-        cell_h: f32,
-    ) -> (f32, f32) {
-        (
-            center_x + self.rel_x * cell_w,
-            center_y + self.rel_y * cell_h,
-        )
-    }
-
-    #[inline]
-    fn update(
-        &mut self,
-        center_x: f32,
-        center_y: f32,
-        cell_w: f32,
-        cell_h: f32,
-        dt: f32,
-        immediate_movement: bool,
-    ) -> bool {
-        let (dest_x, dest_y) = self.destination(center_x, center_y, cell_w, cell_h);
-
-        if (dest_x - self.prev_dest_x).abs() > 0.01
-            || (dest_y - self.prev_dest_y).abs() > 0.01
-        {
-            self.spring_x.position = dest_x - self.x;
-            self.spring_y.position = dest_y - self.y;
-            self.prev_dest_x = dest_x;
-            self.prev_dest_y = dest_y;
-        }
-
-        // Teleport: snap to destination without animating.
-        if immediate_movement {
-            self.x = dest_x;
-            self.y = dest_y;
-            self.spring_x.reset();
-            self.spring_y.reset();
-            return false;
-        }
-
-        let mut animating = self.spring_x.update(dt, self.anim_length);
-        animating |= self.spring_y.update(dt, self.anim_length);
-        self.x = dest_x - self.spring_x.position;
-        self.y = dest_y - self.spring_y.position;
-
-        animating
-    }
-
-    /// Direction alignment: dot product of the corner's relative direction
-    /// with the travel direction.  Higher = more aligned with movement =
-    /// "leading".  Matches neovide's `calculate_direction_alignment`.
-    #[inline]
-    fn direction_alignment(
-        &self,
-        center_x: f32,
-        center_y: f32,
-        cell_w: f32,
-        cell_h: f32,
-    ) -> f32 {
-        let (dest_x, dest_y) = self.destination(center_x, center_y, cell_w, cell_h);
-
-        // Corner's relative direction (normalized).
-        let rel_len = (self.rel_x * self.rel_x + self.rel_y * self.rel_y)
-            .sqrt()
-            .max(1e-6);
-        let corner_dir_x = self.rel_x / rel_len;
-        let corner_dir_y = self.rel_y / rel_len;
-
-        // Travel direction (from current animated pos to destination).
-        let dx = dest_x - self.x;
-        let dy = dest_y - self.y;
-        let travel_len = (dx * dx + dy * dy).sqrt().max(1e-6);
-
-        (dx / travel_len) * corner_dir_x + (dy / travel_len) * corner_dir_y
+impl TrailSettings {
+    pub fn sanitized(mut self) -> Self {
+        self.opacity = self.opacity.clamp(0.0, 1.0);
+        self.decay_fast = self.decay_fast.max(0.001);
+        // The slow corner can never beat the fast one.
+        self.decay_slow = self.decay_slow.max(self.decay_fast);
+        self.start_threshold = self.start_threshold.max(0.0);
+        self
     }
 }
 
 pub struct TrailCursor {
-    /// Four corners: [top-left, top-right, bottom-right, bottom-left].
-    corners: [Corner; 4],
-    last_frame: Instant,
-    /// Current destination center (physical pixels).
-    dest_cx: f32,
-    dest_cy: f32,
-    /// Previous destination center, used to detect jumps.
-    prev_dest_cx: f32,
-    prev_dest_cy: f32,
-    /// Center before the current jump — preserved so `compute_jump` can
-    /// measure travel distance (since `set_destination` overwrites
-    /// `prev_dest` before `animate` runs).
-    jump_from_cx: f32,
-    jump_from_cy: f32,
-    /// One-shot flag: set when destination changes, consumed in `animate`.
-    jumped: bool,
-    /// True until the first real destination is set — first frame teleports.
-    first_frame: bool,
+    /// Animated quad corners, TL TR BR BL, physical pixels.
+    corners: [[f32; 2]; 4],
+    /// Where the corners are headed: the cursor rect for the current
+    /// shape. Kept across a hide so the fade-out happens in place.
+    target: [[f32; 2]; 4],
+    /// Visibility ramp, 0.0 to 1.0. Rises and falls over
+    /// `decay_slow` so a hiding cursor fades its trail out instead of
+    /// cutting it.
+    opacity: f32,
+    last_tick: Instant,
+    /// Corners still travelling this frame.
+    moving: bool,
+    /// One extra frame after settling so the final snap paints.
+    was_moving: bool,
+    /// Frames are still needed (movement or an in-flight fade).
+    active: bool,
     route_id: Option<usize>,
-    animating: bool,
+    first_frame: bool,
+    settings: TrailSettings,
+}
+
+/// The cursor rect a shape occupies, as quad corners TL TR BR BL.
+/// `None` for a hidden cursor: the trail keeps its previous target
+/// and fades where it stands.
+fn target_rect(
+    x: f32,
+    y: f32,
+    cell_width: f32,
+    cell_height: f32,
+    shape: CursorShape,
+) -> Option<[[f32; 2]; 4]> {
+    let thickness = (cell_width * THIN_SHAPE_FRACTION).round().max(1.0);
+    let (x0, y0, w, h) = match shape {
+        CursorShape::Block => (x, y, cell_width, cell_height),
+        CursorShape::Beam => (x, y, thickness, cell_height),
+        CursorShape::Underline => (x, y + cell_height - thickness, cell_width, thickness),
+        CursorShape::Hidden => return None,
+    };
+    Some([[x0, y0], [x0 + w, y0], [x0 + w, y0 + h], [x0, y0 + h]])
 }
 
 impl TrailCursor {
-    pub fn new() -> Self {
+    pub fn new(settings: TrailSettings) -> Self {
         Self {
-            corners: [
-                Corner::new(-0.5, -0.5), // top-left
-                Corner::new(0.5, -0.5),  // top-right
-                Corner::new(0.5, 0.5),   // bottom-right
-                Corner::new(-0.5, 0.5),  // bottom-left
-            ],
-            last_frame: Instant::now(),
-            dest_cx: 0.0,
-            dest_cy: 0.0,
-            prev_dest_cx: -1e6,
-            prev_dest_cy: -1e6,
-            jump_from_cx: -1e6,
-            jump_from_cy: -1e6,
-            jumped: false,
-            first_frame: true,
+            corners: [[0.0; 2]; 4],
+            target: [[0.0; 2]; 4],
+            opacity: 0.0,
+            last_tick: Instant::now(),
+            moving: false,
+            was_moving: false,
+            active: false,
             route_id: None,
-            animating: false,
+            first_frame: true,
+            settings: settings.sanitized(),
         }
     }
 
-    pub fn set_route(&mut self, route_id: usize) {
-        if self.route_id != Some(route_id) {
-            self.route_id = Some(route_id);
-            self.first_frame = true;
-        }
-    }
-
-    /// Update the cursor destination.  Called once per frame **before**
-    /// `animate()`.  Sets the `jumped` flag when the destination changes
-    /// (matching neovide's `update_cursor_destination`).
-    pub fn set_destination(
+    /// Advance the trail toward the cursor at (`cursor_x`,
+    /// `cursor_y`) physical pixels. Returns whether another frame is
+    /// needed; while it returns `true` the caller must keep frames
+    /// coming or the animation freezes mid-flight.
+    #[allow(clippy::too_many_arguments)]
+    pub fn update(
         &mut self,
         cursor_x: f32,
         cursor_y: f32,
         cell_width: f32,
         cell_height: f32,
-    ) {
-        // Center of cursor cell.
-        let cx = cursor_x + cell_width * 0.5;
-        let cy = cursor_y + cell_height * 0.5;
-        self.dest_cx = cx;
-        self.dest_cy = cy;
-
-        // Detect a jump (destination changed).
-        if (cx - self.prev_dest_cx).abs() > 0.01 || (cy - self.prev_dest_cy).abs() > 0.01
-        {
-            self.jump_from_cx = self.prev_dest_cx;
-            self.jump_from_cy = self.prev_dest_cy;
-            self.prev_dest_cx = cx;
-            self.prev_dest_cy = cy;
-            self.jumped = true;
-        }
-    }
-
-    /// Run animation for one frame.  Called once per frame **after**
-    /// `set_destination()`.  If `jumped` is set, computes corner ranking
-    /// and assigns animation lengths exactly once per jump (matching
-    /// neovide's `animate`).
-    pub fn animate(&mut self, cell_width: f32, cell_height: f32) {
+        shape: CursorShape,
+        visible: bool,
+        route_id: usize,
+    ) -> bool {
         let now = Instant::now();
-        let dt = now.duration_since(self.last_frame).as_secs_f32().min(0.1);
-        self.last_frame = now;
+        let dt = now.duration_since(self.last_tick).as_secs_f32();
+        self.last_tick = now;
+        let visible = visible && shape != CursorShape::Hidden;
 
-        let cx = self.dest_cx;
-        let cy = self.dest_cy;
+        if let Some(rect) =
+            target_rect(cursor_x, cursor_y, cell_width, cell_height, shape)
+        {
+            self.target = rect;
+        }
 
-        // First frame: teleport all corners to destination without
-        // animation (matches neovide's `immediate_movement`).
-        let immediate = self.first_frame;
-        if self.first_frame {
+        self.tick(dt, visible, route_id, cell_width, cell_height)
+    }
+
+    /// The dt-explicit core of [`update`], separated so tests control
+    /// time.
+    fn tick(
+        &mut self,
+        dt: f32,
+        visible: bool,
+        route_id: usize,
+        cell_width: f32,
+        cell_height: f32,
+    ) -> bool {
+        // A panel or tab switch is not cursor travel: teleport.
+        if self.first_frame || self.route_id != Some(route_id) {
+            self.route_id = Some(route_id);
             self.first_frame = false;
+            self.corners = self.target;
+            self.opacity = if visible { 1.0 } else { 0.0 };
+            self.moving = false;
+            self.was_moving = false;
+            self.active = false;
+            return false;
         }
 
-        // On jump: compute ranking and set animation lengths (one-shot).
-        if self.jumped && !immediate {
-            self.compute_jump(cx, cy, cell_width, cell_height);
-        }
-        self.jumped = false;
-
-        // Spring update every frame (matching neovide).
-        let mut still_animating = false;
-        for corner in &mut self.corners {
-            if corner.update(cx, cy, cell_width, cell_height, dt, immediate) {
-                still_animating = true;
+        // From rest, a jump within the threshold snaps: typing-scale
+        // movement stays trail-free. Once in flight, every retarget
+        // is followed so the trail bends with the cursor.
+        if !self.moving && !self.was_moving {
+            let dx = (self.target[0][0] - self.corners[0][0]).abs() / cell_width.max(1.0);
+            let dy =
+                (self.target[0][1] - self.corners[0][1]).abs() / cell_height.max(1.0);
+            if dx <= self.settings.start_threshold && dy <= self.settings.start_threshold
+            {
+                self.corners = self.target;
             }
         }
 
-        self.animating = still_animating;
-    }
-
-    /// Compute corner direction-alignment ranking and assign animation
-    /// lengths.  Called exactly once per cursor jump (matching neovide's
-    /// `Corner::jump` called from the `if self.jumped` block).
-    fn compute_jump(&mut self, cx: f32, cy: f32, cell_width: f32, cell_height: f32) {
-        // Compute jump vector in cell units for short-movement detection.
-        // `jump_from` is the center *before* this jump was detected.
-        let jump_x = if cell_width > 0.0 {
-            ((cx - self.jump_from_cx) / cell_width).abs()
+        // Visibility ramp. A cursor hidden by the program (DECTCEM,
+        // as file managers and TUI dashboards do on every refresh)
+        // fades the trail out over `decay_slow` instead of letting it
+        // animate forever or vanish in one frame.
+        let ramp = dt / self.settings.decay_slow;
+        self.opacity = if visible {
+            (self.opacity + ramp).min(1.0)
         } else {
-            0.0
+            (self.opacity - ramp).max(0.0)
         };
-        let jump_y = if cell_height > 0.0 {
-            ((cy - self.jump_from_cy) / cell_height).abs()
-        } else {
-            0.0
-        };
-        let is_short = jump_x <= 2.001 && jump_y < 0.001;
+        if !visible && self.opacity <= 0.0 {
+            // Fully faded: park on the target so reappearing starts
+            // clean.
+            self.corners = self.target;
+            let extra_frame = self.moving || self.was_moving;
+            self.moving = false;
+            self.was_moving = false;
+            self.active = extra_frame;
+            return extra_frame;
+        }
 
-        if is_short {
-            let t = ANIMATION_LENGTH.min(SHORT_ANIMATION_LENGTH);
-            for c in &mut self.corners {
-                c.anim_length = t;
+        // Per-corner decay by direction alignment: the dot product of
+        // each corner's remaining travel with its outward direction
+        // from the target center says whether the corner sits on the
+        // leading side of the motion. Leading corners take
+        // `decay_fast`, trailing ones `decay_slow`, normalized across
+        // the four so any travel direction stretches the quad.
+        let center_x = (self.target[0][0] + self.target[2][0]) * 0.5;
+        let center_y = (self.target[0][1] + self.target[2][1]) * 0.5;
+        let half_diag = {
+            let dx = self.target[0][0] - center_x;
+            let dy = self.target[0][1] - center_y;
+            (dx * dx + dy * dy).sqrt().max(1e-6)
+        };
+
+        let mut dots = [0.0f32; 4];
+        let mut any_travel = false;
+        for (i, corner) in self.corners.iter().enumerate() {
+            let dx = self.target[i][0] - corner[0];
+            let dy = self.target[i][1] - corner[1];
+            let dist = (dx * dx + dy * dy).sqrt();
+            if dist < 1e-6 {
+                continue;
             }
-            return;
+            any_travel = true;
+            let out_x = self.target[i][0] - center_x;
+            let out_y = self.target[i][1] - center_y;
+            dots[i] = (dx * out_x + dy * out_y) / (dist * half_diag);
         }
 
-        // Direction-alignment ranking (neovide-style).
-        let mut alignments: [(usize, f32); 4] = [
-            (
-                0,
-                self.corners[0].direction_alignment(cx, cy, cell_width, cell_height),
-            ),
-            (
-                1,
-                self.corners[1].direction_alignment(cx, cy, cell_width, cell_height),
-            ),
-            (
-                2,
-                self.corners[2].direction_alignment(cx, cy, cell_width, cell_height),
-            ),
-            (
-                3,
-                self.corners[3].direction_alignment(cx, cy, cell_width, cell_height),
-            ),
-        ];
+        if any_travel {
+            let min_dot = dots.iter().cloned().fold(f32::INFINITY, f32::min);
+            let max_dot = dots.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+            let range = max_dot - min_dot;
 
-        // Sort ascending: lowest alignment = most trailing.
-        alignments.sort_by(|a, b| {
-            a.1.partial_cmp(&b.1)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then(a.0.cmp(&b.0))
-        });
-
-        // Build per-corner rank array.
-        let mut ranks = [0usize; 4];
-        for (rank, &(corner_idx, _)) in alignments.iter().enumerate() {
-            ranks[corner_idx] = rank;
+            for (i, corner) in self.corners.iter_mut().enumerate() {
+                let alignment = if range > 1e-6 {
+                    (dots[i] - min_dot) / range
+                } else {
+                    // Uniform travel (pure translation of a settled
+                    // quad ranks all corners equally): everyone slow.
+                    0.0
+                };
+                let decay = self.settings.decay_slow
+                    + (self.settings.decay_fast - self.settings.decay_slow) * alignment;
+                let step = 1.0 - (2.0f32).powf(-10.0 * dt / decay);
+                corner[0] += (self.target[i][0] - corner[0]) * step;
+                corner[1] += (self.target[i][1] - corner[1]) * step;
+            }
         }
 
-        let leading = ANIMATION_LENGTH * (1.0 - TRAIL_SIZE).clamp(0.0, 1.0);
-        let trailing = ANIMATION_LENGTH;
-        let mid = (leading + trailing) / 2.0;
-
+        // Settled corners snap so the quad ends exactly on the cell.
+        let mut moving = false;
         for (i, corner) in self.corners.iter_mut().enumerate() {
-            corner.anim_length = match ranks[i] {
-                0 => trailing,
-                1 => mid,
-                _ => leading,
-            };
+            let dx = self.target[i][0] - corner[0];
+            let dy = self.target[i][1] - corner[1];
+            if dx.abs() > SETTLE_EPSILON_PX || dy.abs() > SETTLE_EPSILON_PX {
+                moving = true;
+            } else {
+                *corner = self.target[i];
+            }
         }
+
+        let fading = !visible && self.opacity > 0.0;
+        let filling = visible && self.opacity < 1.0 && moving;
+        let result = moving || self.was_moving || fading || filling;
+        self.was_moving = moving;
+        self.moving = moving;
+        self.active = result;
+        result
     }
 
-    /// Draw the cursor trail as a single convex quad spanned by the four
-    /// animated corners — emitted as two triangles through the existing
-    /// `DrawCmd::Vertices` pipeline. Matches neovide's approach of
-    /// `PathBuilder::move_to(TL).line_to(TR).line_to(BR).line_to(BL).close()`
-    /// into a single `draw_path`. The old scanline fill (up to 640 rects
-    /// per frame) was a workaround for `sugarloaf.rect` being axis-aligned
-    /// only; `sugarloaf.triangle` already accepts arbitrary vertex
-    /// positions, so one fan covers the same pixels in one draw call.
+    /// Draw the trail quad as two triangles through the existing
+    /// vertex pipeline. `cursor_color` applies when no color override
+    /// is configured; the visibility ramp and the configured opacity
+    /// both scale the alpha.
     pub fn draw(
         &self,
         sugarloaf: &mut Sugarloaf,
         scale_factor: f32,
         cursor_color: [f32; 4],
     ) {
-        if !self.animating {
+        if !self.active {
+            return;
+        }
+        let alpha = self.opacity * self.settings.opacity;
+        if alpha <= 0.0 {
             return;
         }
 
-        let inv = 1.0 / scale_factor;
+        let base = self.settings.color.unwrap_or(cursor_color);
+        let color = [base[0], base[1], base[2], base[3] * alpha];
 
-        // Corner positions in *logical* pixels (sugarloaf.triangle scales
-        // by scale_factor internally). Ordered TL, TR, BR, BL — same
-        // winding as neovide's path builder.
+        // Logical pixels: sugarloaf.triangle scales internally.
+        let inv = 1.0 / scale_factor;
         let pts: [(f32, f32); 4] = [
-            (self.corners[0].x * inv, self.corners[0].y * inv),
-            (self.corners[1].x * inv, self.corners[1].y * inv),
-            (self.corners[2].x * inv, self.corners[2].y * inv),
-            (self.corners[3].x * inv, self.corners[3].y * inv),
+            (self.corners[0][0] * inv, self.corners[0][1] * inv),
+            (self.corners[1][0] * inv, self.corners[1][1] * inv),
+            (self.corners[2][0] * inv, self.corners[2][1] * inv),
+            (self.corners[3][0] * inv, self.corners[3][1] * inv),
         ];
 
-        // Fan from TL: (TL, TR, BR) + (TL, BR, BL). Two triangles share
-        // TL and BR, so the shared diagonal seam is hidden inside the
-        // convex hull — same as any triangle-fan tessellation.
+        // Fan from TL: the shared diagonal stays inside the convex
+        // hull.
         sugarloaf.triangle(
-            pts[0].0,
-            pts[0].1,
-            pts[1].0,
-            pts[1].1,
-            pts[2].0,
-            pts[2].1,
-            DEPTH,
-            cursor_color,
+            pts[0].0, pts[0].1, pts[1].0, pts[1].1, pts[2].0, pts[2].1, DEPTH, color,
         );
         sugarloaf.triangle(
-            pts[0].0,
-            pts[0].1,
-            pts[2].0,
-            pts[2].1,
-            pts[3].0,
-            pts[3].1,
-            DEPTH,
-            cursor_color,
+            pts[0].0, pts[0].1, pts[2].0, pts[2].1, pts[3].0, pts[3].1, DEPTH, color,
         );
     }
 
-    /// `true` while the spring corners haven't settled *visibly*.
+    /// `true` while another frame is needed to advance the animation.
     #[inline]
     pub fn is_animating(&self) -> bool {
-        self.animating
+        self.active
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CELL_W: f32 = 10.0;
+    const CELL_H: f32 = 20.0;
+
+    fn trail(threshold: f32) -> TrailCursor {
+        let mut t = TrailCursor::new(TrailSettings {
+            start_threshold: threshold,
+            ..TrailSettings::default()
+        });
+        // First tick teleports onto the origin cell.
+        t.target = target_rect(0.0, 0.0, CELL_W, CELL_H, CursorShape::Block).unwrap();
+        t.tick(0.016, true, 1, CELL_W, CELL_H);
+        t
+    }
+
+    fn retarget(t: &mut TrailCursor, col: f32, row: f32) {
+        t.target = target_rect(
+            col * CELL_W,
+            row * CELL_H,
+            CELL_W,
+            CELL_H,
+            CursorShape::Block,
+        )
+        .unwrap();
+    }
+
+    fn max_corner_error(t: &TrailCursor) -> f32 {
+        t.corners
+            .iter()
+            .zip(t.target.iter())
+            .map(|(c, d)| ((c[0] - d[0]).abs()).max((c[1] - d[1]).abs()))
+            .fold(0.0, f32::max)
+    }
+
+    /// The exponential form must land on (nearly) the same path
+    /// regardless of how the wall-clock time is sliced into frames.
+    /// This is the property the previous spring integration lacked,
+    /// and it is why event-driven rendering froze or snapped the old
+    /// trail. The tolerance is not zero because per-corner decay is
+    /// re-ranked from live positions each tick; only that re-ranking
+    /// varies with slicing, the easing itself composes exactly.
+    #[test]
+    fn frame_slicing_does_not_change_the_path() {
+        let mut coarse = trail(0.0);
+        let mut fine = trail(0.0);
+        retarget(&mut coarse, 10.0, 5.0);
+        retarget(&mut fine, 10.0, 5.0);
+
+        coarse.tick(0.128, true, 1, CELL_W, CELL_H);
+        for _ in 0..8 {
+            fine.tick(0.016, true, 1, CELL_W, CELL_H);
+        }
+
+        // Travel is ~110px; hold divergence under 2% of it.
+        for (a, b) in coarse.corners.iter().zip(fine.corners.iter()) {
+            assert!((a[0] - b[0]).abs() < 2.5, "{a:?} vs {b:?}");
+            assert!((a[1] - b[1]).abs() < 2.5, "{a:?} vs {b:?}");
+        }
+    }
+
+    /// Long frame gaps (an idle terminal waking up) must complete the
+    /// animation, not freeze it partway.
+    #[test]
+    fn giant_dt_settles_instead_of_freezing() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 30.0, 20.0);
+        t.tick(5.0, true, 1, CELL_W, CELL_H);
+        assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
+        // One extra frame paints the snap, then it goes quiet.
+        assert!(t.tick(0.016, true, 1, CELL_W, CELL_H) || !t.is_animating());
+        assert!(!t.tick(0.016, true, 1, CELL_W, CELL_H));
+    }
+
+    #[test]
+    fn settles_within_decay_budget() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 40.0, 0.0);
+        // decay_slow reaches 1/1024 of the distance per its own
+        // definition; 2x the budget is comfortably settled.
+        let mut frames = 0;
+        while t.tick(0.016, true, 1, CELL_W, CELL_H) {
+            frames += 1;
+            assert!(frames < 100, "did not settle");
+        }
+        assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
+    }
+
+    /// Typing-scale movement from rest snaps without a trail; jumps
+    /// beyond the threshold animate.
+    #[test]
+    fn start_threshold_gates_from_rest() {
+        let mut t = trail(2.0);
+        retarget(&mut t, 1.0, 0.0);
+        assert!(!t.tick(0.016, true, 1, CELL_W, CELL_H));
+        assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
+
+        retarget(&mut t, 20.0, 0.0);
+        assert!(t.tick(0.016, true, 1, CELL_W, CELL_H));
+    }
+
+    /// Once in flight, retargets inside the threshold are still
+    /// followed: the trail bends with the cursor instead of snapping
+    /// mid-animation.
+    #[test]
+    fn mid_flight_retarget_is_followed() {
+        let mut t = trail(2.0);
+        retarget(&mut t, 20.0, 0.0);
+        assert!(t.tick(0.016, true, 1, CELL_W, CELL_H));
+
+        retarget(&mut t, 21.0, 0.0);
+        assert!(t.tick(0.016, true, 1, CELL_W, CELL_H));
+        assert!(max_corner_error(&t) > SETTLE_EPSILON_PX);
+    }
+
+    /// Corners on the leading side of the travel catch up faster:
+    /// that differential is the smear.
+    #[test]
+    fn leading_corners_outrun_trailing_ones() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 20.0, 0.0); // pure rightward travel
+        t.tick(0.016, true, 1, CELL_W, CELL_H);
+
+        // TR (index 1) leads, TL (index 0) trails.
+        let leading_left = t.target[1][0] - t.corners[1][0];
+        let trailing_left = t.target[0][0] - t.corners[0][0];
+        assert!(
+            leading_left < trailing_left,
+            "leading {leading_left} vs trailing {trailing_left}"
+        );
+    }
+
+    /// A hidden cursor fades the trail out and stops the animation;
+    /// it must not keep animating during TUI refreshes (yazi,
+    /// lazygit) and must not stick at full opacity.
+    #[test]
+    fn hidden_cursor_fades_out_and_stops() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 20.0, 0.0);
+        t.tick(0.016, true, 1, CELL_W, CELL_H);
+
+        // Hide: fade frames are still requested while opacity drains.
+        assert!(t.tick(0.016, false, 1, CELL_W, CELL_H));
+        assert!(t.opacity < 1.0);
+
+        // Drain past decay_slow: parked, quiet.
+        t.tick(1.0, false, 1, CELL_W, CELL_H);
+        t.tick(0.016, false, 1, CELL_W, CELL_H);
+        assert_eq!(t.opacity, 0.0);
+        assert!(!t.tick(0.016, false, 1, CELL_W, CELL_H));
+        assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
+    }
+
+    /// Switching panels or tabs teleports: a route change is not
+    /// cursor travel and must not smear across the screen.
+    #[test]
+    fn route_change_teleports() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 50.0, 30.0);
+        assert!(!t.tick(0.016, true, 2, CELL_W, CELL_H));
+        assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
+    }
+
+    #[test]
+    fn settings_sanitize_clamps() {
+        let s = TrailSettings {
+            color: None,
+            opacity: 3.0,
+            decay_fast: 0.5,
+            decay_slow: 0.1,
+            start_threshold: -1.0,
+        }
+        .sanitized();
+        assert_eq!(s.opacity, 1.0);
+        assert!(s.decay_slow >= s.decay_fast);
+        assert_eq!(s.start_threshold, 0.0);
     }
 }

--- a/frontends/rioterm/src/renderer/trail_cursor.rs
+++ b/frontends/rioterm/src/renderer/trail_cursor.rs
@@ -240,7 +240,15 @@ impl TrailCursor {
         // cursor, so the opacity drops outright.
         let ramp = dt / self.settings.decay_slow;
         self.opacity = if visible {
-            (self.opacity + ramp).min(1.0)
+            if self.moving || self.was_moving {
+                (self.opacity + ramp).min(1.0)
+            } else {
+                // Parked and visible nothing is drawn, so restore in
+                // one step: a cursor that hides and shows per refresh
+                // (TUIs, scrollback) must not dim its next flight by
+                // ramping up from the last chop.
+                1.0
+            }
         } else if self.moving || self.was_moving {
             (self.opacity - ramp).max(0.0)
         } else {
@@ -589,6 +597,41 @@ mod tests {
         // frame is owed because the previous frame painted.
         assert!(t.tick(1.0, false, true, 1, CELL_W, CELL_H));
         assert_eq!(t.opacity, 0.0);
+        assert!(!t.tick(0.016, false, true, 1, CELL_W, CELL_H));
+    }
+
+    /// A hide/show storm at rest (TUIs redrawing with DECTCEM, or
+    /// scrolling back and returning) must leave the trail at full
+    /// strength for its next flight, not dimmed by the last chop.
+    #[test]
+    fn reappearing_at_rest_restores_full_opacity() {
+        let mut t = trail(0.0);
+        for _ in 0..5 {
+            t.tick(0.016, false, true, 1, CELL_W, CELL_H);
+            t.tick(0.016, true, true, 1, CELL_W, CELL_H);
+        }
+        assert_eq!(t.opacity, 1.0);
+    }
+
+    /// Corners can settle while a hide-fade still has opacity left:
+    /// the drain tick then owes one clearing frame even though both
+    /// motion flags already dropped (the motion-flag logic alone
+    /// stranded the last painted quad here).
+    #[test]
+    fn settle_during_fade_still_clears_the_last_quad() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 20.0, 0.0);
+        t.tick(0.016, true, true, 1, CELL_W, CELL_H);
+
+        // Hide mid-flight with a dt that settles the corners while
+        // the fade is still in flight.
+        assert!(t.tick(0.36, false, true, 1, CELL_W, CELL_H));
+        assert!(!t.moving, "corners must have settled");
+        assert!(t.opacity > 0.0, "fade must still be in flight");
+
+        // The drain tick paints nothing, but the previous frame did:
+        // one clearing frame, then quiet.
+        assert!(t.tick(0.05, false, true, 1, CELL_W, CELL_H));
         assert!(!t.tick(0.016, false, true, 1, CELL_W, CELL_H));
     }
 

--- a/frontends/rioterm/src/renderer/trail_cursor.rs
+++ b/frontends/rioterm/src/renderer/trail_cursor.rs
@@ -202,7 +202,8 @@ impl TrailCursor {
         cell_width: f32,
         cell_height: f32,
     ) -> bool {
-        // A panel or tab switch is not cursor travel: teleport. A
+        // A panel or tab switch is not cursor travel, and neither is
+        // a layout reflow (`snap` arms this same branch): teleport. A
         // hidden cursor keeps the previous panel's rect, and parking
         // on it would smear from foreign coordinates once the cursor
         // shows, so the teleport waits until a real target exists.

--- a/frontends/rioterm/src/renderer/trail_cursor.rs
+++ b/frontends/rioterm/src/renderer/trail_cursor.rs
@@ -389,6 +389,15 @@ impl TrailCursor {
     pub fn is_animating(&self) -> bool {
         self.active
     }
+
+    /// Adopt the next real target without travel. Layout changes
+    /// (window resize, font-size change) displace the cursor without
+    /// the cursor having moved; animating that displacement smears
+    /// across the reflow.
+    #[inline]
+    pub fn snap(&mut self) {
+        self.first_frame = true;
+    }
 }
 
 #[cfg(test)]
@@ -652,6 +661,17 @@ mod tests {
         // from the old panel's coordinates.
         retarget(&mut t, 0.0, 0.0);
         assert!(!t.tick(0.016, true, true, 2, CELL_W, CELL_H));
+        assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
+    }
+
+    /// After a layout change (`snap`: resize, font-size change), the
+    /// next target is adopted without travel even at jump distance.
+    #[test]
+    fn snap_adopts_next_target_without_travel() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 40.0, 20.0);
+        t.snap();
+        assert!(!t.tick(0.016, true, true, 1, CELL_W, CELL_H));
         assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
     }
 

--- a/frontends/rioterm/src/renderer/trail_cursor.rs
+++ b/frontends/rioterm/src/renderer/trail_cursor.rs
@@ -2,10 +2,12 @@
 // with exponential ease-out, corners on the leading side of the motion
 // faster than trailing ones, which is what stretches the quad into a
 // smear. The model is kitty's (kitty/cursor_trail.c): the easing
-// `1 - 2^(-10 * dt / decay)` is exact for any frame gap, so an
-// event-driven renderer with irregular frame timing animates the same
-// path a fixed-cadence one would, no sub-stepping or frame-rate
-// normalization required.
+// `1 - 2^(-10 * dt / decay)` composes exactly across frames, so an
+// event-driven renderer with irregular in-flight frame timing animates
+// the same path a fixed-cadence one would, no sub-stepping required.
+// The one gap that is NOT animation time is idle: no frames are
+// scheduled while the trail rests, so the first tick of a new flight
+// integrates a nominal frame instead of the whole pause (frame_dt).
 
 use rio_backend::ansi::CursorShape;
 use rio_backend::sugarloaf::Sugarloaf;
@@ -15,6 +17,14 @@ const DEPTH: f32 = 0.0;
 
 /// A corner is settled within half a physical pixel of its target.
 const SETTLE_EPSILON_PX: f32 = 0.5;
+
+/// Nominal frame integrated when a flight starts from idle: the gap
+/// since the last rendered frame is not travel time.
+const IDLE_FRAME_DT: f32 = 1.0 / 60.0;
+
+/// Per-step cap while in flight, so a stalled compositor cannot
+/// complete the whole animation in one step.
+const MAX_FRAME_DT: f32 = 0.1;
 
 /// Beam and underline thickness as a fraction of the cell width.
 const THIN_SHAPE_FRACTION: f32 = 0.15;
@@ -49,10 +59,25 @@ impl Default for TrailSettings {
 
 impl TrailSettings {
     pub fn sanitized(mut self) -> Self {
+        // NaN passes through clamp; a non-finite knob takes its
+        // default rather than poisoning every frame's arithmetic.
+        let defaults = TrailSettings::default();
+        if !self.opacity.is_finite() {
+            self.opacity = defaults.opacity;
+        }
+        if !self.decay_fast.is_finite() {
+            self.decay_fast = defaults.decay_fast;
+        }
+        if !self.decay_slow.is_finite() {
+            self.decay_slow = defaults.decay_slow;
+        }
+        if !self.start_threshold.is_finite() {
+            self.start_threshold = defaults.start_threshold;
+        }
         self.opacity = self.opacity.clamp(0.0, 1.0);
-        self.decay_fast = self.decay_fast.max(0.001);
+        self.decay_fast = self.decay_fast.clamp(0.001, 10.0);
         // The slow corner can never beat the fast one.
-        self.decay_slow = self.decay_slow.max(self.decay_fast);
+        self.decay_slow = self.decay_slow.clamp(self.decay_fast, 10.0);
         self.start_threshold = self.start_threshold.max(0.0);
         self
     }
@@ -75,6 +100,9 @@ pub struct TrailCursor {
     was_moving: bool,
     /// Frames are still needed (movement or an in-flight fade).
     active: bool,
+    /// The previous tick painted the quad (nonzero alpha): one more
+    /// frame is owed after it stops, so the scene repaints without it.
+    painted: bool,
     route_id: Option<usize>,
     first_frame: bool,
     settings: TrailSettings,
@@ -110,9 +138,27 @@ impl TrailCursor {
             moving: false,
             was_moving: false,
             active: false,
+            painted: false,
             route_id: None,
             first_frame: true,
             settings: settings.sanitized(),
+        }
+    }
+
+    /// The animation dt for a frame that arrives `raw` seconds after
+    /// the previous one. While idle no frames are scheduled, so the
+    /// gap since the last render is not travel time: the first tick
+    /// of a new flight integrates one nominal frame instead of
+    /// completing the whole flight in a single step. Mid-flight,
+    /// frames arrive at vsync cadence and the real dt is what keeps
+    /// the easing exact, capped so a compositor stall cannot swallow
+    /// the animation either.
+    #[inline]
+    fn frame_dt(&self, raw: f32) -> f32 {
+        if self.active {
+            raw.min(MAX_FRAME_DT)
+        } else {
+            IDLE_FRAME_DT
         }
     }
 
@@ -132,17 +178,17 @@ impl TrailCursor {
         route_id: usize,
     ) -> bool {
         let now = Instant::now();
-        let dt = now.duration_since(self.last_tick).as_secs_f32();
+        let dt = self.frame_dt(now.duration_since(self.last_tick).as_secs_f32());
         self.last_tick = now;
         let visible = visible && shape != CursorShape::Hidden;
 
-        if let Some(rect) =
-            target_rect(cursor_x, cursor_y, cell_width, cell_height, shape)
-        {
+        let rect = target_rect(cursor_x, cursor_y, cell_width, cell_height, shape);
+        let fresh_target = rect.is_some();
+        if let Some(rect) = rect {
             self.target = rect;
         }
 
-        self.tick(dt, visible, route_id, cell_width, cell_height)
+        self.tick(dt, visible, fresh_target, route_id, cell_width, cell_height)
     }
 
     /// The dt-explicit core of [`update`], separated so tests control
@@ -151,19 +197,24 @@ impl TrailCursor {
         &mut self,
         dt: f32,
         visible: bool,
+        fresh_target: bool,
         route_id: usize,
         cell_width: f32,
         cell_height: f32,
     ) -> bool {
-        // A panel or tab switch is not cursor travel: teleport.
+        // A panel or tab switch is not cursor travel: teleport. A
+        // hidden cursor keeps the previous panel's rect, and parking
+        // on it would smear from foreign coordinates once the cursor
+        // shows, so the teleport waits until a real target exists.
         if self.first_frame || self.route_id != Some(route_id) {
             self.route_id = Some(route_id);
-            self.first_frame = false;
+            self.first_frame = !fresh_target;
             self.corners = self.target;
             self.opacity = if visible { 1.0 } else { 0.0 };
             self.moving = false;
             self.was_moving = false;
             self.active = false;
+            self.painted = false;
             return false;
         }
 
@@ -180,23 +231,30 @@ impl TrailCursor {
             }
         }
 
-        // Visibility ramp. A cursor hidden by the program (DECTCEM,
-        // as file managers and TUI dashboards do on every refresh)
-        // fades the trail out over `decay_slow` instead of letting it
-        // animate forever or vanish in one frame.
+        // Visibility ramp. A cursor hidden mid-flight (DECTCEM, as
+        // file managers and TUI dashboards do on every refresh) fades
+        // its smear out over `decay_slow` instead of letting it
+        // animate forever or vanish in one frame. Hidden with the
+        // corners parked there is no smear to fade, and a quad
+        // lingering over freshly drawn content reads as a phantom
+        // cursor, so the opacity drops outright.
         let ramp = dt / self.settings.decay_slow;
         self.opacity = if visible {
             (self.opacity + ramp).min(1.0)
-        } else {
+        } else if self.moving || self.was_moving {
             (self.opacity - ramp).max(0.0)
+        } else {
+            0.0
         };
         if !visible && self.opacity <= 0.0 {
             // Fully faded: park on the target so reappearing starts
-            // clean.
+            // clean. When the previous frame painted the quad, one
+            // more frame is owed so the scene repaints without it.
             self.corners = self.target;
-            let extra_frame = self.moving || self.was_moving;
+            let extra_frame = self.moving || self.was_moving || self.painted;
             self.moving = false;
             self.was_moving = false;
+            self.painted = false;
             self.active = extra_frame;
             return extra_frame;
         }
@@ -264,11 +322,11 @@ impl TrailCursor {
         }
 
         let fading = !visible && self.opacity > 0.0;
-        let filling = visible && self.opacity < 1.0 && moving;
-        let result = moving || self.was_moving || fading || filling;
+        let result = moving || self.was_moving || fading;
         self.was_moving = moving;
         self.moving = moving;
         self.active = result;
+        self.painted = result && self.opacity * self.settings.opacity > 0.0;
         result
     }
 
@@ -283,6 +341,12 @@ impl TrailCursor {
         cursor_color: [f32; 4],
     ) {
         if !self.active {
+            return;
+        }
+        // Settled at full opacity the quad is exactly the cursor rect:
+        // pure overdraw, and a visible tint when a color override is
+        // configured. The extra post-settle frame presents without it.
+        if !self.moving && self.opacity >= 1.0 {
             return;
         }
         let alpha = self.opacity * self.settings.opacity;
@@ -333,7 +397,7 @@ mod tests {
         });
         // First tick teleports onto the origin cell.
         t.target = target_rect(0.0, 0.0, CELL_W, CELL_H, CursorShape::Block).unwrap();
-        t.tick(0.016, true, 1, CELL_W, CELL_H);
+        t.tick(0.016, true, true, 1, CELL_W, CELL_H);
         t
     }
 
@@ -370,9 +434,9 @@ mod tests {
         retarget(&mut coarse, 10.0, 5.0);
         retarget(&mut fine, 10.0, 5.0);
 
-        coarse.tick(0.128, true, 1, CELL_W, CELL_H);
+        coarse.tick(0.128, true, true, 1, CELL_W, CELL_H);
         for _ in 0..8 {
-            fine.tick(0.016, true, 1, CELL_W, CELL_H);
+            fine.tick(0.016, true, true, 1, CELL_W, CELL_H);
         }
 
         // Travel is ~110px; hold divergence under 2% of it.
@@ -388,11 +452,11 @@ mod tests {
     fn giant_dt_settles_instead_of_freezing() {
         let mut t = trail(0.0);
         retarget(&mut t, 30.0, 20.0);
-        t.tick(5.0, true, 1, CELL_W, CELL_H);
+        t.tick(5.0, true, true, 1, CELL_W, CELL_H);
         assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
-        // One extra frame paints the snap, then it goes quiet.
-        assert!(t.tick(0.016, true, 1, CELL_W, CELL_H) || !t.is_animating());
-        assert!(!t.tick(0.016, true, 1, CELL_W, CELL_H));
+        // At most one extra frame paints the snap, then it goes quiet.
+        t.tick(0.016, true, true, 1, CELL_W, CELL_H);
+        assert!(!t.tick(0.016, true, true, 1, CELL_W, CELL_H));
     }
 
     #[test]
@@ -402,7 +466,7 @@ mod tests {
         // decay_slow reaches 1/1024 of the distance per its own
         // definition; 2x the budget is comfortably settled.
         let mut frames = 0;
-        while t.tick(0.016, true, 1, CELL_W, CELL_H) {
+        while t.tick(0.016, true, true, 1, CELL_W, CELL_H) {
             frames += 1;
             assert!(frames < 100, "did not settle");
         }
@@ -415,11 +479,11 @@ mod tests {
     fn start_threshold_gates_from_rest() {
         let mut t = trail(2.0);
         retarget(&mut t, 1.0, 0.0);
-        assert!(!t.tick(0.016, true, 1, CELL_W, CELL_H));
+        assert!(!t.tick(0.016, true, true, 1, CELL_W, CELL_H));
         assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
 
         retarget(&mut t, 20.0, 0.0);
-        assert!(t.tick(0.016, true, 1, CELL_W, CELL_H));
+        assert!(t.tick(0.016, true, true, 1, CELL_W, CELL_H));
     }
 
     /// Once in flight, retargets inside the threshold are still
@@ -429,10 +493,10 @@ mod tests {
     fn mid_flight_retarget_is_followed() {
         let mut t = trail(2.0);
         retarget(&mut t, 20.0, 0.0);
-        assert!(t.tick(0.016, true, 1, CELL_W, CELL_H));
+        assert!(t.tick(0.016, true, true, 1, CELL_W, CELL_H));
 
         retarget(&mut t, 21.0, 0.0);
-        assert!(t.tick(0.016, true, 1, CELL_W, CELL_H));
+        assert!(t.tick(0.016, true, true, 1, CELL_W, CELL_H));
         assert!(max_corner_error(&t) > SETTLE_EPSILON_PX);
     }
 
@@ -442,7 +506,7 @@ mod tests {
     fn leading_corners_outrun_trailing_ones() {
         let mut t = trail(0.0);
         retarget(&mut t, 20.0, 0.0); // pure rightward travel
-        t.tick(0.016, true, 1, CELL_W, CELL_H);
+        t.tick(0.016, true, true, 1, CELL_W, CELL_H);
 
         // TR (index 1) leads, TL (index 0) trails.
         let leading_left = t.target[1][0] - t.corners[1][0];
@@ -460,17 +524,17 @@ mod tests {
     fn hidden_cursor_fades_out_and_stops() {
         let mut t = trail(0.0);
         retarget(&mut t, 20.0, 0.0);
-        t.tick(0.016, true, 1, CELL_W, CELL_H);
+        t.tick(0.016, true, true, 1, CELL_W, CELL_H);
 
         // Hide: fade frames are still requested while opacity drains.
-        assert!(t.tick(0.016, false, 1, CELL_W, CELL_H));
+        assert!(t.tick(0.016, false, true, 1, CELL_W, CELL_H));
         assert!(t.opacity < 1.0);
 
         // Drain past decay_slow: parked, quiet.
-        t.tick(1.0, false, 1, CELL_W, CELL_H);
-        t.tick(0.016, false, 1, CELL_W, CELL_H);
+        t.tick(1.0, false, true, 1, CELL_W, CELL_H);
+        t.tick(0.016, false, true, 1, CELL_W, CELL_H);
         assert_eq!(t.opacity, 0.0);
-        assert!(!t.tick(0.016, false, 1, CELL_W, CELL_H));
+        assert!(!t.tick(0.016, false, true, 1, CELL_W, CELL_H));
         assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
     }
 
@@ -480,7 +544,71 @@ mod tests {
     fn route_change_teleports() {
         let mut t = trail(0.0);
         retarget(&mut t, 50.0, 30.0);
-        assert!(!t.tick(0.016, true, 2, CELL_W, CELL_H));
+        assert!(!t.tick(0.016, true, true, 2, CELL_W, CELL_H));
+        assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
+    }
+
+    /// The gap since the last rendered frame is idle time, not travel
+    /// time: a jump after a pause must animate from one nominal
+    /// frame, not complete instantly because dt spanned the pause.
+    #[test]
+    fn idle_gap_is_not_travel_time() {
+        let t = trail(0.0);
+        assert!(!t.is_animating());
+        assert_eq!(t.frame_dt(2.0), IDLE_FRAME_DT);
+
+        let mut t = trail(0.0);
+        retarget(&mut t, 20.0, 0.0);
+        assert!(t.tick(0.016, true, true, 1, CELL_W, CELL_H));
+        // In flight, real dt applies, capped against stalls.
+        assert_eq!(t.frame_dt(0.032), 0.032);
+        assert_eq!(t.frame_dt(2.0), MAX_FRAME_DT);
+    }
+
+    /// Hiding a cursor whose trail is at rest must not paint a fading
+    /// phantom quad over whatever the program draws next.
+    #[test]
+    fn hide_from_rest_shows_no_phantom() {
+        let mut t = trail(0.0);
+        // Parked and quiet.
+        assert!(!t.tick(0.016, true, true, 1, CELL_W, CELL_H));
+        assert!(!t.tick(0.016, false, true, 1, CELL_W, CELL_H));
+        assert_eq!(t.opacity, 0.0);
+    }
+
+    /// When a mid-flight fade drains out, one final frame is granted
+    /// so the scene repaints without the quad; the frame after that
+    /// stays quiet (no infinite frame requests).
+    #[test]
+    fn fade_end_grants_exactly_one_clearing_frame() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 20.0, 0.0);
+        assert!(t.tick(0.016, true, true, 1, CELL_W, CELL_H));
+
+        // Hide and drain the whole fade in one step: the clearing
+        // frame is owed because the previous frame painted.
+        assert!(t.tick(1.0, false, true, 1, CELL_W, CELL_H));
+        assert_eq!(t.opacity, 0.0);
+        assert!(!t.tick(0.016, false, true, 1, CELL_W, CELL_H));
+    }
+
+    /// A route switch while the cursor is hidden keeps a stale target
+    /// from the old panel; the teleport must wait for a real target
+    /// so the first visible cursor on the new panel doesn't inherit
+    /// foreign coordinates.
+    #[test]
+    fn route_change_while_hidden_defers_teleport() {
+        let mut t = trail(0.0);
+        retarget(&mut t, 50.0, 30.0);
+        t.tick(0.016, true, true, 1, CELL_W, CELL_H);
+
+        // Switch to route 2 with a hidden cursor: no fresh target.
+        assert!(!t.tick(0.016, false, false, 2, CELL_W, CELL_H));
+
+        // The cursor appears on the new panel: teleport, no smear
+        // from the old panel's coordinates.
+        retarget(&mut t, 0.0, 0.0);
+        assert!(!t.tick(0.016, true, true, 2, CELL_W, CELL_H));
         assert!(max_corner_error(&t) <= SETTLE_EPSILON_PX);
     }
 

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -545,6 +545,8 @@ impl Screen<'_> {
 
         self.mark_dirty();
         self.resize_all_contexts();
+        // Reflowed cursor displacement is layout, not travel.
+        self.renderer.trail_cursor.snap();
     }
 
     #[inline]
@@ -564,6 +566,10 @@ impl Screen<'_> {
 
         self.context_manager
             .resize_all_grids(width, height, &mut self.sugarloaf);
+
+        // A resize reflows the cursor; that displacement is layout,
+        // not travel, and must not animate a smear.
+        self.renderer.trail_cursor.snap();
 
         self
     }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -640,6 +640,8 @@ impl Screen<'_> {
         self.context_manager
             .resize_all_grids(width, height, &mut self.sugarloaf);
         self.mark_dirty();
+        // Rescaled cursor displacement is layout, not travel.
+        self.renderer.trail_cursor.snap();
 
         self
     }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1543,6 +1543,8 @@ impl Screen<'_> {
             .move_divider_up(amount, &mut self.sugarloaf)
         {
             self.mark_dirty();
+            // Divider displacement is layout, not cursor travel.
+            self.renderer.trail_cursor.snap();
         }
     }
 
@@ -1553,6 +1555,8 @@ impl Screen<'_> {
             .move_divider_down(amount, &mut self.sugarloaf)
         {
             self.mark_dirty();
+            // Divider displacement is layout, not cursor travel.
+            self.renderer.trail_cursor.snap();
         }
     }
 
@@ -1563,6 +1567,8 @@ impl Screen<'_> {
             .move_divider_left(amount, &mut self.sugarloaf)
         {
             self.mark_dirty();
+            // Divider displacement is layout, not cursor travel.
+            self.renderer.trail_cursor.snap();
         }
     }
 
@@ -1573,6 +1579,8 @@ impl Screen<'_> {
             .move_divider_right(amount, &mut self.sugarloaf)
         {
             self.mark_dirty();
+            // Divider displacement is layout, not cursor travel.
+            self.renderer.trail_cursor.snap();
         }
     }
 
@@ -1689,6 +1697,11 @@ impl Screen<'_> {
             ));
             context_grid.update_dimensions(&mut self.sugarloaf);
         }
+
+        // The tab strip appearing or vanishing shifts every panel;
+        // a background tab can close without a route change, so this
+        // reflow is not covered by the route-switch teleport.
+        self.renderer.trail_cursor.snap();
     }
 
     #[inline]

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3791,8 +3791,6 @@ impl Screen<'_> {
         let (window_update, any_panel_dirty) = self
             .renderer
             .run(&mut self.sugarloaf, &mut self.context_manager);
-        let has_animation = self.renderer.needs_redraw();
-        let should_present = any_panel_dirty || has_animation;
 
         if self.renderer.custom_mouse_cursor {
             let scale = self.sugarloaf.scale_factor();
@@ -3829,14 +3827,15 @@ impl Screen<'_> {
                 let cursor_px_x = origin_x + cursor_col as f32 * cell_width;
                 let cursor_px_y = origin_y + cursor_row as f32 * cell_height;
 
-                self.renderer.trail_cursor.set_route(current.route_id);
-                self.renderer.trail_cursor.set_destination(
+                self.renderer.trail_cursor.update(
                     cursor_px_x,
                     cursor_px_y,
                     cell_width,
                     cell_height,
+                    cursor.state.content,
+                    cursor.state.is_visible(),
+                    current.route_id,
                 );
-                self.renderer.trail_cursor.animate(cell_width, cell_height);
 
                 let cursor_color = self.renderer.named_colors.cursor;
                 self.renderer.trail_cursor.draw(
@@ -3846,6 +3845,13 @@ impl Screen<'_> {
                 );
             }
         }
+
+        // Animation state is read after the trail advanced: a cursor
+        // movement can start animating in this same frame, and reading
+        // it earlier would fail to schedule the continuation frame,
+        // freezing the trail mid-flight until unrelated damage arrives.
+        let has_animation = self.renderer.needs_redraw();
+        let should_present = any_panel_dirty || has_animation;
 
         // Phase 2.2/2.3: per-panel CellBg + CellText emission with
         // per-row dirty gating. Iterates every panel in the active

--- a/rio-backend/src/config/effects.rs
+++ b/rio-backend/src/config/effects.rs
@@ -1,9 +1,87 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Effects {
     #[serde(default = "bool::default", rename = "custom-mouse-cursor")]
     pub custom_mouse_cursor: bool,
     #[serde(default = "bool::default", rename = "trail-cursor")]
     pub trail_cursor: bool,
+    /// Trail color as a hex string ("#F07178"). Unset means the trail
+    /// takes the cursor color.
+    #[serde(default, rename = "trail-cursor-color")]
+    pub trail_cursor_color: Option<String>,
+    /// Trail opacity, 0.0 to 1.0.
+    #[serde(default = "default_trail_opacity", rename = "trail-cursor-opacity")]
+    pub trail_cursor_opacity: f32,
+    /// Decay pair in milliseconds: how long the fastest and the
+    /// slowest corner of the trail take to catch up with the cursor.
+    /// The gap between the two is what stretches the trail.
+    #[serde(default = "default_trail_decay", rename = "trail-cursor-decay")]
+    pub trail_cursor_decay: [u32; 2],
+    /// Cursor jumps at or under this many cells (on both axes) do not
+    /// start a trail. 0 animates every movement.
+    #[serde(
+        default = "default_trail_start_threshold",
+        rename = "trail-cursor-start-threshold"
+    )]
+    pub trail_cursor_start_threshold: u32,
+}
+
+fn default_trail_opacity() -> f32 {
+    1.0
+}
+
+fn default_trail_decay() -> [u32; 2] {
+    [100, 400]
+}
+
+fn default_trail_start_threshold() -> u32 {
+    2
+}
+
+impl Default for Effects {
+    fn default() -> Self {
+        Self {
+            custom_mouse_cursor: false,
+            trail_cursor: false,
+            trail_cursor_color: None,
+            trail_cursor_opacity: default_trail_opacity(),
+            trail_cursor_decay: default_trail_decay(),
+            trail_cursor_start_threshold: default_trail_start_threshold(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_bare_table() {
+        let effects: Effects = toml::from_str("").unwrap();
+        assert_eq!(effects, Effects::default());
+        assert_eq!(effects.trail_cursor_opacity, 1.0);
+        assert_eq!(effects.trail_cursor_decay, [100, 400]);
+        assert_eq!(effects.trail_cursor_start_threshold, 2);
+        assert!(effects.trail_cursor_color.is_none());
+    }
+
+    #[test]
+    fn full_table_parses() {
+        let effects: Effects = toml::from_str(
+            r##"
+            trail-cursor = true
+            trail-cursor-color = "#F07178"
+            trail-cursor-opacity = 0.4
+            trail-cursor-decay = [50, 250]
+            trail-cursor-start-threshold = 0
+            "##,
+        )
+        .unwrap();
+        assert!(effects.trail_cursor);
+        assert_eq!(effects.trail_cursor_color.as_deref(), Some("#F07178"));
+        assert_eq!(effects.trail_cursor_opacity, 0.4);
+        assert_eq!(effects.trail_cursor_decay, [50, 250]);
+        assert_eq!(effects.trail_cursor_start_threshold, 0);
+    }
 }


### PR DESCRIPTION
The trail's animation only advanced when unrelated damage produced a frame: the continuation flag was read before the trail ticked, so an animation could freeze mid-flight and stay painted until the next output arrived. On top of that, the spring integration snapped to the destination whenever a frame gap exceeded the animation length, which at event-driven cadence was most of the time. Both are structural, so this replaces the motion model with kitty's exponential ease-out (composes exactly across frames, no fixed-cadence loop needed), keeps the four-corner smear via direction-aligned per-corner decay, fades the trail out when the program hides the cursor mid-flight, and skips trails for jumps at or under a configurable cell threshold.

Refinements that came out of review rounds against the kitty/neovide sources: idle gaps integrate one nominal frame instead of completing the flight instantly (last_tick only advances on rendered frames); hiding a settled cursor drops the quad outright instead of fading a phantom over fresh content, with one clearing frame guaranteed after the last painted one; reappearing at rest restores full opacity so hide/show-heavy TUIs and scrollback don't dim the next flight (an exposure kitty itself has); route switches teleport, deferred while the cursor is hidden so a stale target from another panel never smears; and layout reflows (window resize, font-size change, rescale, split-divider drags) snap instead of animating, since displacement from layout is not cursor travel.

New config in `[effects]`: `trail-cursor-color`, `trail-cursor-opacity`, `trail-cursor-decay = [fast_ms, slow_ms]`, `trail-cursor-start-threshold`. Defaults match kitty (100/400ms, threshold 2). Known follow-up: kitty's ms stability gate (suppressing trails for cursors that bounce during visible redraw storms) needs CUP-timestamp plumbing rio doesn't carry yet.

Fixes #1830, fixes #1597 (the stuck full-screen quad was the freeze at scroll-jump scale), fixes #1511, fixes #1594, fixes #1520.