### PR TITLE
fix(rioterm): keep quick-select hints synced while scrolling

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -819,6 +819,11 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         .lock();
                     terminal.scroll_display(scroll);
                     drop(terminal);
+                    route.window.screen.refresh_hints_after_scroll();
+                    route
+                        .window
+                        .winit_window
+                        .set_cursor(route.window.screen.mouse_cursor_icon());
                 }
             }
             RioEventType::Rio(RioEvent::ClipboardLoad(
@@ -1951,6 +1956,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     }
                 }
 
+                route
+                    .window
+                    .winit_window
+                    .set_cursor(route.window.screen.mouse_cursor_icon());
                 route.request_redraw();
             }
 
@@ -1977,6 +1986,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     .window
                     .screen
                     .process_key_event(&key_event, &mut self.router.clipboard);
+                route
+                    .window
+                    .winit_window
+                    .set_cursor(route.window.screen.mouse_cursor_icon());
                 // `process_key_event` used to call `self.render()` for
                 // local-only keystrokes (VI mode, search input, hint
                 // mode). Now it just marks `pending_update.set_dirty()`

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -77,6 +77,25 @@ impl HintState {
         &mut self,
         term: &rio_backend::crosswords::Crosswords<T>,
     ) {
+        self.rebuild_matches(term);
+        if self.matches.is_empty() {
+            self.stop();
+        }
+    }
+
+    /// Refresh matches without leaving hint mode when none are visible.
+    pub(crate) fn refresh_matches<T: EventListener>(
+        &mut self,
+        term: &rio_backend::crosswords::Crosswords<T>,
+    ) {
+        self.keys.clear();
+        self.rebuild_matches(term);
+    }
+
+    fn rebuild_matches<T: EventListener>(
+        &mut self,
+        term: &rio_backend::crosswords::Crosswords<T>,
+    ) {
         self.matches.clear();
 
         let hint = match &self.active_hint {
@@ -98,9 +117,8 @@ impl HintState {
             self.find_hyperlink_matches(term, hint.clone());
         }
 
-        // Cancel hint mode if no matches found
         if self.matches.is_empty() {
-            self.stop();
+            self.labels.clear();
             return;
         }
 
@@ -217,9 +235,6 @@ impl HintState {
         // Scan each visible line for matches
         for line_idx in 0..visible_lines {
             let line = Line(line_idx as i32 - display_offset as i32);
-            if line < Line(0) || line.0 >= grid.total_lines() as i32 {
-                continue;
-            }
 
             // Extract text from the line
             let line_text = self.extract_line_text(term, line);
@@ -268,9 +283,6 @@ impl HintState {
 
         for line_idx in 0..visible_lines {
             let line = Line(line_idx as i32 - display_offset as i32);
-            if line < Line(0) || line.0 >= grid.total_lines() as i32 {
-                continue;
-            }
 
             let mut col = 0usize;
             let cols = grid.columns();
@@ -760,6 +772,20 @@ mod tests {
     use super::*;
     use rio_backend::config::hints::{HintAction, HintInternalAction};
 
+    fn test_hint() -> Rc<Hint> {
+        Rc::new(Hint {
+            regex: Some("test".to_string()),
+            hyperlinks: false,
+            post_processing: true,
+            persist: false,
+            action: HintAction::Action {
+                action: HintInternalAction::Copy,
+            },
+            mouse: Default::default(),
+            binding: None,
+        })
+    }
+
     #[test]
     fn test_label_generator() {
         let mut gen = LabelGenerator::new("abc");
@@ -777,23 +803,32 @@ mod tests {
         let mut state = HintState::new("abc".to_string());
         assert!(!state.is_active());
 
-        let hint = Rc::new(Hint {
-            regex: Some("test".to_string()),
-            hyperlinks: false,
-            post_processing: true,
-            persist: false,
-            action: HintAction::Action {
-                action: HintInternalAction::Copy,
-            },
-            mouse: Default::default(),
-            binding: None,
-        });
-
-        state.start(hint);
+        state.start(test_hint());
         assert!(state.is_active());
 
         state.stop();
         assert!(!state.is_active());
+    }
+
+    #[test]
+    fn scrolling_keeps_hint_mode_active_until_matches_reappear() {
+        let mut term = mock_term("test\nx");
+        let screen_lines = term.grid.screen_lines();
+        term.grid
+            .scroll_up(&(Line(0)..Line(screen_lines as i32)), 1);
+
+        let mut state = HintState::new("ab".to_string());
+        state.start(test_hint());
+
+        state.refresh_matches(&term);
+        assert!(state.is_active());
+        assert!(state.matches().is_empty());
+
+        term.scroll_display(rio_backend::crosswords::grid::Scroll::Delta(1));
+        state.refresh_matches(&term);
+        assert!(state.is_active());
+        assert_eq!(state.matches().len(), 1);
+        assert_eq!(state.visible_labels().len(), 1);
     }
 
     #[test]
@@ -840,17 +875,7 @@ mod tests {
                     rio_backend::crosswords::pos::Line(0),
                     rio_backend::crosswords::pos::Column(5),
                 ),
-                hint: Rc::new(Hint {
-                    regex: Some("test".to_string()),
-                    hyperlinks: false,
-                    post_processing: true,
-                    persist: false,
-                    action: HintAction::Action {
-                        action: HintInternalAction::Copy,
-                    },
-                    mouse: Default::default(),
-                    binding: None,
-                }),
+                hint: test_hint(),
             },
             HintMatch {
                 text: "match1".to_string(),
@@ -862,33 +887,11 @@ mod tests {
                     rio_backend::crosswords::pos::Line(0),
                     rio_backend::crosswords::pos::Column(15),
                 ),
-                hint: Rc::new(Hint {
-                    regex: Some("test".to_string()),
-                    hyperlinks: false,
-                    post_processing: true,
-                    persist: false,
-                    action: HintAction::Action {
-                        action: HintInternalAction::Copy,
-                    },
-                    mouse: Default::default(),
-                    binding: None,
-                }),
+                hint: test_hint(),
             },
         ];
 
-        let hint = Rc::new(Hint {
-            regex: Some("test".to_string()),
-            hyperlinks: false,
-            post_processing: true,
-            persist: false,
-            action: HintAction::Action {
-                action: HintInternalAction::Copy,
-            },
-            mouse: Default::default(),
-            binding: None,
-        });
-
-        state.active_hint = Some(hint);
+        state.active_hint = Some(test_hint());
 
         // Test keyboard input logic without needing a terminal
         // Test that 'j' should match the first label

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -686,6 +686,7 @@ impl Screen<'_> {
             terminal.scroll_display(Scroll::Bottom);
         }
         drop(terminal);
+        self.refresh_hints_after_scroll();
     }
 
     #[inline]
@@ -803,8 +804,7 @@ impl Screen<'_> {
             return;
         }
 
-        let ignore_chars = self.process_key_bindings(key, &mode, mods, clipboard);
-        if ignore_chars {
+        if self.process_key_bindings(key, &mode, mods, clipboard) {
             return;
         }
 
@@ -1115,6 +1115,7 @@ impl Screen<'_> {
                             .set_terminal_damage(
                                 rio_backend::event::TerminalDamage::Full,
                             );
+                        self.refresh_hints_after_scroll();
                         self.mark_dirty();
                     }
                     Act::Vi(ViAction::ToggleNormalSelection) => {
@@ -1246,6 +1247,7 @@ impl Screen<'_> {
                         let mut terminal = current.terminal.lock();
                         terminal.scroll_to_prompt(false);
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1255,6 +1257,7 @@ impl Screen<'_> {
                         let mut terminal = current.terminal.lock();
                         terminal.scroll_to_prompt(true);
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1268,6 +1271,7 @@ impl Screen<'_> {
                             terminal.vi_mode_cursor.scroll(&terminal, scroll_lines);
                         terminal.scroll_display(Scroll::PageUp);
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1283,6 +1287,7 @@ impl Screen<'_> {
 
                         terminal.scroll_display(Scroll::PageDown);
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1298,6 +1303,7 @@ impl Screen<'_> {
 
                         terminal.scroll_display(Scroll::Delta(scroll_lines));
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1313,6 +1319,7 @@ impl Screen<'_> {
 
                         terminal.scroll_display(Scroll::Delta(scroll_lines));
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1326,6 +1333,7 @@ impl Screen<'_> {
                         terminal.vi_mode_cursor.pos.row = topmost_line;
                         terminal.vi_motion(ViMotion::FirstOccupied);
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1342,6 +1350,7 @@ impl Screen<'_> {
                         terminal.vi_motion(ViMotion::FirstOccupied);
                         terminal.vi_motion(ViMotion::FirstOccupied);
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1351,6 +1360,7 @@ impl Screen<'_> {
                         let mut terminal = current.terminal.lock();
                         terminal.scroll_display(Scroll::Delta(*delta));
                         drop(terminal);
+                        self.refresh_hints_after_scroll();
                         self.renderer.scrollbar.notify_scroll(rtid);
                         self.mark_dirty();
                     }
@@ -1515,7 +1525,8 @@ impl Screen<'_> {
             }
         }
 
-        ignore_chars.unwrap_or(false)
+        // Hint activation always consumes its key, even with an overlapping `ReceiveChar`.
+        ignore_chars.unwrap_or(false) || self.hint_state.is_active()
     }
 
     pub fn split_right_with_config(&mut self, config: rio_backend::config::Config) {
@@ -1806,6 +1817,7 @@ impl Screen<'_> {
         terminal.scroll_display(Scroll::Delta(-self.search_state.display_offset_delta));
         drop(terminal);
         self.search_state.origin = new_origin;
+        self.refresh_hints_after_scroll();
     }
 
     /// Whether we should send `ESC` due to `Alt` being pressed.
