### PR TITLE
glyph protocol: cap decoded outline size at 64 KiB

### DIFF
--- a/rio-graphics/src/glyph/glyf_decode.rs
+++ b/rio-graphics/src/glyph/glyf_decode.rs
@@ -22,6 +22,10 @@
 use skrifa::raw::tables::glyf::{CurvePoint, SimpleGlyph};
 use skrifa::raw::{FontData, FontRead};
 
+/// Decoded-size budget from Glyph Protocol v1.10 (§8.2): 64 KiB at
+/// 12 bytes per point, per outline and per registration.
+pub const MAX_DECODED_POINTS: usize = (64 * 1024) / 12;
+
 /// Reasons a `glyf` record can be rejected. Maps onto Glyph Protocol v1
 /// `reason=` error codes where applicable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,6 +38,8 @@ pub enum DecodeError {
     /// Payload ended before the decoder expected, or a structural
     /// invariant was violated.
     Malformed,
+    /// The outline decodes past [`MAX_DECODED_POINTS`] (spec §8.2).
+    TooLarge,
 }
 
 /// A single decoded point.
@@ -103,6 +109,12 @@ pub fn decode(data: &[u8]) -> Result<Outline, DecodeError> {
         }
     }
     let num_points = end_pts[end_pts.len() - 1] + 1;
+    // §8.2 decoded-size budget: the point count comes straight from
+    // endPtsOfContours, so the check runs before any point storage
+    // is allocated.
+    if num_points > MAX_DECODED_POINTS {
+        return Err(DecodeError::TooLarge);
+    }
 
     let pts: Vec<CurvePoint> = glyph.points().collect();
     if pts.len() != num_points {
@@ -132,6 +144,29 @@ pub fn decode(data: &[u8]) -> Result<Outline, DecodeError> {
         x_max,
         y_max,
     })
+}
+
+/// Point count of a simple-glyph record without decoding it. O(1),
+/// no allocation: numberOfContours and the last endPtsOfContours
+/// entry sit at fixed offsets. Lets the register path enforce the
+/// §8.2 per-registration budget across a colour container's
+/// outlines without paying for a full decode of each one.
+pub fn peek_point_count(data: &[u8]) -> Result<usize, DecodeError> {
+    if data.len() < 10 {
+        return Err(DecodeError::Malformed);
+    }
+    let num_contours = i16::from_be_bytes([data[0], data[1]]);
+    if num_contours < 0 {
+        return Err(DecodeError::Composite);
+    }
+    if num_contours == 0 {
+        return Ok(0);
+    }
+    let last = 10 + 2 * (num_contours as usize - 1);
+    if data.len() < last + 2 {
+        return Err(DecodeError::Malformed);
+    }
+    Ok(u16::from_be_bytes([data[last], data[last + 1]]) as usize + 1)
 }
 
 /// A single path command produced by [`Outline::walk`]. Intentionally
@@ -380,6 +415,60 @@ mod tests {
         assert_eq!(out.contours[0].len(), 4);
         assert_eq!(out.contours[0][3].x, 40);
         assert_eq!(out.contours[0][3].y, 0);
+    }
+
+    /// Encode `n` points in as few wire bytes as possible: every
+    /// flag carries X_SAME | Y_SAME (both deltas omitted, zero) and
+    /// REPEAT compresses the flag array to two bytes per 256 points.
+    /// This is the §8.2 amplification attack in miniature.
+    fn dense_bytes(n: usize) -> Vec<u8> {
+        const FLAG_X_SAME: u8 = 0x10;
+        const FLAG_Y_SAME: u8 = 0x20;
+        let mut v = Vec::new();
+        v.extend_from_slice(&1i16.to_be_bytes()); // numberOfContours
+        v.extend_from_slice(&[0u8; 8]); // bounding box
+        v.extend_from_slice(&((n - 1) as u16).to_be_bytes()); // endPts
+        v.extend_from_slice(&0u16.to_be_bytes()); // instructionLength
+        let flag = FLAG_ON_CURVE | FLAG_REPEAT | FLAG_X_SAME | FLAG_Y_SAME;
+        // Runs of 255, not 256: read-fonts tracks the repeat count in
+        // a u8 and a repeat byte of 255 overflows it in debug builds.
+        let mut left = n;
+        while left > 0 {
+            let run = left.min(255);
+            v.push(flag);
+            v.push((run - 1) as u8);
+            left -= run;
+        }
+        v
+    }
+
+    #[test]
+    fn rejects_outline_over_decoded_budget() {
+        let v = dense_bytes(MAX_DECODED_POINTS + 1);
+        // The whole attack payload is under 100 wire bytes.
+        assert!(v.len() < 100);
+        assert_eq!(decode(&v), Err(DecodeError::TooLarge));
+    }
+
+    #[test]
+    fn accepts_outline_at_decoded_budget() {
+        let v = dense_bytes(MAX_DECODED_POINTS);
+        let out = decode(&v).unwrap();
+        assert_eq!(out.contours[0].len(), MAX_DECODED_POINTS);
+    }
+
+    #[test]
+    fn peek_matches_decode() {
+        assert_eq!(peek_point_count(&triangle_bytes()), Ok(3));
+        assert_eq!(
+            peek_point_count(&dense_bytes(MAX_DECODED_POINTS + 1)),
+            Ok(MAX_DECODED_POINTS + 1)
+        );
+        assert_eq!(peek_point_count(&[]), Err(DecodeError::Malformed));
+        let mut composite = Vec::new();
+        composite.extend_from_slice(&(-1i16).to_be_bytes());
+        composite.extend_from_slice(&[0u8; 8]);
+        assert_eq!(peek_point_count(&composite), Err(DecodeError::Composite));
     }
 
     #[test]

