### PR TITLE
Fix hover hint underline alignment and wrapped URL matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4036,6 +4036,7 @@ dependencies = [
  "notify",
  "objc-rs 0.3.2",
  "onig",
+ "onig_sys",
  "parking_lot",
  "pretty_assertions",
  "rapidhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ image_rs = { package = "image", version = "0.25.10", default-features = false, f
 ] }
 regex = "1.12.3"
 onig = { version = "6.5.3", default-features = false }
-onig_sys = { version = "69.9.1", default-features = false }
+onig_sys = { version = "69.9.3", default-features = false }
 bytemuck = { version = "1.25.2", features = ["derive"] }
 serde = { version = "1.0.229", features = ["derive"] }
 wgpu = "30.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ image_rs = { package = "image", version = "0.25.10", default-features = false, f
 ] }
 regex = "1.12.3"
 onig = { version = "6.5.3", default-features = false }
+# Direct dep only for FFI the `onig` wrapper doesn't expose
+# (per-search retry limits on MatchParam). Same version and features
+# `onig` itself builds against.
+onig_sys = { version = "69.9.1", default-features = false }
 bytemuck = { version = "1.25.2", features = ["derive"] }
 serde = { version = "1.0.229", features = ["derive"] }
 wgpu = "30.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,6 @@ image_rs = { package = "image", version = "0.25.10", default-features = false, f
 ] }
 regex = "1.12.3"
 onig = { version = "6.5.3", default-features = false }
-# Direct dep only for FFI the `onig` wrapper doesn't expose
-# (per-search retry limits on MatchParam). Same version and features
-# `onig` itself builds against.
 onig_sys = { version = "69.9.1", default-features = false }
 bytemuck = { version = "1.25.2", features = ["derive"] }
 serde = { version = "1.0.229", features = ["derive"] }

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -33,6 +33,7 @@ futures = { workspace = true }
 corcovado = { workspace = true }
 regex = { workspace = true }
 onig = { workspace = true }
+onig_sys = { workspace = true }
 raw-window-handle = { workspace = true }
 clap = { version = "4.6.1", features = ["derive"] }
 dirs = "6.0.0"

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -1,6 +1,8 @@
 use rio_backend::config::hints::Hint;
 use rio_backend::crosswords::grid::Dimensions;
 use rio_backend::crosswords::pos::{Column, Line, Pos};
+use rio_backend::crosswords::square::Wide;
+use rio_backend::crosswords::Crosswords;
 use rio_backend::event::EventListener;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -382,6 +384,237 @@ impl LabelGenerator {
             self.indices.push(0);
         }
     }