@@ -1997,9 +2009,8 @@ impl Screen<'_> {
         // pure geometry, so an unchanged probe skips without even
         // taking the terminal lock. While a highlight is shown the
         // probe always reruns, so text changing under the underline
-        // still refreshes it. Wheel scrolling resets the probe in
-        // `Self::scroll`; content sliding under a stationary cursor
-        // without one is stale until the mouse crosses a cell.
+        // still refreshes it. Viewport changes invalidate the probe
+        // through `Self::refresh_hints_after_scroll`.
         let viewport_point = self.mouse_position(0);
         if !had_highlight && self.last_hint_probe == Some((viewport_point, mods)) {
             return false;
@@ -2404,6 +2415,7 @@ impl Screen<'_> {
         let mut terminal = self.context_manager.current_mut().terminal.lock();
         terminal.scroll_display(Scroll::Delta(delta));
         drop(terminal);
+        self.refresh_hints_after_scroll();
 
         // Update selection to match the new scroll position.
         let display_offset = self.display_offset();
@@ -2645,8 +2657,13 @@ impl Screen<'_> {
                     let mut terminal = self.context_manager.current_mut().terminal.lock();
                     let current = terminal.display_offset();
                     let delta = new_offset as i32 - current as i32;
-                    terminal.scroll_display(Scroll::Delta(delta));
+                    if delta != 0 {
+                        terminal.scroll_display(Scroll::Delta(delta));
+                    }
                     drop(terminal);
+                    if delta != 0 {
+                        self.refresh_hints_after_scroll();
+                    }
                 }
             }
             self.mark_dirty();