--- a/rio-vt/src/ansi/glyph_protocol.rs
+++ b/rio-vt/src/ansi/glyph_protocol.rs
@@ -213,6 +213,7 @@ pub enum RegisterError {
     HintingUnsupported,
     MalformedPayload,
     PayloadTooLarge,
+    OutlineTooLarge,
 }
 
 impl RegisterError {
@@ -223,6 +224,7 @@ impl RegisterError {
             RegisterError::HintingUnsupported => "hinting_unsupported",
             RegisterError::MalformedPayload => "malformed_payload",
             RegisterError::PayloadTooLarge => "payload_too_large",
+            RegisterError::OutlineTooLarge => "outline_too_large",
         }
     }
 }

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -5283,39 +5283,62 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 }
                 glyf_decode::DecodeError::Hinted => RegisterError::HintingUnsupported,
                 glyf_decode::DecodeError::Malformed => RegisterError::MalformedPayload,
+                glyf_decode::DecodeError::TooLarge => RegisterError::OutlineTooLarge,
             }
+        }
+
+        // §8.2: a container's outlines must sum to at most
+        // MAX_DECODED_POINTS. Peeks each record header, no decoding.
+        fn container_budget(glyphs: &[Vec<u8>]) -> Result<(), RegisterError> {
+            let mut total = 0usize;
+            for glyf in glyphs {
+                total += glyf_decode::peek_point_count(glyf).map_err(translate)?;
+                if total > glyf_decode::MAX_DECODED_POINTS {
+                    return Err(RegisterError::OutlineTooLarge);
+                }
+            }
+            Ok(())
         }
 
         // Validate the monochrome `glyf` payload at register time so a
         // bad outline produces a clear error response. For COLR
-        // containers, validation is render-time only — re-decoding
-        // every carried outline (up to 1024 per registration) on the
-        // hot register path costs more than it saves, and the parser
-        // already catches the common-case malformation. A
-        // structurally-broken COLR payload manifests as tofu at first
-        // render rather than a register-time error; that's the
-        // accepted trade-off.
+        // containers, structural validation stays render-time only:
+        // re-decoding every carried outline (up to 1024 per
+        // registration) on the hot register path costs more than it
+        // saves, and the parser already catches the common-case
+        // malformation. A structurally-broken COLR payload manifests
+        // as tofu at first render rather than a register-time error;
+        // that's the accepted trade-off. The one register-time check
+        // containers do get is the §8.2 decoded-size budget, because
+        // it exists precisely to stop hostile payloads from reaching
+        // the decoder's allocations.
         let (stored, upm) = match payload {
             GlyphPayload::Glyf { glyf, upm } => {
                 glyf_decode::decode(&glyf).map_err(translate)?;
                 (StoredPayload::Glyf { glyf }, upm)
             }
-            GlyphPayload::ColrV0 { container, upm } => (
-                StoredPayload::ColrV0 {
-                    glyphs: container.glyphs,
-                    colr: container.colr,
-                    cpal: container.cpal,
-                },
-                upm,
-            ),
-            GlyphPayload::ColrV1 { container, upm } => (
-                StoredPayload::ColrV1 {
-                    glyphs: container.glyphs,
-                    colr: container.colr,
-                    cpal: container.cpal,
-                },
-                upm,
-            ),
+            GlyphPayload::ColrV0 { container, upm } => {
+                container_budget(&container.glyphs)?;
+                (
+                    StoredPayload::ColrV0 {
+                        glyphs: container.glyphs,
+                        colr: container.colr,
+                        cpal: container.cpal,
+                    },
+                    upm,
+                )
+            }
+            GlyphPayload::ColrV1 { container, upm } => {
+                container_budget(&container.glyphs)?;
+                (
+                    StoredPayload::ColrV1 {
+                        glyphs: container.glyphs,
+                        colr: container.colr,
+                        cpal: container.cpal,
+                    },
+                    upm,
+                )
+            }
         };
 
         // Lazily allocate the registry — idle terminals that never see