+}
+
+/// A regex match resolved against the grid: inclusive cell bounds plus
+/// the matched text.
+#[derive(Debug, PartialEq, Eq)]
+pub struct GridMatch {
+    pub start: Pos,
+    pub end: Pos,
+    pub text: String,
+}
+
+/// The logical (unwrapped) line under a point: its text plus the source
+/// cell of every byte, so regex byte offsets anchor back to cells.
+///
+/// Extraction is separate from matching so a probe with several hint
+/// rules extracts once and runs every regex against the same buffer.
+pub struct LogicalLine {
+    text: String,
+    map: Vec<Pos>,
+}
+
+impl LogicalLine {
+    /// Extract the logical line containing `point`, following soft
+    /// wraps in both directions.
+    pub fn extract<T: EventListener>(term: &Crosswords<T>, point: Pos) -> Option<Self> {
+        /// How many cells of the logical line are followed across soft
+        /// wraps on each side of the hovered row. Only matches
+        /// containing the hovered cell matter, so nothing hoverable is
+        /// lost for matches shorter than this. An unbounded scan is
+        /// quadratic in oniguruma on a wrapped wall of word characters
+        /// (the URL pattern rescans ahead at every start position),
+        /// measured at ~90ms per probe; bounded it stays single-digit ms.
+        const SCAN_CELLS: usize = 2048;
+
+        let cols = term.columns();
+        let topmost = -(term.history_size() as i32);
+        let bottommost = term.bottommost_line().0;
+        if cols == 0
+            || point.row.0 < topmost
+            || point.row.0 > bottommost
+            || point.col.0 >= cols
+        {
+            return None;
+        }
+
+        let wraps = |line: i32| term.grid[Line(line)][Column(cols - 1)].wrapline();
+        let max_rows = (SCAN_CELLS / cols).max(1) as i32;
+
+        let mut start_line = point.row.0;
+        while start_line > topmost
+            && point.row.0 - start_line < max_rows
+            && wraps(start_line - 1)
+        {
+            start_line -= 1;
+        }
+        let mut end_line = point.row.0;
+        while end_line < bottommost
+            && end_line - point.row.0 < max_rows
+            && wraps(end_line)
+        {
+            end_line += 1;
+        }
+
+        // Record the source cell of every byte. Wide-char spacers are
+        // skipped so the text holds each character once; blank (`\0`)
+        // cells read as spaces, matching what is on screen; zero-width
+        // marks are emitted with their base character, every byte
+        // mapping back to the same cell.
+        let rows = (end_line - start_line + 1) as usize;
+        let mut text = String::with_capacity(rows * cols);
+        let mut map: Vec<Pos> = Vec::with_capacity(rows * cols);
+        for l in start_line..=end_line {
+            let line = Line(l);
+            for c in 0..cols {
+                let col = Column(c);
+                let pos = Pos::new(line, col);
+                let square = &term.grid[line][col];
+                if matches!(square.wide(), Wide::Spacer | Wide::LeadingSpacer) {
+                    continue;
+                }
+                for (i, ch) in term.grid.cell_text(pos).enumerate() {
+                    let ch = if i == 0 && ch == '\0' { ' ' } else { ch };
+                    text.push(ch);
+                    for _ in 0..ch.len_utf8() {
+                        map.push(pos);
+                    }
+                }
+            }
+        }
+        while text.ends_with(' ') {
+            text.pop();
+            map.pop();
+        }
+
+        Some(LogicalLine { text, map })
+    }
+
+    /// Find the regex match covering `point` in this line.
+    ///
+    /// Cell bounds come through the byte-to-cell map, never from byte
+    /// offsets used as columns: the previous implementation did the
+    /// latter, so any multi-byte character left of the match (a `│`
+    /// prefix, CJK, emoji) dragged the hover underline that many bytes
+    /// to the right, and its single-row search matched soft-wrapped
+    /// URLs truncated or not at all.
+    pub fn match_at<T: EventListener>(
+        &self,
+        term: &Crosswords<T>,
+        point: Pos,
+        regex: &onig::Regex,
+        post_processing: bool,
+    ) -> Option<GridMatch> {
+        let cols = term.columns();
+        let text = &self.text;
+        let map = &self.map;
+
+        // Manual search loop instead of `find_iter` so each attempt
+        // carries a retry budget. The text is terminal output, i.e.
+        // attacker-controlled, the pattern is user-config, and this
+        // runs on mouse movement: unbounded backtracking here is a
+        // denial of service. Hitting the budget reads as "no more
+        // matches".
+        const RETRY_LIMIT: u32 = 100_000;
+
+        let mut region = onig::Region::new();
+        let mut offset = 0;
+        while offset < text.len() {
+            region.clear();
+            let match_param = onig::MatchParam::default();
+            // The in-search limit bounds the whole call, every start
+            // position included; the in-match limit the safe wrapper
+            // exposes is per attempt, which a long pathological line
+            // multiplies by its length. Safety: `as_raw` is a live
+            // pointer for the parameter owned just above.
+            unsafe {
+                onig_sys::onig_set_retry_limit_in_search_of_match_param(
+                    match_param.as_raw(),
+                    RETRY_LIMIT.into(),
+                );
+            }
+            match regex.search_with_param(
+                text.as_str(),
+                offset,
+                text.len(),
+                onig::SearchOptions::SEARCH_OPTION_NONE,
+                Some(&mut region),
+                match_param,
+            ) {
+                Ok(Some(_)) => (),
+                Ok(None) | Err(_) => break,
+            }
+            let Some((m_start, m_end)) = region.pos(0) else {
+                break;
+            };
+            // Guard against a stalled loop on an empty match.
+            offset = m_end.max(m_start + 1);
+
+            if m_start >= m_end || m_end > map.len() {
+                continue;
+            }
+            let start = map[m_start];
+            if point < start {
+                // Matches arrive in order; everything further is past
+                // the point.
+                break;
+            }
+
+            let trimmed_len = if post_processing {
+                trim_match_tail(&text[m_start..m_end])
+            } else {
+                m_end - m_start
+            };
+            if trimmed_len == 0 {
+                continue;
+            }
+            let mut end = map[m_start + trimmed_len - 1];
+            if point > end {
+                continue;
+            }
+
+            // A match ending on a wide character owns its spacer cell
+            // too, so the hover underline covers the full glyph.
+            if end.col.0 + 1 < cols
+                && term.grid[end.row][end.col].wide() == Wide::Wide
+            {
+                end.col = Column(end.col.0 + 1);
+            }
+
+            return Some(GridMatch {
+                start,
+                end,
+                text: text[m_start..m_start + trimmed_len].to_string(),
+            });
+        }
+
+        None
+    }
+}
+
+/// How many leading bytes of a regex match survive post-processing: an
+/// unmatched `)` or `]` ends the match, then trailing prose delimiters
+/// are dropped. Same rules the grid-walking `hint_post_processing` used,
+/// applied to the matched text instead of cells.
+fn trim_match_tail(text: &str) -> usize {
+    let mut open_parens = 0i32;
+    let mut open_brackets = 0i32;
+    let mut cut = text.len();
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '(' => open_parens += 1,
+            '[' => open_brackets += 1,
+            ')' => {
+                if open_parens == 0 {
+                    cut = idx;
+                    break;
+                }
+                open_parens -= 1;
+            }
+            ']' => {
+                if open_brackets == 0 {
+                    cut = idx;
+                    break;
+                }
+                open_brackets -= 1;
+            }
+            _ => (),
+        }
+    }
+    text[..cut]
+        .trim_end_matches(['.', ',', ':', ';', '?', '!', '(', '[', '\''])
+        .len()
 }
 
 /// URI scheme prefixes that should never be resolved as file paths.