@@ -2669,6 +2686,9 @@ impl Screen<'_> {
                 terminal.scroll_display(Scroll::Delta(delta));
             }
             drop(terminal);
+            if delta != 0 {
+                self.refresh_hints_after_scroll();
+            }
             self.mark_dirty();
         }
         true
@@ -3304,6 +3324,7 @@ impl Screen<'_> {
             drop(terminal);
         }
         self.search_state.display_offset_delta = 0;
+        self.refresh_hints_after_scroll();
     }
 
     /// Jump to the first regex match from the search origin.
@@ -3371,6 +3392,8 @@ impl Screen<'_> {
 
         if should_reset_search_state {
             self.search_reset_state();
+        } else {
+            self.refresh_hints_after_scroll();
         }
     }
 
@@ -3525,10 +3548,7 @@ impl Screen<'_> {
 
     #[inline]
     pub fn scroll(&mut self, new_scroll_x_px: f64, new_scroll_y_px: f64) {
-        // Scrolling slides different text under the pointer while the
-        // viewport cell stays the same, so the hover-probe dedup key
-        // must not suppress the next probe.
-        self.last_hint_probe = None;
+        let old_display_offset = self.display_offset();
 
         let dim = self.context_manager.current().dimension.dimension;
         let width = dim.width as f64;
@@ -3613,8 +3633,35 @@ impl Screen<'_> {
             }
         }
 
+        if old_display_offset != self.display_offset() {
+            self.refresh_hints_after_scroll();
+        }
+
         self.mouse.accumulated_scroll.x %= width;
         self.mouse.accumulated_scroll.y %= height;
+    }
+
+    pub(crate) fn refresh_hints_after_scroll(&mut self) {
+        // Scrolling changes the grid point under a stationary cursor.
+        self.last_hint_probe = None;
+        self.mouse.inside_text_area = self.contains_point(self.mouse.x, self.mouse.y);
+
+        let quick_select_active = self.hint_state.is_active();
+        if quick_select_active {
+            let terminal = self.context_manager.current().terminal.lock();
+            self.hint_state.refresh_matches(&*terminal);
+            drop(terminal);
+            self.update_hint_state();
+        }
+
+        let hover_changed = if self.mouse.inside_text_area {
+            self.update_highlighted_hints()
+        } else {
+            self.clear_highlighted_hint()
+        };
+        if quick_select_active || hover_changed {
+            self.mark_dirty();
+        }
     }
 
     #[inline]
@@ -4655,7 +4702,7 @@ impl Screen<'_> {
     ) {
         self.hint_state.start(hint);
         let terminal = self.context_manager.current().terminal.lock();
-        self.hint_state.update_matches(&*terminal);
+        self.hint_state.refresh_matches(&*terminal);
         drop(terminal);
 
         // Update hint state and trigger damage tracking


### PR DESCRIPTION
Quick-select hints were tied to the viewport where hint mode started. Scrolling could leave stale labels or exit hint mode when the new viewport had no matches.

This refreshes hints whenever the viewport moves and keeps hint mode active across empty viewports. Activating quick-select also preserves the current scroll position.