@@ -5981,6 +6004,90 @@ mod tests {
         // Decode failed before the registry was touched, so it stays
         // uninitialised.
         assert!(cw.glyph_registry.is_none());
+    }
+
+    // A simple glyph declaring `n` points in almost no wire bytes:
+    // the §8.2 decode-amplification payload.
+    #[cfg(feature = "graphics")]
+    fn dense_glyf_bytes(n: usize) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&1i16.to_be_bytes()); // numberOfContours
+        v.extend_from_slice(&[0u8; 8]); // bounding box
+        v.extend_from_slice(&((n - 1) as u16).to_be_bytes()); // endPts
+        v.extend_from_slice(&0u16.to_be_bytes()); // instructionLength
+        let flag = 0x01 | 0x08 | 0x10 | 0x20; // on-curve|repeat|x-same|y-same
+        let mut left = n;
+        while left > 0 {
+            let run = left.min(255);
+            v.push(flag);
+            v.push((run - 1) as u8);
+            left -= run;
+        }
+        v
+    }
+
+    #[cfg(feature = "graphics")]
+    #[test]
+    fn glyph_protocol_register_rejects_oversized_outline() {
+        use crate::ansi::glyph_protocol::RegisterError;
+        use rio_graphics::glyph::glyf_decode::MAX_DECODED_POINTS;
+        let mut cw = make_crosswords();
+
+        let v = dense_glyf_bytes(MAX_DECODED_POINTS + 1);
+        let res = Handler::glyph_register(&mut cw, 0xE0A0, glyf_payload(v, 1000), 1);
+        assert_eq!(res, Err(RegisterError::OutlineTooLarge));
+        assert!(cw.glyph_registry.is_none());
+    }
+
+    #[cfg(feature = "graphics")]
+    #[test]
+    fn glyph_protocol_register_rejects_container_over_budget() {
+        use crate::ansi::glyph_protocol::{ColrContainer, GlyphPayload, RegisterError};
+        use rio_graphics::glyph::glyf_decode::MAX_DECODED_POINTS;
+        let mut cw = make_crosswords();
+
+        // Each outline is under the per-outline budget, but together
+        // they blow the per-registration budget. The budget check runs
+        // before COLR validation, so junk table bytes are fine here.
+        let half = MAX_DECODED_POINTS / 2 + 1;
+        let container = ColrContainer {
+            glyphs: vec![dense_glyf_bytes(half), dense_glyf_bytes(half)],
+            colr: vec![0u8; 4],
+            cpal: Vec::new(),
+        };
+        let res = Handler::glyph_register(
+            &mut cw,
+            0xE0A0,
+            GlyphPayload::ColrV0 {
+                container,
+                upm: 1000,
+            },
+            1,
+        );
+        assert_eq!(res, Err(RegisterError::OutlineTooLarge));
+        assert!(cw.glyph_registry.is_none());
+
+        // The same total spread across outlines that stay within the
+        // budget registers fine.
+        let container = ColrContainer {
+            glyphs: vec![
+                dense_glyf_bytes(MAX_DECODED_POINTS / 2),
+                dense_glyf_bytes(MAX_DECODED_POINTS / 2),
+            ],
+            colr: vec![0u8; 4],
+            cpal: Vec::new(),
+        };
+        let res = Handler::glyph_register(
+            &mut cw,
+            0xE0A0,
+            GlyphPayload::ColrV0 {
+                container,
+                upm: 1000,
+            },
+            1,
+        );
+        assert!(res.is_ok());
+        assert!(registry_contains(&cw, 0xE0A0));
     }
 
     #[cfg(feature = "graphics")]