@@ -785,5 +1018,173 @@ mod tests {
         unsafe {
             std::env::remove_var("RIO_TEST_PATH_VAR");
         }
+    }
+
+    use rio_backend::ansi::CursorShape;
+    use rio_backend::config::hints::DEFAULT_URL_REGEX;
+    use rio_backend::crosswords::CrosswordsSize;
+    use rio_backend::event::{VoidListener, WindowId};
+    use rio_unicode::UnicodeWidthChar;
+
+    /// Build a terminal from literal content, the same way rio-vt's
+    /// search tests do: `\n` continues a soft-wrapped line, `\r\n` is a
+    /// hard line break. Soft-wrapped rows must be written full width,
+    /// as they are in a live grid.
+    fn mock_term(content: &str) -> Crosswords<VoidListener> {
+        let lines: Vec<&str> = content.split('\n').collect();
+        let num_cols = lines
+            .iter()
+            .map(|line| {
+                line.chars()
+                    .filter(|c| *c != '\r')
+                    .map(|c| c.width().unwrap())
+                    .sum()
+            })
+            .max()
+            .unwrap_or(0);
+
+        let size = CrosswordsSize::new(num_cols, lines.len());
+        let mut term = Crosswords::new(
+            size,
+            CursorShape::Block,
+            VoidListener {},
+            WindowId::from(0),
+            0,
+            10_000,
+        );
+
+        for (line, text) in lines.iter().enumerate() {
+            let line = Line(line as i32);
+            if !text.ends_with('\r') && line + 1 != lines.len() {
+                term.grid[line][Column(num_cols - 1)].set_wrapline(true);
+            }
+
+            let mut index = 0;
+            for c in text.chars().take_while(|c| *c != '\r') {
+                term.grid[line][Column(index)].set_c(c);
+                let width = c.width().unwrap();
+                if width == 2 {
+                    term.grid[line][Column(index)].set_wide(Wide::Wide);
+                    term.grid[line][Column(index + 1)].set_wide(Wide::Spacer);
+                }
+                index += width;
+            }
+        }
+
+        term
+    }
+
+    fn url_regex() -> onig::Regex {
+        onig::Regex::new(DEFAULT_URL_REGEX).unwrap()
+    }
+
+    fn match_at(
+        term: &Crosswords<VoidListener>,
+        row: i32,
+        col: usize,
+    ) -> Option<GridMatch> {
+        let point = Pos::new(Line(row), Column(col));
+        LogicalLine::extract(term, point)?.match_at(term, point, &url_regex(), true)
+    }
+
+    // Hovering anywhere on a mid-line URL yields exactly the URL's
+    // cells, and the parenthesized note after it stays prose.
+    #[test]
+    fn test_match_at_point_plain_ascii_line() {
+        let term = mock_term(
+            "Dev server is listening at http://localhost:1313/ (bind address 127.0.0.1)",
+        );
+
+        // "Dev server is listening at " is 27 cells; the URL is 22 more.
+        for col in [27, 35, 48] {
+            let m = match_at(&term, 0, col)
+                .unwrap_or_else(|| panic!("no match at col {col}"));
+            assert_eq!(m.text, "http://localhost:1313/");
+            assert_eq!(m.start, Pos::new(Line(0), Column(27)));
+            assert_eq!(m.end, Pos::new(Line(0), Column(48)));
+        }
+        assert!(match_at(&term, 0, 26).is_none(), "space before the url");
+        assert!(match_at(&term, 0, 50).is_none(), "note after the url");
+    }
+
+    // Multi-byte characters left of the match must not drag the bounds
+    // to the right. The old byte-offset code returned cols shifted by
+    // one per extra UTF-8 byte: two box-drawing characters shifted the
+    // hover underline four cells.
+    #[test]
+    fn test_match_at_point_multibyte_prefix() {
+        let term = mock_term("\u{2502}\u{2502} see http://a.b/c after");
+
+        let m = match_at(&term, 0, 10).expect("hover on the url");
+        assert_eq!(m.text, "http://a.b/c");
+        assert_eq!(m.start, Pos::new(Line(0), Column(7)));
+        assert_eq!(m.end, Pos::new(Line(0), Column(18)));
+    }
+
+    // Wide characters occupy two cells but one char: bounds are cells,
+    // not chars, and hovering the spacer half still hits.
+    #[test]
+    fn test_match_at_point_wide_prefix() {
+        let term = mock_term("\u{65e5}\u{672c} http://a.b/c");
+
+        let m = match_at(&term, 0, 8).expect("hover on the url");
+        assert_eq!(m.text, "http://a.b/c");
+        assert_eq!(m.start, Pos::new(Line(0), Column(5)));
+        assert_eq!(m.end, Pos::new(Line(0), Column(16)));
+    }
+
+    // A soft-wrapped URL matches whole from either row, with bounds
+    // spanning the wrap. The old single-row code matched a truncated
+    // URL on the first row and nothing on the second.
+    #[test]
+    fn test_match_at_point_wrapped_url() {
+        let term = mock_term("see http://examp\nle.com/path here");
+
+        let from_first = match_at(&term, 0, 6).expect("hover on first row");
+        assert_eq!(from_first.text, "http://example.com/path");
+        assert_eq!(from_first.start, Pos::new(Line(0), Column(4)));
+        assert_eq!(from_first.end, Pos::new(Line(1), Column(10)));
+
+        let from_second = match_at(&term, 1, 3).expect("hover on second row");
+        assert_eq!(from_second, from_first);
+
+        assert!(match_at(&term, 1, 13).is_none(), "prose after the url");
+    }
+
+    // A URL deep inside a huge fully-wrapped logical line still
+    // resolves with exact bounds: the extraction clips to a byte
+    // window around the point, and the window must land on the match.
+    #[test]
+    fn test_match_at_point_clipped_long_line() {
+        let url = "http://example.com/path";
+        let mut rows: Vec<String> = (0..201).map(|_| "x".repeat(300)).collect();
+        rows[100] = format!(
+            "{} {} {}",
+            "x".repeat(99),
+            url,
+            "x".repeat(300 - 99 - url.len() - 2)
+        );
+        let term = mock_term(&rows.join("\n"));
+
+        let m = match_at(&term, 100, 110).expect("hover on the url");
+        assert_eq!(m.text, url);
+        assert_eq!(m.start, Pos::new(Line(100), Column(100)));
+        assert_eq!(m.end, Pos::new(Line(100), Column(122)));
+
+        assert!(match_at(&term, 100, 95).is_none(), "filler is not a link");
+    }
+
+    #[test]
+    fn test_trim_match_tail() {
+        assert_eq!(trim_match_tail("http://a.b/c"), "http://a.b/c".len());
+        // Unmatched closing paren ends the match.
+        assert_eq!(trim_match_tail("http://a.b/c)x"), "http://a.b/c".len());
+        // Balanced pairs survive.
+        assert_eq!(
+            trim_match_tail("http://a.b/(c)"),
+            "http://a.b/(c)".len()
+        );
+        // Trailing prose delimiters are dropped.
+        assert_eq!(trim_match_tail("http://a.b/c,."), "http://a.b/c".len());
     }
 }

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -566,9 +566,7 @@ impl LogicalLine {
 
             // A match ending on a wide character owns its spacer cell
             // too, so the hover underline covers the full glyph.
-            if end.col.0 + 1 < cols
-                && term.grid[end.row][end.col].wide() == Wide::Wide
-            {
+            if end.col.0 + 1 < cols && term.grid[end.row][end.col].wide() == Wide::Wide {
                 end.col = Column(end.col.0 + 1);
             }
 
@@ -1180,10 +1178,7 @@ mod tests {
         // Unmatched closing paren ends the match.
         assert_eq!(trim_match_tail("http://a.b/c)x"), "http://a.b/c".len());
         // Balanced pairs survive.
-        assert_eq!(
-            trim_match_tail("http://a.b/(c)"),
-            "http://a.b/(c)".len()
-        );
+        assert_eq!(trim_match_tail("http://a.b/(c)"), "http://a.b/(c)".len());
         // Trailing prose delimiters are dropped.
         assert_eq!(trim_match_tail("http://a.b/c,."), "http://a.b/c".len());
     }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2007,7 +2007,8 @@ impl Screen<'_> {
 
         let terminal = self.context_manager.current().terminal.lock();
         let display_offset = terminal.display_offset();
-        let mouse_point = Pos::new(viewport_point.row - display_offset, viewport_point.col);
+        let mouse_point =
+            Pos::new(viewport_point.row - display_offset, viewport_point.col);
 
         // Find hint at mouse position
         let highlighted_hint = self.find_hint_at_point(&terminal, mouse_point, mods);
@@ -2022,16 +2023,15 @@ impl Screen<'_> {
             // match is the same one already displayed there is nothing
             // to redraw, and re-marking full damage per pixel would
             // rebuild the grid for the whole hover.
-            let unchanged =
-                current
-                    .renderable_content
-                    .highlighted_hint
-                    .as_ref()
-                    .is_some_and(|shown| {
-                        shown.start == hint_match.start
-                            && shown.end == hint_match.end
-                            && shown.text == hint_match.text
-                    });
+            let unchanged = current
+                .renderable_content
+                .highlighted_hint
+                .as_ref()
+                .is_some_and(|shown| {
+                    shown.start == hint_match.start
+                        && shown.end == hint_match.end
+                        && shown.text == hint_match.text
+                });
             if unchanged {
                 return false;
             }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -75,6 +75,19 @@ pub struct Screen<'screen> {
     pub context_manager: context::ContextManager<EventProxy>,
     last_ime_cursor_pos: Option<(f32, f32)>,
     hints_config: Vec<std::rc::Rc<rio_backend::config::hints::Hint>>,
+    /// Hint regexes compiled on first use, keyed by pattern. Hover
+    /// hit-testing runs on every mouse move; recompiling the URL
+    /// pattern each time is measurable jank.
+    hint_regex_cache:
+        std::cell::RefCell<std::collections::HashMap<String, std::rc::Rc<onig::Regex>>>,
+    /// The viewport cell and modifiers of the last hover-hint probe
+    /// that found nothing. Mouse events arrive per pixel; re-probing
+    /// the same cell would re-extract and re-scan the logical line for
+    /// every one of them. Viewport coordinates so the check needs no
+    /// terminal lock, and only an unchanged probe that was not over a
+    /// link is skippable, so text changing under a shown underline
+    /// still refreshes it. Reset on wheel scroll and highlight clears.
+    last_hint_probe: Option<(Pos, rio_window::keyboard::ModifiersState)>,
     pub resize_state: Option<crate::layout::ResizeState>,
     #[cfg(target_os = "macos")]
     pub allow_manual_dragging: bool,
@@ -304,6 +317,8 @@ impl Screen<'_> {
                 .iter()
                 .map(|h| std::rc::Rc::new(h.clone()))
                 .collect(),
+            hint_regex_cache: Default::default(),
+            last_hint_probe: None,
             mouse_bindings: crate::bindings::default_mouse_bindings(),
             modifiers: Modifiers::default(),
             context_manager,
@@ -1974,18 +1989,53 @@ impl Screen<'_> {
             return self.clear_highlighted_hint();
         }
 
+        let mods = self.modifiers.state();
+
+        // Mouse events arrive per pixel; when the last probe of this
+        // viewport cell with these modifiers found nothing, there is
+        // nothing new to learn until one of them changes. The cell is
+        // pure geometry, so an unchanged probe skips without even
+        // taking the terminal lock. While a highlight is shown the
+        // probe always reruns, so text changing under the underline
+        // still refreshes it. Wheel scrolling resets the probe in
+        // `Self::scroll`; content sliding under a stationary cursor
+        // without one is stale until the mouse crosses a cell.
+        let viewport_point = self.mouse_position(0);
+        if !had_highlight && self.last_hint_probe == Some((viewport_point, mods)) {
+            return false;
+        }
+
         let terminal = self.context_manager.current().terminal.lock();
         let display_offset = terminal.display_offset();
-        let mouse_point = self.mouse_position(display_offset);
+        let mouse_point = Pos::new(viewport_point.row - display_offset, viewport_point.col);
 
         // Find hint at mouse position
-        let highlighted_hint =
-            self.find_hint_at_point(&terminal, mouse_point, self.modifiers.state());
+        let highlighted_hint = self.find_hint_at_point(&terminal, mouse_point, mods);
         drop(terminal);
+        self.last_hint_probe = Some((viewport_point, mods));
 
         let current = self.context_manager.current_mut();
 
         if let Some(hint_match) = highlighted_hint {
+            // Reprobes run on every mouse event while a highlight is
+            // shown (so text changing under it refreshes); when the
+            // match is the same one already displayed there is nothing
+            // to redraw, and re-marking full damage per pixel would
+            // rebuild the grid for the whole hover.
+            let unchanged =
+                current
+                    .renderable_content
+                    .highlighted_hint
+                    .as_ref()
+                    .is_some_and(|shown| {
+                        shown.start == hint_match.start
+                            && shown.end == hint_match.end
+                            && shown.text == hint_match.text
+                    });
+            if unchanged {
+                return false;
+            }
+
             // Mark the hint range as damaged so it gets re-rendered.
             //
             // Two damage signals are required:
@@ -2032,8 +2082,11 @@ impl Screen<'_> {
     }
 
     /// Drop any hint highlight, clearing its damage so the line
-    /// repaints. Returns whether a highlight existed.
+    /// repaints. Returns whether a highlight existed. Also forgets the
+    /// last probed cell: clears run on context switches, where a stale
+    /// probe could suppress the first probe of the new panel.
     pub fn clear_highlighted_hint(&mut self) -> bool {
+        self.last_hint_probe = None;
         let current = self.context_manager.current_mut();
         let had_highlight = current.renderable_content.highlighted_hint.is_some();
 
@@ -2079,6 +2132,11 @@ impl Screen<'_> {
         point: rio_backend::crosswords::pos::Pos,
         _modifiers: rio_window::keyboard::ModifiersState,
     ) -> Option<crate::hints::HintMatch> {
+        // The logical line under the point is rule-independent:
+        // extracted lazily on the first regex rule, then shared across
+        // the remaining rules.
+        let mut logical_line: Option<Option<crate::hints::LogicalLine>> = None;
+
         // Check each enabled hint configuration
         for hint_config in &self.hints_config {
             // Check if mouse highlighting is enabled for this hint
@@ -2102,14 +2160,24 @@ impl Screen<'_> {
 
             // Check regex patterns if specified
             if let Some(regex_pattern) = &hint_config.regex {
-                if let Ok(regex) = onig::Regex::new(regex_pattern) {
-                    if let Some(regex_match) = self.find_regex_match_at_point(
-                        terminal,
-                        point,
-                        &regex,
-                        hint_config.clone(),
-                    ) {
-                        return Some(regex_match);
+                if let Some(regex) = self.compiled_hint_regex(regex_pattern) {
+                    let line = logical_line.get_or_insert_with(|| {
+                        crate::hints::LogicalLine::extract(terminal, point)
+                    });
+                    if let Some(m) = line.as_ref().and_then(|line| {
+                        line.match_at(
+                            terminal,
+                            point,
+                            &regex,
+                            hint_config.post_processing,
+                        )
+                    }) {
+                        return Some(crate::hints::HintMatch {
+                            text: m.text,
+                            start: m.start,
+                            end: m.end,
+                            hint: hint_config.clone(),
+                        });
                     }
                 }
             }
@@ -2187,77 +2255,19 @@ impl Screen<'_> {
         })
     }
 
-    /// Find regex match at the specified point
-    fn find_regex_match_at_point(
-        &self,
-        terminal: &rio_backend::crosswords::Crosswords<EventProxy>,
-        point: rio_backend::crosswords::pos::Pos,
-        regex: &onig::Regex,
-        hint_config: std::rc::Rc<rio_backend::config::hints::Hint>,
-    ) -> Option<crate::hints::HintMatch> {
-        let grid = &terminal.grid;
-
-        // Check if the point is within grid bounds
-        if point.row >= grid.total_lines() as i32 || point.col.0 >= grid.columns() {
-            return None;
+    /// Compiled regex for a hint pattern, from the cache when possible.
+    /// A pattern that fails to compile is cached as absent implicitly:
+    /// the failed compile repeats, but invalid patterns are a config
+    /// error and rare.
+    fn compiled_hint_regex(&self, pattern: &str) -> Option<std::rc::Rc<onig::Regex>> {
+        if let Some(regex) = self.hint_regex_cache.borrow().get(pattern) {
+            return Some(regex.clone());
         }
-
-        // Extract text from the line
-        let mut line_text = String::new();
-        for col in 0..grid.columns() {
-            let cell = &grid[point.row][rio_backend::crosswords::pos::Column(col)];
-            line_text.push(cell.c());
-        }
-        let line_text = line_text.trim_end();
-
-        // Find all matches in this line and check if point is within any of them.
-        // Onig yields (byte_start, byte_end); we slice the source ourselves.
-        for (start, end) in regex.find_iter(line_text) {
-            let start_col = rio_backend::crosswords::pos::Column(start);
-            let end_col = rio_backend::crosswords::pos::Column(end.saturating_sub(1));
-
-            // Check if the point is within this match
-            if point.col >= start_col && point.col <= end_col {
-                let original_match_text = line_text[start..end].to_string();
-                let mut match_text = original_match_text.clone();
-
-                // Apply grid-based post-processing
-                let (processed_start, processed_end) = if hint_config.post_processing {
-                    self.hint_post_processing(
-                        terminal,
-                        start_col,
-                        end_col,
-                        rio_backend::crosswords::pos::Line(point.row.0),
-                    )
-                    .unwrap_or((start_col, end_col))
-                } else {
-                    (start_col, end_col)
-                };
-
-                // Extract the processed text
-                if hint_config.post_processing {
-                    let mut processed_text = String::new();
-                    for col in processed_start.0..=processed_end.0 {
-                        let cell =
-                            &grid[point.row][rio_backend::crosswords::pos::Column(col)];
-                        processed_text.push(cell.c());
-                    }
-                    match_text = processed_text.trim_end().to_string();
-                }
-
-                return Some(crate::hints::HintMatch {
-                    text: match_text,
-                    start: rio_backend::crosswords::pos::Pos::new(
-                        point.row,
-                        processed_start,
-                    ),
-                    end: rio_backend::crosswords::pos::Pos::new(point.row, processed_end),
-                    hint: hint_config,
-                });
-            }
-        }
-
-        None
+        let regex = std::rc::Rc::new(onig::Regex::new(pattern).ok()?);
+        self.hint_regex_cache
+            .borrow_mut()
+            .insert(pattern.to_string(), regex.clone());
+        Some(regex)
     }
 
     /// Whether a hint (regex match or OSC 8 link) is currently highlighted
@@ -3515,6 +3525,11 @@ impl Screen<'_> {
 
     #[inline]
     pub fn scroll(&mut self, new_scroll_x_px: f64, new_scroll_y_px: f64) {
+        // Scrolling slides different text under the pointer while the
+        // viewport cell stays the same, so the hover-probe dedup key
+        // must not suppress the next probe.
+        self.last_hint_probe = None;
+
         let dim = self.context_manager.current().dimension.dimension;
         let width = dim.width as f64;
         let height = dim.height as f64;
@@ -4842,100 +4857,6 @@ impl Screen<'_> {
             .current_mut()
             .renderable_content
             .hint_labels = hint_labels;
-    }
-
-    /// Apply grid-based hint post-processing.
-    ///
-    /// This iterates through the terminal grid character by character and adjusts
-    /// the match bounds based on bracket balance and trailing delimiters.
-    fn hint_post_processing(
-        &self,
-        terminal: &rio_backend::crosswords::Crosswords<EventProxy>,
-        start_col: rio_backend::crosswords::pos::Column,
-        end_col: rio_backend::crosswords::pos::Column,
-        row: rio_backend::crosswords::pos::Line,
-    ) -> Option<(
-        rio_backend::crosswords::pos::Column,
-        rio_backend::crosswords::pos::Column,
-    )> {
-        use rio_backend::crosswords::grid::BidirectionalIterator;
-
-        let grid = &terminal.grid;
-        let start_pos = rio_backend::crosswords::pos::Pos::new(row, start_col);
-        let end_pos = rio_backend::crosswords::pos::Pos::new(row, end_col);
-
-        let mut iter = grid.iter_from(start_pos);
-        let mut current_pos = start_pos;
-        let mut open_parents = 0;
-        let mut open_brackets = 0;
-
-        // First pass: handle uneven brackets/parentheses
-        while current_pos <= end_pos {
-            if let Some(indexed) = iter.next() {
-                let c = indexed.square.c();
-                current_pos = indexed.pos;
-
-                match c {
-                    '(' => open_parents += 1,
-                    '[' => open_brackets += 1,
-                    ')' => {
-                        if open_parents == 0 {
-                            // Unmatched closing parenthesis, truncate here
-                            if iter.prev().is_some() {
-                                return Some((start_col, iter.pos().col));
-                            }
-                            break;
-                        } else {
-                            open_parents -= 1;
-                        }
-                    }
-                    ']' => {
-                        if open_brackets == 0 {
-                            // Unmatched closing bracket, truncate here
-                            if iter.prev().is_some() {
-                                return Some((start_col, iter.pos().col));
-                            }
-                            break;
-                        } else {
-                            open_brackets -= 1;
-                        }
-                    }
-                    _ => (),
-                }
-
-                if current_pos == end_pos {
-                    break;
-                }
-            } else {
-                break;
-            }
-        }
-
-        // Second pass: remove trailing delimiters
-        let mut final_end = end_pos;
-        let mut iter = grid.iter_from(end_pos);
-
-        while final_end > start_pos {
-            if let Some(indexed) = iter.next() {
-                let c = indexed.square.c();
-                if !matches!(c, '.' | ',' | ':' | ';' | '?' | '!' | '(' | '[' | '\'') {
-                    break;
-                }
-
-                if let Some(prev_indexed) = iter.prev() {
-                    final_end = prev_indexed.pos;
-                    if iter.prev().is_some() {
-                        // Move iterator back one more position for next iteration
-                    }
-                } else {
-                    break;
-                }
-            } else {
-                break;
-            }
-        }
-
-        Some((start_col, final_end.col))
     }
 }
 

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -1708,6 +1708,29 @@ mod tests {
         assert!(surface.url_at(1, 10).is_none());
     }
 
+    // A scheme URL mid-line followed by a parenthesized note: the hover
+    // run must sit exactly under the URL, not drift into the scheme or
+    // the note.
+    #[test]
+    fn urls_underline_alignment_mid_line() {
+        let surface = quiet_surface(90, 5);
+        surface.inject_output(
+            b"Dev server is listening at http://localhost:1313/ (bind address 127.0.0.1)",
+        );
+
+        // "Dev server is listening at " is 27 cells, so the URL occupies
+        // cols 27..=48 and the note after it is prose.
+        for col in [27, 31, 35, 48] {
+            let (uri, start, end) = surface
+                .url_at(0, col)
+                .unwrap_or_else(|| panic!("hover at col {col} misses the url"));
+            assert_eq!(uri, "http://localhost:1313/");
+            assert_eq!((start, end), (27, 48), "hover at col {col}");
+        }
+        assert!(surface.url_at(0, 26).is_none(), "space before the scheme");
+        assert!(surface.url_at(0, 50).is_none(), "note after the url");
+    }
+
     // OSC 9;4 (ConEmu progress) must reach the embedder as an action:
     // set with a value, then remove.
     #[test]


### PR DESCRIPTION
The hover underline for URL hints could render shifted to the right of the actual URL. The regex hover path used oniguruma byte offsets directly as cell columns, so any multi-byte character left of the match on the row (box-drawing prefixes, CJK, emoji) dragged the underline right by one cell per extra UTF-8 byte. The same code searched a single visual row at a time, so soft-wrapped URLs matched truncated or not at all.

Matching now runs over the logical (unwrapped) line under the pointer, extracted together with a byte-to-cell map: every byte of the extracted text records its source cell, and match offsets resolve through the map, so bounds cannot drift regardless of encoding. Wide-char spacers are skipped, blank cells read as spaces, zero-width marks are emitted with their base character, and a match ending on a wide character extends over its spacer so the underline covers the full glyph. Wrapped URLs now resolve whole from any of their rows, and clicking opens the full URL.

Performance work on the probe path, since it runs on mouse movement:

- Hint regexes are compiled once and cached; previously the URL pattern was recompiled on every mouse move.
- A probe of the same viewport cell with the same modifiers is skipped entirely, without taking the terminal lock (the cell is derived from geometry alone). A shown highlight always reprobes so text changing under the underline stays fresh; wheel scroll and highlight clears reset the dedup.
- The logical line is extracted once per probe and shared across all hint rules.
- Reprobes that find the same match no longer re-mark full terminal damage per pixel while hovering a link.
- Searches carry a per-search retry budget (via onig_sys, which the onig wrapper does not expose), so pathological content cannot stall the event loop through backtracking.
- The wrap scan is bounded to 2048 cells on each side of the hovered row. Only matches containing the hovered cell matter, so nothing hoverable is lost for any sane URL length. Measured in release mode: a typical probe is ~12us; a 201-row wrapped wall of word characters, where the URL pattern's lookaheads rescan ahead at every position, drops from ~88ms to ~6ms.

Covered by new unit tests over a mock grid: exact cell bounds on plain ASCII, multi-byte prefixes, wide-char prefixes, soft-wrapped URLs from either row, a URL deep inside a huge wrapped line, and tail post-processing rules. Also adds a librio test pinning url_at alignment for the same scenario.