### PR TITLE
fix(kitty): draw Unicode placeholders after a=t + a=p,U=1 (placement id 0, GPU upload)

### DIFF
--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -1107,10 +1107,11 @@ impl Renderer {
             z_index: i32,
             clip: (f32, f32, f32, f32),
         ) {
-            let vp = rc
-                .kitty_virtual_placements
-                .get(&(run.image_id, run.placement_id))
-                .or_else(|| rc.kitty_virtual_placements.get(&(run.image_id, 0)));
+            let vp = rio_backend::ansi::kitty_virtual::resolve_virtual_placement(
+                &rc.kitty_virtual_placements,
+                run.image_id,
+                run.placement_id,
+            );
             let vp = match vp {
                 Some(v) => v,
                 None => return,

--- a/librio/src/render_state.rs
+++ b/librio/src/render_state.rs
@@ -4,7 +4,8 @@ use rio_vt::ansi::graphics::{
     VirtualPlacement,
 };
 use rio_vt::ansi::kitty_virtual::{
-    compute_run_geometry, IncompletePlacement, PlaceholderRun, PLACEHOLDER,
+    compute_run_geometry, resolve_virtual_placement, IncompletePlacement, PlaceholderRun,
+    PLACEHOLDER,
 };
 use rio_vt::ansi::CursorShape;
 use rio_vt::config::colors::term::TermColors;
@@ -355,10 +356,11 @@ impl RenderState {
                      run: PlaceholderRun,
                      line: usize,
                      start_col: usize| {
-            let placement = graphics
-                .kitty_virtual_placements
-                .get(&(run.image_id, run.placement_id))
-                .or_else(|| graphics.kitty_virtual_placements.get(&(run.image_id, 0)));
+            let placement = resolve_virtual_placement(
+                &graphics.kitty_virtual_placements,
+                run.image_id,
+                run.placement_id,
+            );
             let Some(placement) = placement else { return };
             let Some(image) = graphics.get_kitty_image(run.image_id) else {
                 return;

--- a/rio-vt/src/ansi/kitty_virtual.rs
+++ b/rio-vt/src/ansi/kitty_virtual.rs
@@ -1,6 +1,8 @@
 // Kitty graphics protocol virtual placement encoding/decoding
 
+use crate::ansi::graphics::VirtualPlacement;
 use crate::config::colors::{AnsiColor, ColorRgb};
+use rustc_hash::FxHashMap;
 
 /// The Kitty Unicode placeholder codepoint (U+10EEEE). Cells containing
 /// this codepoint are interpreted as image placeholders; their fg color
@@ -648,9 +650,90 @@ pub fn compute_run_geometry(
     })
 }
 
+/// Resolve the virtual placement a placeholder run refers to.
+///
+/// The placement id comes from the cell's underline color. Per the
+/// kitty spec, "if it's omitted or zero, the terminal may choose any
+/// virtual placement of the given image" — and clients routinely
+/// omit it: Neovim's TUI only emits the underline color (SGR 58) for
+/// cells that carry an underline attribute, so snacks.image's
+/// placeholder cells always arrive with `placement_id == 0` even
+/// though the placement was registered with `p=N`. kitty
+/// (`graphics.c`, `find the first virtual image placement`) and
+/// ghostty (`graphics_unicode.zig`, `placeholderTarget`) both fall
+/// back to the first virtual placement of the image in that case.
+///
+/// A non-zero id must match exactly, as in kitty. For id 0 the
+/// placement with the lowest id is chosen so the result does not
+/// depend on hash-map iteration order (an explicit `p=0` placement
+/// therefore still wins).
+pub fn resolve_virtual_placement(
+    placements: &FxHashMap<(u32, u32), VirtualPlacement>,
+    image_id: u32,
+    placement_id: u32,
+) -> Option<&VirtualPlacement> {
+    if placement_id != 0 {
+        return placements.get(&(image_id, placement_id));
+    }
+    placements
+        .iter()
+        .filter(|((img, _), _)| *img == image_id)
+        .min_by_key(|((_, pid), _)| *pid)
+        .map(|(_, vp)| vp)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn vp(image_id: u32, placement_id: u32) -> VirtualPlacement {
+        VirtualPlacement {
+            image_id,
+            placement_id,
+            columns: 4,
+            rows: 2,
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        }
+    }
+
+    #[test]
+    fn resolve_zero_placement_id_falls_back_to_any_placement_of_image() {
+        // snacks.image registers `p=11`; Neovim never sends the underline
+        // color for non-underlined cells, so the cells decode to id 0.
+        let mut m = FxHashMap::default();
+        m.insert((7, 11), vp(7, 11));
+        m.insert((8, 3), vp(8, 3));
+        let got = resolve_virtual_placement(&m, 7, 0).expect("placement");
+        assert_eq!((got.image_id, got.placement_id), (7, 11));
+        assert!(resolve_virtual_placement(&m, 9, 0).is_none());
+    }
+
+    #[test]
+    fn resolve_zero_placement_id_prefers_lowest_id() {
+        let mut m = FxHashMap::default();
+        m.insert((7, 11), vp(7, 11));
+        m.insert((7, 0), vp(7, 0));
+        m.insert((7, 5), vp(7, 5));
+        let got = resolve_virtual_placement(&m, 7, 0).unwrap();
+        assert_eq!(got.placement_id, 0);
+        m.remove(&(7, 0));
+        assert_eq!(resolve_virtual_placement(&m, 7, 0).unwrap().placement_id, 5);
+    }
+
+    #[test]
+    fn resolve_nonzero_placement_id_must_match_exactly() {
+        let mut m = FxHashMap::default();
+        m.insert((7, 11), vp(7, 11));
+        m.insert((7, 0), vp(7, 0));
+        assert_eq!(
+            resolve_virtual_placement(&m, 7, 11).unwrap().placement_id,
+            11
+        );
+        assert!(resolve_virtual_placement(&m, 7, 12).is_none());
+    }
 
     #[test]
     fn test_diacritic_conversion() {

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -4910,7 +4910,12 @@ impl<U: EventListener> Handler for Crosswords<U> {
             .graphics
             .kitty_placements
             .keys()
-            .any(|(id, _)| *id == image_id);
+            .any(|(id, _)| *id == image_id)
+            || self
+                .graphics
+                .kitty_virtual_placements
+                .keys()
+                .any(|(id, _)| *id == image_id);
         let image_width = graphic.width;
         let image_height = graphic.height;
         let pixel_data = has_placements.then(|| graphic.clone());
@@ -5004,6 +5009,14 @@ impl<U: EventListener> Handler for Crosswords<U> {
         // emits U+10EEEE placeholder cells itself. The renderer scans
         // visible cells and composites the image at those positions.
         if placement.virtual_placement {
+            // `a=t` deliberately defers the GPU upload to the placement
+            // (see `store_graphic`). The direct path does it in
+            // `place_kitty_overlay`; the virtual path has to do it here,
+            // otherwise the placeholder cells stay blank (this is the
+            // `a=t` + `a=p,U=1` sequence snacks.image and yazi emit).
+            // Upload once per image: clients re-place on every relayout,
+            // and that must not resend the pixels.
+            self.upload_for_virtual_placement(image_id);
             self.place_virtual_graphic(placement);
             return true;
         }
@@ -5776,6 +5789,33 @@ impl<U: EventListener> Crosswords<U> {
     /// decodes the image_id from the foreground color and the row/col
     /// indices from the combining-mark diacritics (kitty_virtual::*), and
     /// looks up the metadata stored here to know which image to composite.
+    /// Queue the stored pixels of `image_id` for the GPU before its first
+    /// virtual placement. Returns whether an upload was queued: `false`
+    /// when the image already has a virtual placement (pixels are on the
+    /// GPU) or is unknown.
+    fn upload_for_virtual_placement(&mut self, image_id: u32) -> bool {
+        let already_uploaded = self
+            .graphics
+            .kitty_virtual_placements
+            .keys()
+            .any(|(id, _)| *id == image_id);
+        if already_uploaded {
+            return false;
+        }
+        let pixel_data = self
+            .graphics
+            .get_kitty_image(image_id)
+            .map(|stored| stored.data.clone());
+        match pixel_data {
+            Some(pixel_data) => {
+                self.graphics.pending_images.push((image_id, pixel_data));
+                self.send_graphics_updates();
+                true
+            }
+            None => false,
+        }
+    }
+
     fn place_virtual_graphic(
         &mut self,
         placement: crate::ansi::kitty_graphics_protocol::PlacementRequest,
@@ -9685,6 +9725,63 @@ mod tests {
 
         // Cursor must be untouched.
         assert_eq!(cw.grid.cursor.pos, cursor_before);
+    }
+
+    #[test]
+    fn virtual_placement_uploads_pixels_once_per_image() {
+        use crate::ansi::kitty_graphics_protocol::PlacementRequest;
+
+        let size = CrosswordsSize::new(40, 20);
+        let window_id = crate::event::WindowId::from(0);
+        let mut cw = Crosswords::new(
+            size,
+            CursorShape::Block,
+            VoidListener {},
+            window_id,
+            0,
+            10_000,
+        );
+        // Unknown image: nothing to upload.
+        assert!(!cw.upload_for_virtual_placement(1234));
+
+        cw.graphics.store_kitty_image(
+            1234,
+            None,
+            GraphicData {
+                id: rio_graphics::GraphicId::new(1234),
+                width: 1,
+                height: 1,
+                pixels: vec![0u8; 4],
+                color_type: rio_graphics::ColorType::Rgba,
+                is_opaque: true,
+                display_width: None,
+                display_height: None,
+                resize: None,
+                transmit_time: crate::time::Instant::now(),
+            },
+        );
+        // `a=t` stored the image without uploading; the first virtual
+        // placement must queue the pixels …
+        assert!(cw.upload_for_virtual_placement(1234));
+        let placement = PlacementRequest {
+            image_id: 1234,
+            placement_id: 7,
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+            columns: 8,
+            rows: 4,
+            z_index: 0,
+            virtual_placement: true,
+            unicode_placeholder: 0,
+            cursor_movement: 0,
+            cell_x_offset: 0,
+            cell_y_offset: 0,
+        };
+        assert!(cw.place_graphic(placement));
+        // … and a re-place of the same image must not resend them.
+        assert!(!cw.upload_for_virtual_placement(1234));
     }
 
     /// DECSTBM bounds where scrolling happens, not what is on screen. Both


### PR DESCRIPTION
## Summary

Fixes #1891 — Unicode placeholder cells (`a=p,U=1` + U+10EEEE) were never drawn for the sequence real clients emit (`a=t`, then `a=p,U=1,p=N`, then cells without an underline color), e.g. snacks.image in Neovim and yazi. Two independent causes, one commit each:

1. **Resolve placement id 0 to any virtual placement of the image** (`kitty_virtual::resolve_virtual_placement`, used by both the rioterm renderer and `librio`). Per the spec the underline color carries the placement id and "if it's omitted or zero, the terminal may choose any virtual placement of the given image"; kitty and ghostty do that, Rio only tried the exact key and `(image_id, 0)`. Neovim's TUI emits SGR 58 only for underlined cells, so snacks' placeholder cells always arrive with id 0 while the placement is registered as `p=N`. A non-zero id must still match exactly; id 0 picks the lowest placement id so the result does not depend on hash-map order.

2. **Upload pixels before the first virtual placement after `a=t`** (`upload_for_virtual_placement`). `store_graphic` defers the GPU upload to the placement; the direct `a=p` path and `a=T,U=1` do it, the plain `a=p,U=1` branch did not, so the placement existed but the texture never did. Re-placing the same image (clients do that on every relayout) does not resend; retransmitting an image with virtual placements now refreshes them like it does for direct ones.

## Test plan

- [x] `cargo test -p rio-vt` — 3 new tests for `resolve_virtual_placement`, 1 for `upload_for_virtual_placement`, existing virtual-placement tests unchanged (35 pass in the filtered run)
- [x] Windows build with `--features wgpu`: the script from the issue draws the image; the four variants from the issue table all draw
- [x] Neovim 0.12.5 + snacks.image with `SNACKS_KITTY=1`: images and `pdflatex`-rendered math render inline in markdown buffers (previously: space reserved, nothing drawn)
- [ ] macOS/Linux not tested (the changed code is platform-independent)