--- a/specs/glyph-protocol.md
+++ b/specs/glyph-protocol.md
@@ -2,7 +2,7 @@
 
 **Author:** Raphael Amorim
 **Year:** 2026
-**Last updated:** 2026-05-03
+**Last updated:** 2026-08-17
 
 **See also:**
 - Blog post introducing the protocol and its rationale:
@@ -294,6 +294,7 @@ Defined error codes:
 | `hinting_unsupported`   | Payload contains hinting instructions. |
 | `malformed_payload`     | Payload failed to parse as `glyf`. |
 | `payload_too_large`     | Payload exceeds 64 KiB post-base64-decode. |
+| `outline_too_large`     | An outline (or a colour container's outlines in aggregate) exceeds the 64 KiB decoded-size budget (§8.2). |
 
 ### 6.3 Overwrite and eviction
 
@@ -376,6 +377,31 @@ subset of `glyf` and MAY reject anything else with
   terminal's own anti-aliasing is what users see.
 - **Coordinate space** defined by `upm`. The terminal maps this
   space onto its cell at render time.
+- **Decoded-size limit.** The wire form is compressed: repeat
+  flags and 8-bit or omitted deltas mean one wire byte can stand
+  for many decoded points. For limit accounting, one decoded
+  point costs **12 bytes** (two expanded coordinates plus an
+  on-curve flag, what a typical in-memory point representation
+  occupies). An outline whose decoded size would exceed **64
+  KiB**, i.e. more than **5,461 points**, MUST be rejected with
+  `reason=outline_too_large`. The same budget applies to a
+  registration as a whole: the decoded sizes of all outlines
+  carried in a `colrv0`/`colrv1` container (§8.6 / §8.7) MUST sum
+  to at most 64 KiB. The point count is known from
+  `endPtsOfContours` before any point storage exists, so
+  terminals MUST validate against the budget before allocating
+  decoded-point storage. The limit is a bound on allocation, not
+  a post-hoc check.
+
+The 64 KiB budget comes from Mitchell Hashimoto's survey of real
+symbol fonts for Ghostty's implementation: across Apple Symbols,
+Noto, and the Nerd Fonts collection, the largest glyph decodes to
+roughly 40 KiB, so every observed real glyph fits with headroom. Without the cap, a crafted 64 KiB wire payload
+(maximally repeat-compressed flags, omitted deltas) expands to
+~768 KiB of decoded points per monochrome slot, and a colour
+container to many times that, turning the 1024-slot glossary
+into a memory-exhaustion vector measured in hundreds of MiB per
+session.
 
 ### 8.3 Contour semantics
 
@@ -548,7 +574,10 @@ colour, per the OpenType spec.
 `COLR` table that fails to parse SHOULD be rejected with
 `reason=malformed_payload`. Every carried outline MUST satisfy the
 `glyf` simple-glyph subset of §8.2; violations use the same error
-codes as `fmt=glyf`.
+codes as `fmt=glyf`. The decoded-size budget of §8.2 applies both
+to each carried outline and to the container's outlines in
+aggregate: a container whose outlines sum past 64 KiB decoded is
+rejected with `reason=outline_too_large`.
 
 ### 8.7 Payload format: `colrv1`
 
@@ -628,9 +657,13 @@ and the cell buffer honestly reports.
 
 Other considerations:
 
-- **Resource bounds.** The 1024-slot cap and 64 KiB per-payload cap
-  give a hard upper bound of 64 MiB on the glossary's memory
-  footprint per session.
+- **Resource bounds.** Three caps bound the glossary: 1024 slots
+  per session, 64 KiB of wire payload per registration, and 64 KiB
+  of decoded outline data per registration (§8.2). Worst case, a
+  session holds 64 MiB of wire bytes plus 64 MiB of decoded
+  points. The decoded cap is load-bearing: the `glyf` wire form is
+  compressed, so a crafted payload expands ~12× on decode and the
+  wire cap alone bounds nothing that matters.
 - **No code execution.** The `glyf` subset defined in §8.2
   excludes hinting instructions, which is the only part of
   TrueType that is executable. Glyph Protocol is purely
@@ -672,9 +705,13 @@ A terminal emulator is Glyph Protocol v1 conformant if it:
    anything else with `reason=out_of_namespace`.
 4. Holds at most 1024 simultaneous registrations per session and
    evicts in FIFO order when full.
-5. Accepts the `glyf` simple-glyph subset defined in §8.2. The
-   `colrv0` and `colrv1` formats are OPTIONAL; terminals that
-   accept them MUST list the corresponding name in the `s` reply.
+5. Accepts the `glyf` simple-glyph subset defined in §8.2 and
+   enforces its 64 KiB decoded-size budget, per outline and per
+   registration, rejecting violations with
+   `reason=outline_too_large` before allocating decoded-point
+   storage. The `colrv0` and `colrv1` formats are OPTIONAL;
+   terminals that accept them MUST list the corresponding name in
+   the `s` reply.
 6. Renders registered `glyf` glyphs in the current foreground
    color; renders `colrv0`/`colrv1` glyphs using the COLR paint
    graph, resolving palette index `0xFFFF` to the current
@@ -809,3 +846,4 @@ rather than serving a stale bitmap.
 | 2026-04-23 | v1.7    | Added a sizing and placement model to the `r` verb: `aw` / `lh` (authored extent in upm units), `width` (Unicode/wcwidth width, `1` or `2`, authoritative), `size` (`height`/`advance`/`contain`/`cover`/`stretch`), `align` (`<h>,<v>` positioning after scale, with `v=baseline` for character-like glyphs), and `pad` (fractional insets from the render span). Pinned the coordinate convention: Y-up, `y=0` at baseline, `lh` measured descender-to-ascender (OpenType). Scale groups are intentionally omitted — coordinated sets align via matching parameters and outline geometry. |
 | 2026-05-03 | v1.8    | Replaced the `s` reply's `u8` bitfield with a comma-separated list of format names (e.g. `fmt=glyf,colrv0,colrv1`). Names extend without bit-collision worries and stay readable in transcripts; an empty `fmt=` means the terminal advertises no payload formats. Unknown names MUST be ignored by clients, so future formats are forward-compatible. |
 | 2026-05-03 | v1.9    | Replaced the `q` reply's `u8` two-bit `status` field with a comma-separated list of coverage names: `status=system`, `status=glossary`, `status=system,glossary`, or empty for "free". Same motivation as v1.8 for the `s` reply. The `r` and `c` replies still use `status=<u8>` for success/failure since that's a closed boolean, not an extensible set. |
+| 2026-08-17 | v1.10   | Added a decoded-size budget to §8.2: 64 KiB of decoded outline data (12 bytes per point, i.e. 5,461 points), enforced per outline and per registration before point storage is allocated; violations reject with the new `reason=outline_too_large`. Closes a decode-amplification hole: repeat-compressed flags and omitted deltas let a 64 KiB wire payload expand to ~768 KiB per monochrome slot (~768 MiB per session at 1024 slots), and a colour container amplifies further via its up-to-1024 carried outlines. Requested by Mitchell Hashimoto, who hit the expansion while implementing the protocol in Ghostty; the budget follows his survey of Apple Symbols, Noto, and Nerd Fonts, where the largest real glyph decodes to ~40 KiB. |


### PR DESCRIPTION
Spec v1.10 plus reference-implementation enforcement.

Requested by Mitchell Hashimoto, who hit the expansion while implementing the protocol in Ghostty: https://github.com/ghostty-org/ghostty/pull/13849. The `glyf` wire form is compressed (repeat flags, 8-bit or omitted deltas), so the existing 64 KiB wire cap bounds nothing that matters: a crafted payload expands to ~768 KiB of decoded points per slot, ~768 MiB per session at 1024 slots.

## Spec (§8.2, v1.10)

- One decoded point is accounted at 12 bytes; an outline past **64 KiB decoded (5,461 points)** MUST be rejected with the new `reason=outline_too_large`.
- The same budget applies per registration, summed across a `colrv0`/`colrv1` container's carried outlines. Without this, a container's up-to-1024 inner outlines reopen the same hole ×1024.
- The check MUST run before point storage is allocated (the count is known from `endPtsOfContours`), so the limit is a bound on allocation, not a post-hoc check.
- Budget follows Mitchell's survey of Apple Symbols, Noto, and Nerd Fonts: largest real glyph decodes to ~40 KiB, so 64 KiB covers everything observed with headroom.

## Reference implementation

- `glyf_decode` rejects oversized outlines before allocating point vectors (Rio's 12-byte `Point` × 65,535 wire-declarable points was exactly the ~768 KB expansion).
- The register path enforces the container sum via an O(1)-per-outline header peek, no decode needed.
- Tests include the real attack payload: 5,462 points declared in under 100 wire bytes.