### PR TITLE
fix(kitty): draw Unicode placeholders after a=t + a=p,U=1, track GPU uploads per image

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -483,6 +483,15 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         );
                     }
 
+                    // Removals arrive as final image keys (atlas refs
+                    // dropped off scrollback, kitty evictions) and free
+                    // both the pixel store and the cached GPU texture.
+                    // They run before the kitty uploads so a batch that
+                    // frees a key and resends it keeps the new pixels.
+                    for key in queues.remove_queue {
+                        sugarloaf.remove_image(key);
+                    }
+
                     // Image textures (kitty) → separate store, no clone
                     for (image_id, graphic_data) in queues.pending_images {
                         sugarloaf.image_data.insert(
@@ -491,13 +500,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                                 graphic_data,
                             ),
                         );
-                    }
-
-                    // Removals arrive as final image keys (atlas refs
-                    // dropped off scrollback, kitty evictions) and free
-                    // both the pixel store and the cached GPU texture.
-                    for key in queues.remove_queue {
-                        sugarloaf.remove_image(key);
                     }
 
                     // Mark the panel dirty: the renderer skips non-dirty

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -468,6 +468,19 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             RioEventType::Rio(RioEvent::UpdateGraphics { route_id, queues }) => {
                 use rio_backend::sugarloaf::route_image_key;
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    // A batch the VT thread queued before the user
+                    // closed its tab or split would otherwise land
+                    // under a route nothing will ever release.
+                    if route
+                        .window
+                        .screen
+                        .context_manager
+                        .get_by_route_id(route_id)
+                        .is_none()
+                    {
+                        return;
+                    }
+
                     // Process graphics directly in sugarloaf
                     let sugarloaf = &mut route.window.screen.sugarloaf;
 

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -466,6 +466,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::UpdateGraphics { route_id, queues }) => {
+                use rio_backend::sugarloaf::route_image_key;
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     // Process graphics directly in sugarloaf
                     let sugarloaf = &mut route.window.screen.sugarloaf;
@@ -474,7 +475,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     // texture store with kitty images, in a disjoint key
                     // namespace.
                     for graphic_data in queues.pending {
-                        let key = crate::renderer::atlas_image_key(graphic_data.id.get());
+                        let key = route_image_key(
+                            route_id,
+                            crate::renderer::atlas_image_key(graphic_data.id.get()),
+                        );
                         sugarloaf.image_data.insert(
                             key,
                             rio_backend::sugarloaf::GraphicDataEntry::from_graphic_data(
@@ -489,13 +493,16 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     // They run before the kitty uploads so a batch that
                     // frees a key and resends it keeps the new pixels.
                     for key in queues.remove_queue {
-                        sugarloaf.remove_image(key);
+                        sugarloaf.remove_image(route_image_key(route_id, key));
                     }
 
                     // Image textures (kitty) → separate store, no clone
                     for (image_id, graphic_data) in queues.pending_images {
                         sugarloaf.image_data.insert(
-                            crate::renderer::kitty_image_key(image_id),
+                            route_image_key(
+                                route_id,
+                                crate::renderer::kitty_image_key(image_id),
+                            ),
                             rio_backend::sugarloaf::GraphicDataEntry::from_graphic_data(
                                 graphic_data,
                             ),

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -500,7 +500,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
 
         // A whole tab dies.
-        self.contexts[tab_index].remove_all_rich_text(sugarloaf);
+        self.contexts[tab_index].remove_from_sugarloaf(sugarloaf);
         self.contexts.remove(tab_index);
 
         if self.contexts.is_empty() {
@@ -574,10 +574,15 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     }
 
     #[inline]
-    pub fn close_unfocused_tabs(&mut self) {
+    pub fn close_unfocused_tabs(&mut self, sugarloaf: &mut Sugarloaf) {
         let current_route_id = self.current().route_id;
-        self.contexts
-            .retain(|ctx| ctx.current().route_id == current_route_id);
+        self.contexts.retain(|ctx| {
+            let keep = ctx.current().route_id == current_route_id;
+            if !keep {
+                ctx.remove_from_sugarloaf(sugarloaf);
+            }
+            keep
+        });
         self.current_route = self.contexts[0].current().route_id;
         self.set_current(0);
     }
@@ -884,7 +889,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
 
         // Remove all rich text from the grid before removing the context
-        self.contexts[index_to_remove].remove_all_rich_text(sugarloaf);
+        self.contexts[index_to_remove].remove_from_sugarloaf(sugarloaf);
         self.contexts.remove(index_to_remove);
 
         if should_set_current {

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -1340,6 +1340,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
 
         // Get rich text ID before removing
         let rich_text_id = self.inner.get(&to_remove).map(|item| item.val.rich_text_id);
+        let route_id = self.inner.get(&to_remove).map(|item| item.val.route_id);
 
         // Select next panel before removing (use visual ordering)
         let ordered_keys = self.get_ordered_keys();
@@ -1376,6 +1377,9 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
         // no other panel state to clean up post-Content removal.
         if let Some(id) = rich_text_id {
             sugarloaf.clear_image_overlays_for(id);
+        }
+        if let Some(route_id) = route_id {
+            sugarloaf.remove_route_images(route_id);
         }
 
         // Update root if necessary
@@ -1654,9 +1658,12 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
     /// `ContextManager`; only the kitty graphics state needs an
     /// explicit cleanup signal.
     #[inline]
-    pub fn remove_all_rich_text(&self, sugarloaf: &mut Sugarloaf) {
+    /// Release everything this grid's panels hold in sugarloaf: image
+    /// overlays and the images they drew.
+    pub fn remove_from_sugarloaf(&self, sugarloaf: &mut Sugarloaf) {
         for item in self.inner.values() {
             sugarloaf.clear_image_overlays_for(item.val.rich_text_id);
+            sugarloaf.remove_route_images(item.val.route_id);
         }
     }
 }

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -1107,10 +1107,11 @@ impl Renderer {
             z_index: i32,
             clip: (f32, f32, f32, f32),
         ) {
-            let vp = rc
-                .kitty_virtual_placements
-                .get(&(run.image_id, run.placement_id))
-                .or_else(|| rc.kitty_virtual_placements.get(&(run.image_id, 0)));
+            let vp = rio_backend::ansi::kitty_virtual::resolve_virtual_placement(
+                &rc.kitty_virtual_placements,
+                run.image_id,
+                run.placement_id,
+            );
             let vp = match vp {
                 Some(v) => v,
                 None => return,

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -140,7 +140,7 @@ fn window_bg_alpha(config: &Config) -> f32 {
     }
 }
 
-pub use rio_backend::sugarloaf::{atlas_image_key, kitty_image_key};
+pub use rio_backend::sugarloaf::{atlas_image_key, kitty_image_key, route_image_key};
 
 pub struct Renderer {
     is_vi_mode_enabled: bool,
@@ -567,6 +567,7 @@ impl Renderer {
             // exist. Positions depend on display_offset and history_size which
             // change on scroll and text output (like approach).
             let rc = &context.renderable_content;
+            let route_id = context.route_id;
             let has_overlays = !rc.kitty_placements.is_empty();
             let has_virtual = !rc.kitty_virtual_placements.is_empty();
             let has_atlas = !rc.atlas_placements.is_empty();
@@ -622,7 +623,7 @@ impl Renderer {
                             continue;
                         };
                         let mut overlay = rio_backend::sugarloaf::GraphicOverlay {
-                            image_id: p.image_key,
+                            image_id: route_image_key(route_id, p.image_key),
                             x: geometry.x,
                             y: geometry.y,
                             width: geometry.width,
@@ -660,7 +661,10 @@ impl Renderer {
                             continue;
                         };
                         let mut overlay = rio_backend::sugarloaf::GraphicOverlay {
-                            image_id: kitty_image_key(p.image_id),
+                            image_id: route_image_key(
+                                route_id,
+                                kitty_image_key(p.image_id),
+                            ),
                             x: geometry.x,
                             y: geometry.y,
                             width: geometry.width,
@@ -684,6 +688,7 @@ impl Renderer {
                     Self::push_virtual_placeholder_overlays(
                         overlays,
                         rc,
+                        route_id,
                         origin_x,
                         origin_y,
                         cell_width,
@@ -969,6 +974,7 @@ impl Renderer {
     fn push_virtual_placeholder_overlays(
         overlays: &mut Vec<rio_backend::sugarloaf::GraphicOverlay>,
         rc: &RenderableContent,
+        route_id: usize,
         origin_x: f32,
         origin_y: f32,
         cell_width: f32,
@@ -1008,6 +1014,7 @@ impl Renderer {
                         flush_run(
                             overlays,
                             rc,
+                            route_id,
                             p.complete(),
                             line_idx,
                             start_col,
@@ -1044,6 +1051,7 @@ impl Renderer {
                             flush_run(
                                 overlays,
                                 rc,
+                                route_id,
                                 p.complete(),
                                 line_idx,
                                 start_col,
@@ -1074,6 +1082,7 @@ impl Renderer {
                 flush_run(
                     overlays,
                     rc,
+                    route_id,
                     p.complete(),
                     line_idx,
                     start_col,
@@ -1097,6 +1106,7 @@ impl Renderer {
         fn flush_run(
             overlays: &mut Vec<rio_backend::sugarloaf::GraphicOverlay>,
             rc: &RenderableContent,
+            route_id: usize,
             run: PlaceholderRun,
             screen_line: usize,
             start_screen_col: usize,
@@ -1140,7 +1150,7 @@ impl Renderer {
             };
 
             let mut overlay = rio_backend::sugarloaf::GraphicOverlay {
-                image_id: kitty_image_key(run.image_id),
+                image_id: route_image_key(route_id, kitty_image_key(run.image_id)),
                 x: geom.x,
                 y: geom.y,
                 width: geom.width,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -1221,7 +1221,8 @@ impl Screen<'_> {
                         if self.ctx().len() <= 1 {
                             return true;
                         }
-                        self.context_manager.close_unfocused_tabs();
+                        self.context_manager
+                            .close_unfocused_tabs(&mut self.sugarloaf);
                         if let Some(ref mut island) = self.renderer.island {
                             island.dismiss_color_picker();
                         }
@@ -3687,7 +3688,8 @@ impl Screen<'_> {
             PaletteAction::TabClose => self.close_tab(clipboard),
             PaletteAction::TabCloseUnfocused => {
                 if self.ctx().len() > 1 {
-                    self.context_manager.close_unfocused_tabs();
+                    self.context_manager
+                        .close_unfocused_tabs(&mut self.sugarloaf);
                     if let Some(ref mut island) = self.renderer.island {
                         island.dismiss_color_picker();
                     }

--- a/librio/src/render_state.rs
+++ b/librio/src/render_state.rs
@@ -4,7 +4,8 @@ use rio_vt::ansi::graphics::{
     VirtualPlacement,
 };
 use rio_vt::ansi::kitty_virtual::{
-    compute_run_geometry, IncompletePlacement, PlaceholderRun, PLACEHOLDER,
+    compute_run_geometry, resolve_virtual_placement, IncompletePlacement, PlaceholderRun,
+    PLACEHOLDER,
 };
 use rio_vt::ansi::CursorShape;
 use rio_vt::config::colors::term::TermColors;
@@ -355,10 +356,11 @@ impl RenderState {
                      run: PlaceholderRun,
                      line: usize,
                      start_col: usize| {
-            let placement = graphics
-                .kitty_virtual_placements
-                .get(&(run.image_id, run.placement_id))
-                .or_else(|| graphics.kitty_virtual_placements.get(&(run.image_id, 0)));
+            let placement = resolve_virtual_placement(
+                &graphics.kitty_virtual_placements,
+                run.image_id,
+                run.placement_id,
+            );
             let Some(placement) = placement else { return };
             let Some(image) = graphics.get_kitty_image(run.image_id) else {
                 return;

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -2899,7 +2899,6 @@ fn test_eviction_prefers_inactive_screen_images() {
             data: inactive_data,
             transmission_time: std::time::Instant::now()
                 - std::time::Duration::from_secs(60),
-            gpu_uploaded: false,
         },
     );
     // Inactive bytes also count toward total_bytes (kept consistent).
@@ -2965,7 +2964,6 @@ fn test_eviction_keeps_active_used_image_when_inactive_available() {
         StoredImage {
             data: inactive,
             transmission_time: std::time::Instant::now(),
-            gpu_uploaded: false,
         },
     );
     graphics.total_bytes += 50;

--- a/rio-backend/src/graphics/kitty/mod.rs
+++ b/rio-backend/src/graphics/kitty/mod.rs
@@ -2899,6 +2899,7 @@ fn test_eviction_prefers_inactive_screen_images() {
             data: inactive_data,
             transmission_time: std::time::Instant::now()
                 - std::time::Duration::from_secs(60),
+            gpu_uploaded: false,
         },
     );
     // Inactive bytes also count toward total_bytes (kept consistent).
@@ -2964,6 +2965,7 @@ fn test_eviction_keeps_active_used_image_when_inactive_available() {
         StoredImage {
             data: inactive,
             transmission_time: std::time::Instant::now(),
+            gpu_uploaded: false,
         },
     );
     graphics.total_bytes += 50;

--- a/rio-graphics/src/lib.rs
+++ b/rio-graphics/src/lib.rs
@@ -116,6 +116,29 @@ pub fn atlas_image_key(graphic_id: u64) -> u64 {
     (1u64 << 32) + graphic_id
 }
 
+/// Bits of an image key below the terminal namespace: the kitty u32
+/// id space plus the atlas range above it.
+const IMAGE_KEY_ROUTE_SHIFT: u32 = 33;
+
+/// Namespace an image key by the terminal (route) it belongs to. The
+/// texture store is shared by every terminal drawn in a window while
+/// kitty ids are chosen by each terminal's client and atlas ids are a
+/// per-terminal counter, so without this two tabs or splits using the
+/// same id would overwrite each other's pixels. Route 0 is the
+/// identity, which keeps single-terminal embedders on plain keys.
+#[inline]
+pub fn route_image_key(route_id: usize, key: u64) -> u64 {
+    debug_assert!(key < (1u64 << IMAGE_KEY_ROUTE_SHIFT));
+    debug_assert!((route_id as u64) < (1u64 << (64 - IMAGE_KEY_ROUTE_SHIFT)));
+    ((route_id as u64) << IMAGE_KEY_ROUTE_SHIFT) | key
+}
+
+/// The route a namespaced image key belongs to.
+#[inline]
+pub fn image_key_route(key: u64) -> usize {
+    (key >> IMAGE_KEY_ROUTE_SHIFT) as usize
+}
+
 /// An overlay image placement.
 /// Used by the renderer to draw images on top of (or behind) terminal content.
 #[derive(Debug, Clone)]
@@ -521,4 +544,39 @@ fn check_opaque_region() {
 
     assert!(graphic.is_filled(0, 0, 3, 3));
     assert!(!graphic.is_filled(1, 1, 4, 4));
+}
+
+#[cfg(test)]
+mod route_key_tests {
+    use super::*;
+
+    #[test]
+    fn route_zero_is_identity() {
+        assert_eq!(route_image_key(0, kitty_image_key(7)), kitty_image_key(7));
+        assert_eq!(route_image_key(0, atlas_image_key(7)), atlas_image_key(7));
+        assert_eq!(image_key_route(kitty_image_key(u32::MAX)), 0);
+        assert_eq!(image_key_route(atlas_image_key(u32::MAX as u64)), 0);
+    }
+
+    #[test]
+    fn routes_never_collide() {
+        let a = route_image_key(1, kitty_image_key(7));
+        let b = route_image_key(2, kitty_image_key(7));
+        assert_ne!(a, b);
+        assert_ne!(
+            route_image_key(1, atlas_image_key(7)),
+            route_image_key(2, atlas_image_key(7))
+        );
+        assert_ne!(
+            route_image_key(1, kitty_image_key(u32::MAX)),
+            route_image_key(2, kitty_image_key(0))
+        );
+        assert_ne!(
+            route_image_key(1, atlas_image_key(0)),
+            route_image_key(2, kitty_image_key(0))
+        );
+        assert_eq!(image_key_route(a), 1);
+        assert_eq!(image_key_route(b), 2);
+        assert_eq!(image_key_route(route_image_key(3, atlas_image_key(9))), 3);
+    }
 }

--- a/rio-graphics/src/lib.rs
+++ b/rio-graphics/src/lib.rs
@@ -130,7 +130,8 @@ const IMAGE_KEY_ROUTE_SHIFT: u32 = 33;
 pub fn route_image_key(route_id: usize, key: u64) -> u64 {
     debug_assert!(key < (1u64 << IMAGE_KEY_ROUTE_SHIFT));
     debug_assert!((route_id as u64) < (1u64 << (64 - IMAGE_KEY_ROUTE_SHIFT)));
-    ((route_id as u64) << IMAGE_KEY_ROUTE_SHIFT) | key
+    ((route_id as u64) << IMAGE_KEY_ROUTE_SHIFT)
+        | (key & ((1u64 << IMAGE_KEY_ROUTE_SHIFT) - 1))
 }
 
 /// The route a namespaced image key belongs to.

--- a/rio-vt/src/ansi/graphics.rs
+++ b/rio-vt/src/ansi/graphics.rs
@@ -660,7 +660,8 @@ pub struct Graphics {
     /// are per screen, so this is deliberately not swapped with the
     /// screens: a same-id image on the other screen overwrites the
     /// texture, and an eviction on either screen can free it. Other
-    /// terminals sharing the window's texture store are not tracked.
+    /// terminals in the window draw from keys namespaced by route, so
+    /// they never share a texture with this one.
     pub kitty_texture_contents: FxHashMap<u32, crate::time::Instant>,
 
     /// Counter for auto-assigning internal placement IDs.

--- a/rio-vt/src/ansi/graphics.rs
+++ b/rio-vt/src/ansi/graphics.rs
@@ -656,10 +656,11 @@ pub struct Graphics {
 
     /// Which pixels the frontend texture for each kitty image id holds,
     /// by the `transmission_time` of the store they were queued from.
-    /// Textures are per window while image stores are per screen, so
-    /// this is deliberately not swapped with the screens: a same-id
-    /// image on the other screen overwrites the texture, and an
-    /// eviction on either screen frees it.
+    /// Textures outlive the main/alt screen split while image stores
+    /// are per screen, so this is deliberately not swapped with the
+    /// screens: a same-id image on the other screen overwrites the
+    /// texture, and an eviction on either screen can free it. Other
+    /// terminals sharing the window's texture store are not tracked.
     pub kitty_texture_contents: FxHashMap<u32, crate::time::Instant>,
 
     /// Counter for auto-assigning internal placement IDs.
@@ -992,7 +993,22 @@ impl Graphics {
         image_number: Option<u32>,
         mut data: GraphicData,
     ) {
-        let now = crate::time::Instant::now();
+        // transmission_time doubles as the texture generation, so two
+        // stores of one id must never share it (web_time only has
+        // millisecond resolution).
+        let mut now = crate::time::Instant::now();
+        let previous = self
+            .kitty_images
+            .get(&image_id)
+            .map(|old| old.transmission_time)
+            .into_iter()
+            .chain(self.kitty_texture_contents.get(&image_id).copied())
+            .max();
+        if let Some(previous) = previous {
+            if now <= previous {
+                now = previous + crate::time::Duration::from_nanos(1);
+            }
+        }
         data.transmit_time = now;
 
         // Evict before storing to protect images with active placements
@@ -1209,26 +1225,27 @@ impl Graphics {
         // Actually remove the evicted graphics from the right home.
         for (id, source) in evicted {
             let evicted_u32 = id.get() as u32;
-            match source {
+            let removed_kitty = match source {
                 CandidateSource::Pending => {
                     self.pending.retain(|g| g.id != id);
                     // Its bytes join `freed_bytes` below; drop the size
                     // entry so a later placement release cannot subtract
                     // them a second time.
                     self.graphic_sizes.remove(&id);
+                    None
                 }
                 CandidateSource::ActiveKitty => {
-                    self.kitty_images.remove(&evicted_u32);
                     self.kitty_image_numbers.retain(|_, v| *v != evicted_u32);
                     self.kitty_graphics_dirty = true;
+                    self.kitty_images.remove(&evicted_u32)
                 }
                 CandidateSource::InactiveKitty => {
-                    self.kitty_inactive_screen.kitty_images.remove(&evicted_u32);
                     self.kitty_inactive_screen
                         .kitty_image_numbers
                         .retain(|_, v| *v != evicted_u32);
+                    self.kitty_inactive_screen.kitty_images.remove(&evicted_u32)
                 }
-            }
+            };
 
             // Remove timestamp (only used for pending atlas graphics)
             self.image_timestamps.remove(&id);
@@ -1236,11 +1253,21 @@ impl Graphics {
             // Add to removal queue so GPU textures get cleaned up.
             // The key namespace depends on where the image lived:
             // kitty ids map verbatim, atlas graphics live above 2^32.
+            // A kitty texture is only freed when it holds the evicted
+            // pixels; otherwise it belongs to the other screen's image
+            // of the same id and stays.
             let key = match source {
                 CandidateSource::Pending => rio_graphics::atlas_image_key(id.get()),
                 CandidateSource::ActiveKitty | CandidateSource::InactiveKitty => {
-                    self.kitty_texture_contents.remove(&(id.get() as u32));
-                    rio_graphics::kitty_image_key(id.get() as u32)
+                    let holds_evicted = removed_kitty.is_some_and(|img| {
+                        self.kitty_texture_contents.get(&evicted_u32)
+                            == Some(&img.transmission_time)
+                    });
+                    if !holds_evicted {
+                        continue;
+                    }
+                    self.kitty_texture_contents.remove(&evicted_u32);
+                    rio_graphics::kitty_image_key(evicted_u32)
                 }
             };
             self.texture_operations.lock().push(key);
@@ -1276,8 +1303,8 @@ impl Graphics {
         // Update total_bytes
         self.total_bytes = self.total_bytes.saturating_sub(freed_bytes);
 
-        // Evicting the other screen's same-id image freed a texture the
-        // active screen may still draw from.
+        // Evicting an image whose texture the active screen still draws
+        // from (its own copy, freed above) needs the pixels back.
         self.requeue_placed_kitty_images();
 
         debug!(
@@ -1772,15 +1799,72 @@ fn test_kitty_texture_contents_tracks_uploads_across_screens() {
     assert!(graphics.is_kitty_uploaded(1));
     graphics.pending_images.clear();
 
-    // Evicting the inactive same-id image frees the texture, so the
-    // placed active image is queued again right away.
+    // Evicting the inactive same-id image leaves the texture alone: it
+    // holds the active copy, so nothing is freed or resent.
     graphics.store_kitty_image(2, None, image(2, 40));
     assert!(graphics.kitty_inactive_screen.kitty_images.is_empty());
     assert!(graphics.is_kitty_uploaded(1));
+    assert!(graphics.pending_images.is_empty());
+    assert!(graphics.texture_operations.lock().is_empty());
+
+    // The reverse: the inactive copy owns the texture and the active
+    // placed image is stale. Evicting the inactive copy frees the
+    // texture and the active image is resent right away.
+    graphics.kitty_images.remove(&2);
+    graphics.total_bytes = 1600;
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    graphics.kitty_inactive_screen.kitty_images.insert(
+        1,
+        StoredImage {
+            data: image(1, 30),
+            transmission_time: crate::time::Instant::now(),
+        },
+    );
+    graphics.total_bytes += 3600;
+    let inactive_time = graphics.kitty_inactive_screen.kitty_images[&1].transmission_time;
+    graphics.kitty_texture_contents.insert(1, inactive_time);
+    assert!(!graphics.is_kitty_uploaded(1));
+    graphics.store_kitty_image(2, None, image(2, 40));
+    assert!(graphics.kitty_inactive_screen.kitty_images.is_empty());
+    assert!(graphics
+        .texture_operations
+        .lock()
+        .contains(&rio_graphics::kitty_image_key(1)));
+    assert!(graphics.is_kitty_uploaded(1));
     assert_eq!(graphics.pending_images.len(), 1);
     assert_eq!(graphics.pending_images[0].0, 1);
+    assert_eq!(graphics.pending_images[0].1.width, 20);
 
     // Full reset forgets the texture contents.
     graphics.clear_all_kitty_state();
     assert!(graphics.kitty_texture_contents.is_empty());
+}
+
+#[test]
+fn test_kitty_store_never_repeats_transmission_time() {
+    use rio_graphics::ColorType;
+    let mut graphics = Graphics::default();
+    let image = || GraphicData {
+        id: GraphicId::new(1),
+        width: 1,
+        height: 1,
+        color_type: ColorType::Rgba,
+        pixels: vec![0u8; 4],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: crate::time::Instant::now(),
+    };
+    graphics.store_kitty_image(1, None, image());
+    let first = graphics.get_kitty_image(1).unwrap().transmission_time;
+    assert!(graphics.queue_kitty_upload(1));
+    graphics.store_kitty_image(1, None, image());
+    let second = graphics.get_kitty_image(1).unwrap().transmission_time;
+    assert!(second > first);
+    assert!(!graphics.is_kitty_uploaded(1));
+    assert_eq!(
+        graphics.get_kitty_image(1).unwrap().data.transmit_time,
+        second
+    );
 }

--- a/rio-vt/src/ansi/graphics.rs
+++ b/rio-vt/src/ansi/graphics.rs
@@ -33,12 +33,6 @@ pub const KITTY_PLACEHOLDER: char = '\u{10EEEE}';
 pub struct StoredImage {
     pub data: GraphicData,
     pub transmission_time: crate::time::Instant,
-    /// Whether the frontend texture keyed by this image id currently
-    /// holds these pixels. GPU textures are per window while image
-    /// stores are per screen, so a same-id image on the other screen
-    /// can overwrite the texture; `swap_kitty_screen_state` accounts
-    /// for that.
-    pub gpu_uploaded: bool,
 }
 
 /// Overlay placement for a kitty graphics image.
@@ -660,6 +654,14 @@ pub struct Graphics {
     /// keeps its own image set.
     pub kitty_inactive_screen: KittyScreenState,
 
+    /// Which pixels the frontend texture for each kitty image id holds,
+    /// by the `transmission_time` of the store they were queued from.
+    /// Textures are per window while image stores are per screen, so
+    /// this is deliberately not swapped with the screens: a same-id
+    /// image on the other screen overwrites the texture, and an
+    /// eviction on either screen frees it.
+    pub kitty_texture_contents: FxHashMap<u32, crate::time::Instant>,
+
     /// Counter for auto-assigning internal placement IDs.
     ///
     /// Per kitty spec, when a client asks to place an image without an
@@ -698,6 +700,7 @@ impl Default for Graphics {
             atlas_placements: Vec::new(),
             atlas_key_refs: FxHashMap::default(),
             kitty_inactive_screen: KittyScreenState::default(),
+            kitty_texture_contents: FxHashMap::default(),
             next_internal_placement_id: 0,
             kitty_graphics_dirty: false,
         }
@@ -877,43 +880,53 @@ impl Graphics {
             &mut self.kitty_inactive_screen.atlas_key_refs,
         );
         self.kitty_graphics_dirty = true;
+        self.requeue_placed_kitty_images()
+    }
 
-        let mut queued = false;
-        for (id, incoming) in self.kitty_images.iter_mut() {
-            let outgoing_uploaded = self
-                .kitty_inactive_screen
-                .kitty_images
-                .get(id)
-                .is_some_and(|outgoing| outgoing.gpu_uploaded);
-            if !outgoing_uploaded {
-                continue;
+    /// Whether the frontend texture for `image_id` holds the pixels of
+    /// the active screen's stored image.
+    pub fn is_kitty_uploaded(&self, image_id: u32) -> bool {
+        match self.kitty_images.get(&image_id) {
+            Some(stored) => {
+                self.kitty_texture_contents.get(&image_id)
+                    == Some(&stored.transmission_time)
             }
-            let placed = self.kitty_placements.keys().any(|(img, _)| img == id)
-                || self
-                    .kitty_virtual_placements
-                    .keys()
-                    .any(|(img, _)| img == id);
-            incoming.gpu_uploaded = placed;
-            if placed {
-                self.pending_images.push((*id, incoming.data.clone()));
-                queued = true;
-            }
+            None => false,
         }
-        queued
     }
 
     /// Queue the stored pixels of `image_id` for the GPU unless the
     /// texture already holds them. Returns whether an upload was queued.
     pub fn queue_kitty_upload(&mut self, image_id: u32) -> bool {
-        let Some(stored) = self.kitty_images.get_mut(&image_id) else {
-            return false;
-        };
-        if stored.gpu_uploaded {
+        if self.is_kitty_uploaded(image_id) {
             return false;
         }
-        stored.gpu_uploaded = true;
+        let Some(stored) = self.kitty_images.get(&image_id) else {
+            return false;
+        };
+        self.kitty_texture_contents
+            .insert(image_id, stored.transmission_time);
         self.pending_images.push((image_id, stored.data.clone()));
         true
+    }
+
+    /// Resend every placed image on the active screen whose texture no
+    /// longer holds its pixels. Returns whether anything was queued.
+    fn requeue_placed_kitty_images(&mut self) -> bool {
+        let mut stale: Vec<u32> = self
+            .kitty_placements
+            .keys()
+            .chain(self.kitty_virtual_placements.keys())
+            .map(|(img, _)| *img)
+            .filter(|img| !self.is_kitty_uploaded(*img))
+            .collect();
+        stale.sort_unstable();
+        stale.dedup();
+        let mut queued = false;
+        for img in stale {
+            queued |= self.queue_kitty_upload(img);
+        }
+        queued
     }
 
     /// Clear all kitty graphics state on both screens. Used by full reset.
@@ -932,6 +945,7 @@ impl Graphics {
         self.kitty_image_numbers.clear();
         self.kitty_placements.clear();
         self.kitty_virtual_placements.clear();
+        self.kitty_texture_contents.clear();
 
         // Sixel/iTerm2 placements die with the reset too; queue every
         // referenced key (both screens) so the frontend frees the
@@ -1007,7 +1021,6 @@ impl Graphics {
             StoredImage {
                 data,
                 transmission_time: now,
-                gpu_uploaded: false,
             },
         );
         self.total_bytes += new_bytes;
@@ -1226,6 +1239,7 @@ impl Graphics {
             let key = match source {
                 CandidateSource::Pending => rio_graphics::atlas_image_key(id.get()),
                 CandidateSource::ActiveKitty | CandidateSource::InactiveKitty => {
+                    self.kitty_texture_contents.remove(&(id.get() as u32));
                     rio_graphics::kitty_image_key(id.get() as u32)
                 }
             };
@@ -1262,6 +1276,10 @@ impl Graphics {
         // Update total_bytes
         self.total_bytes = self.total_bytes.saturating_sub(freed_bytes);
 
+        // Evicting the other screen's same-id image freed a texture the
+        // active screen may still draw from.
+        self.requeue_placed_kitty_images();
+
         debug!(
             "Evicted {} bytes, new total: {}",
             freed_bytes, self.total_bytes
@@ -1281,6 +1299,9 @@ impl Graphics {
         // Overlay-based (kitty) liveness — use image_id directly
         for placement in self.kitty_placements.values() {
             active.insert(placement.image_id as u64);
+        }
+        for (img, _) in self.kitty_virtual_placements.keys() {
+            active.insert(*img as u64);
         }
         active
     }
@@ -1674,9 +1695,9 @@ fn test_kitty_eviction_protects_virtual_placements_and_sweeps_dangling() {
         .insert((7, 1), vp(7));
     std::thread::sleep(std::time::Duration::from_millis(5));
 
-    // Image 1 is older but virtually placed, so image 2 without a
-    // placement would go first; here both are placed, so the oldest
-    // placed one (1) is the last resort and 2 stays too until needed.
+    // Image 1 is older but virtually placed; image 2 lost its placement
+    // and goes first. The inactive screen's placement of a missing
+    // image is swept as dangling.
     graphics.kitty_virtual_placements.remove(&(2, 1));
     graphics.store_kitty_image(3, None, image(3));
     assert!(graphics.kitty_images.contains_key(&1));
@@ -1687,4 +1708,79 @@ fn test_kitty_eviction_protects_virtual_placements_and_sweeps_dangling() {
         .kitty_inactive_screen
         .kitty_virtual_placements
         .contains_key(&(7, 1)));
+}
+
+#[test]
+fn test_kitty_texture_contents_tracks_uploads_across_screens() {
+    use rio_graphics::ColorType;
+    let mut graphics = Graphics {
+        total_limit: 8_000,
+        ..Graphics::default()
+    };
+    let image = |id: u32, side: usize| GraphicData {
+        id: GraphicId::new(id as u64),
+        width: side,
+        height: side,
+        color_type: ColorType::Rgba,
+        pixels: vec![0u8; side * side * 4],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: crate::time::Instant::now(),
+    };
+    let vp = VirtualPlacement {
+        image_id: 1,
+        placement_id: 1,
+        columns: 2,
+        rows: 2,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    };
+
+    // Unknown image: nothing to upload, nothing recorded.
+    assert!(!graphics.queue_kitty_upload(1));
+    assert!(!graphics.is_kitty_uploaded(1));
+
+    graphics.store_kitty_image(1, None, image(1, 10));
+    assert!(!graphics.is_kitty_uploaded(1));
+    assert!(graphics.queue_kitty_upload(1));
+    assert!(graphics.is_kitty_uploaded(1));
+    assert!(!graphics.queue_kitty_upload(1));
+    assert_eq!(graphics.pending_images.len(), 1);
+    graphics.kitty_virtual_placements.insert((1, 1), vp.clone());
+
+    // A retransmit changes the transmission time; the texture is stale.
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    graphics.store_kitty_image(1, None, image(1, 20));
+    assert!(!graphics.is_kitty_uploaded(1));
+    assert!(graphics.queue_kitty_upload(1));
+
+    // The other screen uploads its own image 1: the record follows the
+    // texture, not the screen.
+    assert!(!graphics.swap_kitty_screen_state());
+    graphics.store_kitty_image(1, None, image(1, 30));
+    assert!(graphics.queue_kitty_upload(1));
+    graphics.pending_images.clear();
+
+    // Coming back, the placed main-screen image is resent once.
+    assert!(graphics.swap_kitty_screen_state());
+    assert_eq!(graphics.pending_images.len(), 1);
+    assert_eq!(graphics.pending_images[0].1.width, 20);
+    assert!(graphics.is_kitty_uploaded(1));
+    graphics.pending_images.clear();
+
+    // Evicting the inactive same-id image frees the texture, so the
+    // placed active image is queued again right away.
+    graphics.store_kitty_image(2, None, image(2, 40));
+    assert!(graphics.kitty_inactive_screen.kitty_images.is_empty());
+    assert!(graphics.is_kitty_uploaded(1));
+    assert_eq!(graphics.pending_images.len(), 1);
+    assert_eq!(graphics.pending_images[0].0, 1);
+
+    // Full reset forgets the texture contents.
+    graphics.clear_all_kitty_state();
+    assert!(graphics.kitty_texture_contents.is_empty());
 }

--- a/rio-vt/src/ansi/graphics.rs
+++ b/rio-vt/src/ansi/graphics.rs
@@ -33,6 +33,12 @@ pub const KITTY_PLACEHOLDER: char = '\u{10EEEE}';
 pub struct StoredImage {
     pub data: GraphicData,
     pub transmission_time: crate::time::Instant,
+    /// Whether the frontend texture keyed by this image id currently
+    /// holds these pixels. GPU textures are per window while image
+    /// stores are per screen, so a same-id image on the other screen
+    /// can overwrite the texture; `swap_kitty_screen_state` accounts
+    /// for that.
+    pub gpu_uploaded: bool,
 }
 
 /// Overlay placement for a kitty graphics image.
@@ -842,7 +848,10 @@ impl Graphics {
         }
     }
 
-    pub fn swap_kitty_screen_state(&mut self) {
+    /// Returns whether pixel uploads were queued: an image on the
+    /// incoming screen whose id was also uploaded by the outgoing
+    /// screen no longer owns its texture and, if placed, is resent.
+    pub fn swap_kitty_screen_state(&mut self) -> bool {
         std::mem::swap(
             &mut self.kitty_images,
             &mut self.kitty_inactive_screen.kitty_images,
@@ -868,6 +877,43 @@ impl Graphics {
             &mut self.kitty_inactive_screen.atlas_key_refs,
         );
         self.kitty_graphics_dirty = true;
+
+        let mut queued = false;
+        for (id, incoming) in self.kitty_images.iter_mut() {
+            let outgoing_uploaded = self
+                .kitty_inactive_screen
+                .kitty_images
+                .get(id)
+                .is_some_and(|outgoing| outgoing.gpu_uploaded);
+            if !outgoing_uploaded {
+                continue;
+            }
+            let placed = self.kitty_placements.keys().any(|(img, _)| img == id)
+                || self
+                    .kitty_virtual_placements
+                    .keys()
+                    .any(|(img, _)| img == id);
+            incoming.gpu_uploaded = placed;
+            if placed {
+                self.pending_images.push((*id, incoming.data.clone()));
+                queued = true;
+            }
+        }
+        queued
+    }
+
+    /// Queue the stored pixels of `image_id` for the GPU unless the
+    /// texture already holds them. Returns whether an upload was queued.
+    pub fn queue_kitty_upload(&mut self, image_id: u32) -> bool {
+        let Some(stored) = self.kitty_images.get_mut(&image_id) else {
+            return false;
+        };
+        if stored.gpu_uploaded {
+            return false;
+        }
+        stored.gpu_uploaded = true;
+        self.pending_images.push((image_id, stored.data.clone()));
+        true
     }
 
     /// Clear all kitty graphics state on both screens. Used by full reset.
@@ -943,6 +989,9 @@ impl Graphics {
             for placement in self.kitty_placements.values() {
                 active.insert(placement.image_id as u64);
             }
+            for (img, _) in self.kitty_virtual_placements.keys() {
+                active.insert(*img as u64);
+            }
             // Also protect the image we're about to store
             active.insert(image_id as u64);
             self.evict_images(new_bytes, &active);
@@ -958,6 +1007,7 @@ impl Graphics {
             StoredImage {
                 data,
                 transmission_time: now,
+                gpu_uploaded: false,
             },
         );
         self.total_bytes += new_bytes;
@@ -1194,6 +1244,8 @@ impl Graphics {
             self.kitty_images.keys().copied().collect();
         self.kitty_placements
             .retain(|_, p| active_ids.contains(&p.image_id));
+        self.kitty_virtual_placements
+            .retain(|(img, _), _| active_ids.contains(img));
         let inactive_ids: std::collections::HashSet<u32> = self
             .kitty_inactive_screen
             .kitty_images
@@ -1203,6 +1255,9 @@ impl Graphics {
         self.kitty_inactive_screen
             .kitty_placements
             .retain(|_, p| inactive_ids.contains(&p.image_id));
+        self.kitty_inactive_screen
+            .kitty_virtual_placements
+            .retain(|(img, _), _| inactive_ids.contains(img));
 
         // Update total_bytes
         self.total_bytes = self.total_bytes.saturating_sub(freed_bytes);
@@ -1576,4 +1631,60 @@ fn test_graphics_no_eviction_when_under_limit() {
     // No eviction should occur
     assert_eq!(graphics.pending.len(), 1);
     assert_eq!(graphics.total_bytes, 50_000);
+}
+
+#[test]
+fn test_kitty_eviction_protects_virtual_placements_and_sweeps_dangling() {
+    use rio_graphics::ColorType;
+    let mut graphics = Graphics {
+        total_limit: 100_000,
+        ..Graphics::default()
+    };
+    let image = |id: u32| GraphicData {
+        id: GraphicId::new(id as u64),
+        width: 100,
+        height: 100,
+        color_type: ColorType::Rgba,
+        pixels: vec![0u8; 40_000],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: crate::time::Instant::now(),
+    };
+    let vp = |id: u32| VirtualPlacement {
+        image_id: id,
+        placement_id: 1,
+        columns: 2,
+        rows: 2,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    };
+
+    graphics.store_kitty_image(1, None, image(1));
+    graphics.kitty_virtual_placements.insert((1, 1), vp(1));
+    std::thread::sleep(std::time::Duration::from_millis(5));
+    graphics.store_kitty_image(2, None, image(2));
+    graphics.kitty_virtual_placements.insert((2, 1), vp(2));
+    graphics
+        .kitty_inactive_screen
+        .kitty_virtual_placements
+        .insert((7, 1), vp(7));
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    // Image 1 is older but virtually placed, so image 2 without a
+    // placement would go first; here both are placed, so the oldest
+    // placed one (1) is the last resort and 2 stays too until needed.
+    graphics.kitty_virtual_placements.remove(&(2, 1));
+    graphics.store_kitty_image(3, None, image(3));
+    assert!(graphics.kitty_images.contains_key(&1));
+    assert!(!graphics.kitty_images.contains_key(&2));
+    assert!(graphics.kitty_images.contains_key(&3));
+    assert!(graphics.kitty_virtual_placements.contains_key(&(1, 1)));
+    assert!(!graphics
+        .kitty_inactive_screen
+        .kitty_virtual_placements
+        .contains_key(&(7, 1)));
 }

--- a/rio-vt/src/ansi/graphics.rs
+++ b/rio-vt/src/ansi/graphics.rs
@@ -946,7 +946,14 @@ impl Graphics {
         self.kitty_image_numbers.clear();
         self.kitty_placements.clear();
         self.kitty_virtual_placements.clear();
+        {
+            let mut removals = self.texture_operations.lock();
+            for id in self.kitty_texture_contents.keys() {
+                removals.push(rio_graphics::kitty_image_key(*id));
+            }
+        }
         self.kitty_texture_contents.clear();
+        self.pending_images.clear();
 
         // Sixel/iTerm2 placements die with the reset too; queue every
         // referenced key (both screens) so the frontend frees the
@@ -1002,6 +1009,12 @@ impl Graphics {
             .get(&image_id)
             .map(|old| old.transmission_time)
             .into_iter()
+            .chain(
+                self.kitty_inactive_screen
+                    .kitty_images
+                    .get(&image_id)
+                    .map(|old| old.transmission_time),
+            )
             .chain(self.kitty_texture_contents.get(&image_id).copied())
             .max();
         if let Some(previous) = previous {
@@ -1066,14 +1079,50 @@ impl Graphics {
         &mut self,
         predicate: impl Fn(&u32, &StoredImage) -> bool,
     ) {
-        let before = self.kitty_images.len();
-        self.kitty_images.retain(|id, img| !predicate(id, img));
-        if self.kitty_images.len() != before {
+        let mut released = Vec::new();
+        self.kitty_images.retain(|id, img| {
+            let delete = predicate(id, img);
+            if delete {
+                released.push((*id, img.transmission_time));
+            }
+            !delete
+        });
+        if !released.is_empty() {
             self.kitty_graphics_dirty = true;
         }
-        // Clean up stale number mappings
+        for (id, transmission_time) in released {
+            self.release_kitty_texture(id, transmission_time);
+        }
+        // Clean up stale number mappings and placements of the images
+        // that are gone.
         self.kitty_image_numbers
             .retain(|_, id| self.kitty_images.contains_key(id));
+        self.kitty_placements
+            .retain(|_, p| self.kitty_images.contains_key(&p.image_id));
+        self.kitty_virtual_placements
+            .retain(|(img, _), _| self.kitty_images.contains_key(img));
+    }
+
+    /// Free the frontend texture for `image_id` if it holds the pixels
+    /// of the store stamped `transmission_time`; a texture holding the
+    /// other screen's image of the same id stays. Returns whether a
+    /// removal was queued.
+    fn release_kitty_texture(
+        &mut self,
+        image_id: u32,
+        transmission_time: crate::time::Instant,
+    ) -> bool {
+        if self.kitty_texture_contents.get(&image_id) != Some(&transmission_time) {
+            return false;
+        }
+        self.kitty_texture_contents.remove(&image_id);
+        // An upload of these pixels still waiting in the queue would
+        // land after the removal.
+        self.pending_images.retain(|(img, _)| *img != image_id);
+        self.texture_operations
+            .lock()
+            .push(rio_graphics::kitty_image_key(image_id));
+        true
     }
 
     /// Calculate the memory size of a graphic in bytes
@@ -1256,21 +1305,18 @@ impl Graphics {
             // A kitty texture is only freed when it holds the evicted
             // pixels; otherwise it belongs to the other screen's image
             // of the same id and stays.
-            let key = match source {
-                CandidateSource::Pending => rio_graphics::atlas_image_key(id.get()),
-                CandidateSource::ActiveKitty | CandidateSource::InactiveKitty => {
-                    let holds_evicted = removed_kitty.is_some_and(|img| {
-                        self.kitty_texture_contents.get(&evicted_u32)
-                            == Some(&img.transmission_time)
-                    });
-                    if !holds_evicted {
-                        continue;
-                    }
-                    self.kitty_texture_contents.remove(&evicted_u32);
-                    rio_graphics::kitty_image_key(evicted_u32)
+            match source {
+                CandidateSource::Pending => {
+                    self.texture_operations
+                        .lock()
+                        .push(rio_graphics::atlas_image_key(id.get()));
                 }
-            };
-            self.texture_operations.lock().push(key);
+                CandidateSource::ActiveKitty | CandidateSource::InactiveKitty => {
+                    if let Some(img) = removed_kitty {
+                        self.release_kitty_texture(evicted_u32, img.transmission_time);
+                    }
+                }
+            }
         }
 
         // Sweep dangling placements on both screens. A placement is
@@ -1867,4 +1913,96 @@ fn test_kitty_store_never_repeats_transmission_time() {
         graphics.get_kitty_image(1).unwrap().data.transmit_time,
         second
     );
+}
+
+#[test]
+fn test_kitty_eviction_cancels_pending_upload_of_evicted_image() {
+    use rio_graphics::ColorType;
+    let mut graphics = Graphics {
+        total_limit: 8_000,
+        ..Graphics::default()
+    };
+    let image = |id: u32, side: usize| GraphicData {
+        id: GraphicId::new(id as u64),
+        width: side,
+        height: side,
+        color_type: ColorType::Rgba,
+        pixels: vec![0u8; side * side * 4],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: crate::time::Instant::now(),
+    };
+
+    // Image 1 is uploaded but not placed, so it is the eviction
+    // candidate when image 2 does not fit; both happen in one batch.
+    graphics.store_kitty_image(1, None, image(1, 30));
+    assert!(graphics.queue_kitty_upload(1));
+    graphics.store_kitty_image(2, None, image(2, 40));
+    assert!(graphics.get_kitty_image(1).is_none());
+    assert!(graphics.pending_images.iter().all(|(img, _)| *img != 1));
+    assert!(graphics
+        .texture_operations
+        .lock()
+        .contains(&rio_graphics::kitty_image_key(1)));
+    assert!(!graphics.kitty_texture_contents.contains_key(&1));
+}
+
+#[test]
+fn test_kitty_delete_frees_texture_only_when_it_holds_the_pixels() {
+    use rio_graphics::ColorType;
+    let mut graphics = Graphics::default();
+    let image = |id: u32| GraphicData {
+        id: GraphicId::new(id as u64),
+        width: 1,
+        height: 1,
+        color_type: ColorType::Rgba,
+        pixels: vec![0u8; 4],
+        is_opaque: true,
+        resize: None,
+        display_width: None,
+        display_height: None,
+        transmit_time: crate::time::Instant::now(),
+    };
+    graphics.store_kitty_image(1, None, image(1));
+    assert!(graphics.queue_kitty_upload(1));
+    graphics.store_kitty_image(2, None, image(2));
+
+    // Image 2 was never uploaded: nothing to free.
+    graphics.delete_kitty_images(|id, _| *id == 2);
+    assert!(graphics.texture_operations.lock().is_empty());
+
+    // The other screen's copy of id 1 owns the texture: deleting the
+    // active copy leaves it alone.
+    assert!(!graphics.swap_kitty_screen_state());
+    graphics.store_kitty_image(1, None, image(1));
+    assert!(graphics.queue_kitty_upload(1));
+    assert!(!graphics.swap_kitty_screen_state());
+    graphics.delete_kitty_images(|id, _| *id == 1);
+    assert!(graphics.texture_operations.lock().is_empty());
+    assert!(graphics.kitty_texture_contents.contains_key(&1));
+
+    // Deleting the owning copy frees it and drops a pending resend.
+    assert!(!graphics.swap_kitty_screen_state());
+    graphics.pending_images.clear();
+    graphics.delete_kitty_images(|id, _| *id == 1);
+    assert!(graphics
+        .texture_operations
+        .lock()
+        .contains(&rio_graphics::kitty_image_key(1)));
+    assert!(!graphics.kitty_texture_contents.contains_key(&1));
+    assert!(graphics.pending_images.is_empty());
+
+    // A full reset frees whatever the record still names.
+    graphics.store_kitty_image(3, None, image(3));
+    assert!(graphics.queue_kitty_upload(3));
+    graphics.texture_operations.lock().clear();
+    graphics.clear_all_kitty_state();
+    assert!(graphics
+        .texture_operations
+        .lock()
+        .contains(&rio_graphics::kitty_image_key(3)));
+    assert!(graphics.pending_images.is_empty());
+    assert!(graphics.kitty_texture_contents.is_empty());
 }

--- a/rio-vt/src/ansi/kitty_virtual.rs
+++ b/rio-vt/src/ansi/kitty_virtual.rs
@@ -654,19 +654,20 @@ pub fn compute_run_geometry(
 ///
 /// The placement id comes from the cell's underline color. Per the
 /// kitty spec, "if it's omitted or zero, the terminal may choose any
-/// virtual placement of the given image" — and clients routinely
-/// omit it: Neovim's TUI only emits the underline color (SGR 58) for
-/// cells that carry an underline attribute, so snacks.image's
-/// placeholder cells always arrive with `placement_id == 0` even
-/// though the placement was registered with `p=N`. kitty
-/// (`graphics.c`, `find the first virtual image placement`) and
-/// ghostty (`graphics_unicode.zig`, `placeholderTarget`) both fall
-/// back to the first virtual placement of the image in that case.
+/// virtual placement of the given image", and clients routinely omit
+/// it: Neovim's TUI only emits the underline color (SGR 58) for cells
+/// that carry an underline attribute, so snacks.image's placeholder
+/// cells always arrive with `placement_id == 0` even though the
+/// placement was registered with `p=N`. An absent underline color and
+/// an explicit black one both decode to 0 (`color_to_id`), matching
+/// kitty.
 ///
-/// A non-zero id must match exactly, as in kitty. For id 0 the
-/// placement with the lowest id is chosen so the result does not
-/// depend on hash-map iteration order (an explicit `p=0` placement
-/// therefore still wins).
+/// A non-zero id must match exactly, as in kitty (`graphics.c`,
+/// `grman_put_cell_image`). For id 0 kitty takes the first virtual
+/// placement its hash table happens to yield; the spec allows any, so
+/// the placement with the lowest id is chosen here instead, so the
+/// result never depends on iteration order (an explicit `p=0`
+/// placement therefore still wins).
 pub fn resolve_virtual_placement(
     placements: &FxHashMap<(u32, u32), VirtualPlacement>,
     image_id: u32,
@@ -674,6 +675,9 @@ pub fn resolve_virtual_placement(
 ) -> Option<&VirtualPlacement> {
     if placement_id != 0 {
         return placements.get(&(image_id, placement_id));
+    }
+    if let Some(vp) = placements.get(&(image_id, 0)) {
+        return Some(vp);
     }
     placements
         .iter()

--- a/rio-vt/src/ansi/kitty_virtual.rs
+++ b/rio-vt/src/ansi/kitty_virtual.rs
@@ -1,6 +1,8 @@
 // Kitty graphics protocol virtual placement encoding/decoding
 
+use crate::ansi::graphics::VirtualPlacement;
 use crate::config::colors::{AnsiColor, ColorRgb};
+use rustc_hash::FxHashMap;
 
 /// The Kitty Unicode placeholder codepoint (U+10EEEE). Cells containing
 /// this codepoint are interpreted as image placeholders; their fg color
@@ -648,9 +650,90 @@ pub fn compute_run_geometry(
     })
 }
 
+/// Resolve the virtual placement a placeholder run refers to.
+///
+/// The placement id comes from the cell's underline color. Per the
+/// kitty spec, "if it's omitted or zero, the terminal may choose any
+/// virtual placement of the given image" — and clients routinely
+/// omit it: Neovim's TUI only emits the underline color (SGR 58) for
+/// cells that carry an underline attribute, so snacks.image's
+/// placeholder cells always arrive with `placement_id == 0` even
+/// though the placement was registered with `p=N`. kitty
+/// (`graphics.c`, `find the first virtual image placement`) and
+/// ghostty (`graphics_unicode.zig`, `placeholderTarget`) both fall
+/// back to the first virtual placement of the image in that case.
+///
+/// A non-zero id must match exactly, as in kitty. For id 0 the
+/// placement with the lowest id is chosen so the result does not
+/// depend on hash-map iteration order (an explicit `p=0` placement
+/// therefore still wins).
+pub fn resolve_virtual_placement(
+    placements: &FxHashMap<(u32, u32), VirtualPlacement>,
+    image_id: u32,
+    placement_id: u32,
+) -> Option<&VirtualPlacement> {
+    if placement_id != 0 {
+        return placements.get(&(image_id, placement_id));
+    }
+    placements
+        .iter()
+        .filter(|((img, _), _)| *img == image_id)
+        .min_by_key(|((_, pid), _)| *pid)
+        .map(|(_, vp)| vp)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn vp(image_id: u32, placement_id: u32) -> VirtualPlacement {
+        VirtualPlacement {
+            image_id,
+            placement_id,
+            columns: 4,
+            rows: 2,
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        }
+    }
+
+    #[test]
+    fn resolve_zero_placement_id_falls_back_to_any_placement_of_image() {
+        // snacks.image registers `p=11`; Neovim never sends the underline
+        // color for non-underlined cells, so the cells decode to id 0.
+        let mut m = FxHashMap::default();
+        m.insert((7, 11), vp(7, 11));
+        m.insert((8, 3), vp(8, 3));
+        let got = resolve_virtual_placement(&m, 7, 0).expect("placement");
+        assert_eq!((got.image_id, got.placement_id), (7, 11));
+        assert!(resolve_virtual_placement(&m, 9, 0).is_none());
+    }
+
+    #[test]
+    fn resolve_zero_placement_id_prefers_lowest_id() {
+        let mut m = FxHashMap::default();
+        m.insert((7, 11), vp(7, 11));
+        m.insert((7, 0), vp(7, 0));
+        m.insert((7, 5), vp(7, 5));
+        let got = resolve_virtual_placement(&m, 7, 0).unwrap();
+        assert_eq!(got.placement_id, 0);
+        m.remove(&(7, 0));
+        assert_eq!(resolve_virtual_placement(&m, 7, 0).unwrap().placement_id, 5);
+    }
+
+    #[test]
+    fn resolve_nonzero_placement_id_must_match_exactly() {
+        let mut m = FxHashMap::default();
+        m.insert((7, 11), vp(7, 11));
+        m.insert((7, 0), vp(7, 0));
+        assert_eq!(
+            resolve_virtual_placement(&m, 7, 11).unwrap().placement_id,
+            11
+        );
+        assert!(resolve_virtual_placement(&m, 7, 12).is_none());
+    }
 
     #[test]
     fn test_diacritic_conversion() {

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -4926,6 +4926,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
             self.refresh_placements_for_image(image_id, image_width, image_height);
             self.ensure_kitty_upload(image_id);
         }
+        self.send_graphics_updates();
     }
 
     fn kitty_transmit_and_display(
@@ -5544,7 +5545,7 @@ impl<U: EventListener> Crosswords<U> {
             }
         };
         let mut graphic_data = stored.data.clone();
-        let texture_current = stored.gpu_uploaded;
+        let texture_current = self.graphics.is_kitty_uploaded(image_id);
 
         let image_width = graphic_data.width;
         let image_height = graphic_data.height;
@@ -5703,12 +5704,12 @@ impl<U: EventListener> Crosswords<U> {
 
         // Only push pixel data when image data actually changed
         if needs_upload {
-            if let Some(stored) = self.graphics.kitty_images.get_mut(&image_id) {
-                stored.gpu_uploaded = true;
-            }
+            self.graphics
+                .kitty_texture_contents
+                .insert(image_id, transmit_time);
             self.graphics.pending_images.push((image_id, graphic_data));
-            self.send_graphics_updates();
         }
+        self.send_graphics_updates();
 
         // Handle cursor movement per kitty spec
         match placement.cursor_movement {
@@ -9755,10 +9756,7 @@ mod tests {
     }
 
     fn uploaded(cw: &Crosswords<VoidListener>, image_id: u32) -> bool {
-        cw.graphics
-            .get_kitty_image(image_id)
-            .map(|s| s.gpu_uploaded)
-            .unwrap_or(false)
+        cw.graphics.is_kitty_uploaded(image_id)
     }
 
     #[test]
@@ -9881,6 +9879,101 @@ mod tests {
         assert!(cw.graphics.pending_images.is_empty());
         assert!(!uploaded(&cw, 1));
         assert!(cw.ensure_kitty_upload(1));
+    }
+
+    #[test]
+    fn alt_screen_delete_still_invalidates_main_texture() {
+        use crate::ansi::kitty_graphics_protocol::DeleteRequest;
+        let mut cw = make_crosswords();
+        cw.store_graphic(kitty_test_image(1, 1, 1));
+        cw.place_graphic(virtual_request(1, 1));
+        assert!(uploaded(&cw, 1));
+
+        // The alt screen uploads its own image 1, then deletes it with
+        // its data before switching back; the texture still holds the
+        // alt pixels.
+        cw.swap_alt();
+        cw.store_graphic(kitty_test_image(1, 2, 2));
+        cw.place_graphic(virtual_request(1, 1));
+        cw.delete_graphics(DeleteRequest {
+            action: b'I',
+            delete_data: true,
+            image_id: 1,
+            image_number: 0,
+            placement_id: 0,
+            x: 0,
+            y: 0,
+            z_index: 0,
+        });
+        assert!(cw.graphics.get_kitty_image(1).is_none());
+
+        assert!(cw.graphics.swap_kitty_screen_state());
+        assert_eq!(cw.graphics.pending_images.len(), 1);
+        assert_eq!(cw.graphics.pending_images[0].1.width, 1);
+        assert!(uploaded(&cw, 1));
+    }
+
+    #[test]
+    fn alt_screen_retransmit_without_placement_invalidates_main_texture() {
+        let mut cw = make_crosswords();
+        cw.store_graphic(kitty_test_image(1, 1, 1));
+        cw.place_graphic(virtual_request(1, 1));
+
+        // Alt uploads image 1, drops its placements, then retransmits
+        // without placing: the texture holds the first alt pixels.
+        cw.swap_alt();
+        cw.store_graphic(kitty_test_image(1, 2, 2));
+        cw.place_graphic(virtual_request(1, 1));
+        cw.graphics.kitty_virtual_placements.clear();
+        cw.store_graphic(kitty_test_image(1, 3, 3));
+        assert!(!uploaded(&cw, 1));
+
+        assert!(cw.graphics.swap_kitty_screen_state());
+        assert_eq!(cw.graphics.pending_images.len(), 1);
+        assert_eq!(cw.graphics.pending_images[0].1.width, 1);
+        assert!(uploaded(&cw, 1));
+    }
+
+    #[test]
+    fn cursor_delete_with_data_keeps_virtually_placed_images() {
+        use crate::ansi::kitty_graphics_protocol::DeleteRequest;
+        let mut cw = make_crosswords();
+        cw.store_graphic(kitty_test_image(1, 1, 1));
+        cw.place_graphic(virtual_request(1, 1));
+        cw.store_graphic(kitty_test_image(2, 1, 1));
+        cw.delete_graphics(DeleteRequest {
+            action: b'C',
+            delete_data: true,
+            image_id: 0,
+            image_number: 0,
+            placement_id: 0,
+            x: 0,
+            y: 0,
+            z_index: 0,
+        });
+        assert!(cw.graphics.get_kitty_image(1).is_some());
+        assert!(cw.graphics.get_kitty_image(2).is_none());
+    }
+
+    #[test]
+    fn evicting_inactive_same_id_image_requeues_active_one() {
+        let mut cw = make_crosswords();
+        cw.graphics.total_limit = 100_000;
+        cw.store_graphic(kitty_test_image(1, 100, 100));
+        cw.place_graphic(virtual_request(1, 1));
+        assert!(uploaded(&cw, 1));
+
+        cw.swap_alt();
+        cw.store_graphic(kitty_test_image(1, 100, 100));
+        cw.swap_alt();
+        assert!(uploaded(&cw, 1));
+
+        // Storing image 2 has to evict; the inactive image 1 goes first
+        // and frees texture 1, which the active screen still draws.
+        cw.store_graphic(kitty_test_image(2, 100, 100));
+        assert!(cw.graphics.kitty_inactive_screen.kitty_images.is_empty());
+        assert!(cw.graphics.get_kitty_image(1).is_some());
+        assert!(uploaded(&cw, 1));
     }
 
     #[test]

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -5535,20 +5535,14 @@ impl<U: EventListener> Crosswords<U> {
         image_id: u32,
         placement: &crate::ansi::kitty_graphics_protocol::PlacementRequest,
     ) {
-        // Read image data from the store (clone needed: one copy for
-        // metadata/dimensions, consumed by pending push for GPU upload)
-        let stored = match self.graphics.get_kitty_image(image_id) {
-            Some(s) => s,
-            None => {
-                warn!("place_kitty_overlay: image {} not found", image_id);
-                return;
-            }
-        };
-        let mut graphic_data = stored.data.clone();
-        let texture_current = self.graphics.is_kitty_uploaded(image_id);
-
-        let image_width = graphic_data.width;
-        let image_height = graphic_data.height;
+        let (image_width, image_height, transmit_time) =
+            match self.graphics.get_kitty_image(image_id) {
+                Some(s) => (s.data.width, s.data.height, s.transmission_time),
+                None => {
+                    warn!("place_kitty_overlay: image {} not found", image_id);
+                    return;
+                }
+            };
         if image_width == 0 || image_height == 0 {
             return;
         }
@@ -5594,18 +5588,6 @@ impl<U: EventListener> Crosswords<U> {
         {
             return;
         }
-
-        // Set display dimensions for GPU scaling
-        graphic_data.display_width = Some(display_w);
-        graphic_data.display_height = Some(display_h);
-
-        // Get transmit_time from stored image for cache invalidation
-        let transmit_time = self
-            .graphics
-            .get_kitty_image(image_id)
-            .map(|s| s.transmission_time)
-            .unwrap_or_else(crate::time::Instant::now);
-        graphic_data.transmit_time = transmit_time;
 
         // Memory is managed in store_kitty_image (eviction happens there)
 
@@ -5685,30 +5667,12 @@ impl<U: EventListener> Crosswords<U> {
             transmit_time,
         };
 
-        // Check if this placement already exists with the same transmit_time
-        // (avoids re-uploading identical pixel data to GPU every frame)
-        let needs_upload = !texture_current
-            || match self
-                .graphics
-                .kitty_placements
-                .get(&(image_id, placement_id))
-            {
-                Some(existing) => existing.transmit_time != transmit_time,
-                None => true,
-            };
-
         self.graphics
             .kitty_placements
             .insert((image_id, placement_id), kitty_placement);
         self.graphics.kitty_graphics_dirty = true;
 
-        // Only push pixel data when image data actually changed
-        if needs_upload {
-            self.graphics
-                .kitty_texture_contents
-                .insert(image_id, transmit_time);
-            self.graphics.pending_images.push((image_id, graphic_data));
-        }
+        self.graphics.queue_kitty_upload(image_id);
         self.send_graphics_updates();
 
         // Handle cursor movement per kitty spec
@@ -9855,7 +9819,7 @@ mod tests {
         cw.graphics.pending_images.clear();
 
         // And the alt screen's image 1 is stale again when it returns;
-        // its unplaced image 2 only gets marked, not resent.
+        // its unplaced image 2 is not resent.
         assert!(cw.graphics.swap_kitty_screen_state());
         let queued: Vec<u32> = cw
             .graphics
@@ -9873,8 +9837,8 @@ mod tests {
             .kitty_virtual_placements
             .clear();
 
-        // Without a placement on the incoming screen nothing is resent,
-        // but the marker is dropped so a later placement uploads.
+        // Without a placement on the incoming screen nothing is resent;
+        // the record still mismatches, so a later placement uploads.
         assert!(!cw.graphics.swap_kitty_screen_state());
         assert!(cw.graphics.pending_images.is_empty());
         assert!(!uploaded(&cw, 1));
@@ -9968,12 +9932,19 @@ mod tests {
         cw.swap_alt();
         assert!(uploaded(&cw, 1));
 
-        // Storing image 2 has to evict; the inactive image 1 goes first
-        // and frees texture 1, which the active screen still draws.
+        // Storing image 2 has to evict; the inactive image 1 goes first.
+        // The texture holds the active copy, so it is neither freed nor
+        // resent.
         cw.store_graphic(kitty_test_image(2, 100, 100));
         assert!(cw.graphics.kitty_inactive_screen.kitty_images.is_empty());
         assert!(cw.graphics.get_kitty_image(1).is_some());
         assert!(uploaded(&cw, 1));
+        assert!(cw
+            .graphics
+            .texture_operations
+            .lock()
+            .iter()
+            .all(|key| *key != rio_graphics::kitty_image_key(1)));
     }
 
     #[test]

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -5028,16 +5028,15 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
         match delete.action {
             b'a' | b'A' => {
-                // Delete all placements — virtual (U=1) ones included:
-                // their placeholder cells keep rendering the image if
-                // the metadata survives, where kitty blanks them.
+                // "All placements visible on screen": virtual (U=1)
+                // placements are not visible by themselves and survive,
+                // as do the images they keep alive (kitty's
+                // clear_filter_func skips virtual refs).
+                overlay_changed = !self.graphics.kitty_placements.is_empty();
                 self.graphics.kitty_placements.clear();
-                self.graphics.kitty_virtual_placements.clear();
-                overlay_changed = true;
 
                 if delete.delete_data {
-                    self.graphics.kitty_images.clear();
-                    self.graphics.kitty_image_numbers.clear();
+                    self.cleanup_unused_kitty_images();
                 }
             }
             b'i' | b'I' => {
@@ -5224,11 +5223,17 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 let range_start = delete.x;
                 let range_end = delete.y;
                 if range_start > 0 && range_end >= range_start {
-                    let before = self.graphics.kitty_placements.len();
+                    let before = self.graphics.kitty_placements.len()
+                        + self.graphics.kitty_virtual_placements.len();
                     self.graphics
                         .kitty_placements
                         .retain(|k, _| k.0 < range_start || k.0 > range_end);
-                    overlay_changed = self.graphics.kitty_placements.len() != before;
+                    self.graphics
+                        .kitty_virtual_placements
+                        .retain(|k, _| k.0 < range_start || k.0 > range_end);
+                    overlay_changed = self.graphics.kitty_placements.len()
+                        + self.graphics.kitty_virtual_placements.len()
+                        != before;
 
                     if delete.delete_data {
                         self.graphics.delete_kitty_images(|id, _| {
@@ -9511,9 +9516,8 @@ mod tests {
     /// placeholder cells itself as ordinary text afterwards. This test
     /// pins that contract: previously rio also auto-wrote the cells,
     /// which raced kitty's own writes and broke the rendering.
-    /// `a=d,d=i` (and `d=a`) must remove virtual (U=1) placements —
-    /// their placeholder cells keep rendering the image if the metadata
-    /// survives, where kitty blanks them.
+    /// `a=d,d=i` must remove virtual (U=1) placements, while `d=a`
+    /// ("all visible placements") leaves them alone as kitty does.
     #[test]
     fn delete_removes_virtual_placements() {
         use crate::ansi::kitty_graphics_protocol::{DeleteRequest, PlacementRequest};
@@ -9593,9 +9597,10 @@ mod tests {
         assert_eq!(cw.graphics.kitty_virtual_placements.len(), 1);
         assert!(cw.graphics.kitty_virtual_placements.contains_key(&(2, 5)));
 
-        // Delete all.
+        // Delete all visible placements: virtual ones are not visible
+        // by themselves and stay.
         cw.delete_graphics(delete(b'a', 0, 0));
-        assert!(cw.graphics.kitty_virtual_placements.is_empty());
+        assert!(cw.graphics.kitty_virtual_placements.contains_key(&(2, 5)));
     }
 
     #[test]
@@ -9920,7 +9925,7 @@ mod tests {
     }
 
     #[test]
-    fn evicting_inactive_same_id_image_requeues_active_one() {
+    fn evicting_inactive_same_id_image_keeps_active_texture() {
         let mut cw = make_crosswords();
         cw.graphics.total_limit = 100_000;
         cw.store_graphic(kitty_test_image(1, 100, 100));
@@ -9945,6 +9950,73 @@ mod tests {
             .lock()
             .iter()
             .all(|key| *key != rio_graphics::kitty_image_key(1)));
+    }
+
+    #[test]
+    fn delete_all_keeps_virtual_placements_and_their_images() {
+        use crate::ansi::kitty_graphics_protocol::{DeleteRequest, PlacementRequest};
+        let mut cw = make_crosswords();
+        cw.graphics.cell_width = 10.0;
+        cw.graphics.cell_height = 20.0;
+        cw.store_graphic(kitty_test_image(1, 10, 20));
+        cw.place_graphic(virtual_request(1, 1));
+        cw.store_graphic(kitty_test_image(2, 10, 20));
+        cw.place_graphic(PlacementRequest {
+            virtual_placement: false,
+            columns: 0,
+            rows: 0,
+            ..virtual_request(2, 1)
+        });
+        assert_eq!(cw.graphics.kitty_placements.len(), 1);
+
+        cw.delete_graphics(DeleteRequest {
+            action: b'A',
+            delete_data: true,
+            image_id: 0,
+            image_number: 0,
+            placement_id: 0,
+            x: 0,
+            y: 0,
+            z_index: 0,
+        });
+        assert!(cw.graphics.kitty_placements.is_empty());
+        assert!(cw.graphics.kitty_virtual_placements.contains_key(&(1, 1)));
+        assert!(cw.graphics.get_kitty_image(1).is_some());
+        assert!(cw.graphics.get_kitty_image(2).is_none());
+    }
+
+    #[test]
+    fn delete_range_covers_virtual_placements() {
+        use crate::ansi::kitty_graphics_protocol::DeleteRequest;
+        let mut cw = make_crosswords();
+        cw.store_graphic(kitty_test_image(5, 1, 1));
+        cw.place_graphic(virtual_request(5, 1));
+        cw.store_graphic(kitty_test_image(9, 1, 1));
+        cw.place_graphic(virtual_request(9, 1));
+
+        cw.delete_graphics(DeleteRequest {
+            action: b'R',
+            delete_data: true,
+            image_id: 0,
+            image_number: 0,
+            placement_id: 0,
+            x: 4,
+            y: 6,
+            z_index: 0,
+        });
+        assert!(!cw.graphics.kitty_virtual_placements.contains_key(&(5, 1)));
+        assert!(cw.graphics.get_kitty_image(5).is_none());
+        assert!(cw.graphics.kitty_virtual_placements.contains_key(&(9, 1)));
+        assert!(cw.graphics.get_kitty_image(9).is_some());
+    }
+
+    #[test]
+    fn deleting_image_data_sweeps_its_placements() {
+        let mut cw = make_crosswords();
+        cw.store_graphic(kitty_test_image(1, 1, 1));
+        cw.place_graphic(virtual_request(1, 1));
+        cw.graphics.delete_kitty_images(|id, _| *id == 1);
+        assert!(cw.graphics.kitty_virtual_placements.is_empty());
     }
 
     #[test]

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -2462,7 +2462,9 @@ impl<U: EventListener> Crosswords<U> {
         // own image cache, placements, number map, and virtual placements.
         // (Marks the overlay layer dirty as a side effect so the renderer
         // rebuilds against the new active screen.)
-        self.graphics.swap_kitty_screen_state();
+        if self.graphics.swap_kitty_screen_state() {
+            self.send_graphics_updates();
+        }
         self.mark_fully_damaged();
     }
 
@@ -4918,14 +4920,11 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 .any(|(id, _)| *id == image_id);
         let image_width = graphic.width;
         let image_height = graphic.height;
-        let pixel_data = has_placements.then(|| graphic.clone());
         self.graphics.store_kitty_image(image_id, None, graphic);
 
-        if let Some(pixel_data) = pixel_data {
+        if has_placements {
             self.refresh_placements_for_image(image_id, image_width, image_height);
-            self.graphics.pending_images.push((image_id, pixel_data));
-            self.graphics.kitty_graphics_dirty = true;
-            self.send_graphics_updates();
+            self.ensure_kitty_upload(image_id);
         }
     }
 
@@ -4944,24 +4943,16 @@ impl<U: EventListener> Handler for Crosswords<U> {
         // emits: combined transmit+place where the placement is virtual.
         // Route to the virtual-placement path so only metadata is
         // registered (the application emits U+10EEEE cells itself).
-        // Unlike `place_kitty_overlay`, this path doesn't push to
-        // `pending_images`, so we have to do that here — otherwise the
-        // GPU never sees the pixel data and the placeholder cells render
-        // as blank space.
-        // Like the a=t path, a retransmission with live direct
-        // placements of this id must refresh their grid footprint
-        // against the new dimensions.
+        // Like the a=t path, a retransmission with live placements of
+        // this id must refresh them against the new dimensions.
         let image_width = graphic_data.width;
         let image_height = graphic_data.height;
 
         if placement.virtual_placement {
-            let pixel_data = graphic_data.clone();
             self.graphics
                 .store_kitty_image(image_id, None, graphic_data);
             self.refresh_placements_for_image(image_id, image_width, image_height);
-            self.graphics.pending_images.push((image_id, pixel_data));
-            self.graphics.kitty_graphics_dirty = true;
-            self.send_graphics_updates();
+            self.ensure_kitty_upload(image_id);
             self.place_virtual_graphic(placement);
             return;
         }
@@ -5009,14 +5000,10 @@ impl<U: EventListener> Handler for Crosswords<U> {
         // emits U+10EEEE placeholder cells itself. The renderer scans
         // visible cells and composites the image at those positions.
         if placement.virtual_placement {
-            // `a=t` deliberately defers the GPU upload to the placement
-            // (see `store_graphic`). The direct path does it in
-            // `place_kitty_overlay`; the virtual path has to do it here,
-            // otherwise the placeholder cells stay blank (this is the
-            // `a=t` + `a=p,U=1` sequence snacks.image and yazi emit).
-            // Upload once per image: clients re-place on every relayout,
-            // and that must not resend the pixels.
-            self.upload_for_virtual_placement(image_id);
+            // `a=t` defers the GPU upload to the placement; without it
+            // the placeholder cells stay blank (the `a=t` + `a=p,U=1`
+            // sequence snacks.image and yazi emit).
+            self.ensure_kitty_upload(image_id);
             self.place_virtual_graphic(placement);
             return true;
         }
@@ -5557,6 +5544,7 @@ impl<U: EventListener> Crosswords<U> {
             }
         };
         let mut graphic_data = stored.data.clone();
+        let texture_current = stored.gpu_uploaded;
 
         let image_width = graphic_data.width;
         let image_height = graphic_data.height;
@@ -5698,14 +5686,15 @@ impl<U: EventListener> Crosswords<U> {
 
         // Check if this placement already exists with the same transmit_time
         // (avoids re-uploading identical pixel data to GPU every frame)
-        let needs_upload = match self
-            .graphics
-            .kitty_placements
-            .get(&(image_id, placement_id))
-        {
-            Some(existing) => existing.transmit_time != transmit_time,
-            None => true,
-        };
+        let needs_upload = !texture_current
+            || match self
+                .graphics
+                .kitty_placements
+                .get(&(image_id, placement_id))
+            {
+                Some(existing) => existing.transmit_time != transmit_time,
+                None => true,
+            };
 
         self.graphics
             .kitty_placements
@@ -5714,6 +5703,9 @@ impl<U: EventListener> Crosswords<U> {
 
         // Only push pixel data when image data actually changed
         if needs_upload {
+            if let Some(stored) = self.graphics.kitty_images.get_mut(&image_id) {
+                stored.gpu_uploaded = true;
+            }
             self.graphics.pending_images.push((image_id, graphic_data));
             self.send_graphics_updates();
         }
@@ -5748,6 +5740,31 @@ impl<U: EventListener> Crosswords<U> {
             if *id == image_id {
                 p.rescale(image_width, image_height, cell_w, cell_h);
             }
+        }
+        // A virtual placement keeps its source rect; if the new pixels
+        // no longer cover it, fall back to the whole image rather than
+        // rendering nothing at the placeholder cells.
+        for ((id, _), vp) in self.graphics.kitty_virtual_placements.iter_mut() {
+            if *id == image_id
+                && (vp.x as usize >= image_width || vp.y as usize >= image_height)
+            {
+                vp.x = 0;
+                vp.y = 0;
+                vp.width = 0;
+                vp.height = 0;
+            }
+        }
+    }
+
+    /// Queue the stored pixels of `image_id` for the GPU unless the
+    /// texture already holds them. Returns whether an upload was queued.
+    fn ensure_kitty_upload(&mut self, image_id: u32) -> bool {
+        if self.graphics.queue_kitty_upload(image_id) {
+            self.graphics.kitty_graphics_dirty = true;
+            self.send_graphics_updates();
+            true
+        } else {
+            false
         }
     }
 
@@ -5789,33 +5806,6 @@ impl<U: EventListener> Crosswords<U> {
     /// decodes the image_id from the foreground color and the row/col
     /// indices from the combining-mark diacritics (kitty_virtual::*), and
     /// looks up the metadata stored here to know which image to composite.
-    /// Queue the stored pixels of `image_id` for the GPU before its first
-    /// virtual placement. Returns whether an upload was queued: `false`
-    /// when the image already has a virtual placement (pixels are on the
-    /// GPU) or is unknown.
-    fn upload_for_virtual_placement(&mut self, image_id: u32) -> bool {
-        let already_uploaded = self
-            .graphics
-            .kitty_virtual_placements
-            .keys()
-            .any(|(id, _)| *id == image_id);
-        if already_uploaded {
-            return false;
-        }
-        let pixel_data = self
-            .graphics
-            .get_kitty_image(image_id)
-            .map(|stored| stored.data.clone());
-        match pixel_data {
-            Some(pixel_data) => {
-                self.graphics.pending_images.push((image_id, pixel_data));
-                self.send_graphics_updates();
-                true
-            }
-            None => false,
-        }
-    }
-
     fn place_virtual_graphic(
         &mut self,
         placement: crate::ansi::kitty_graphics_protocol::PlacementRequest,
@@ -9727,45 +9717,28 @@ mod tests {
         assert_eq!(cw.grid.cursor.pos, cursor_before);
     }
 
-    #[test]
-    fn virtual_placement_uploads_pixels_once_per_image() {
-        use crate::ansi::kitty_graphics_protocol::PlacementRequest;
+    fn kitty_test_image(id: u32, width: usize, height: usize) -> GraphicData {
+        GraphicData {
+            id: rio_graphics::GraphicId::new(id as u64),
+            width,
+            height,
+            pixels: vec![0u8; width * height * 4],
+            color_type: rio_graphics::ColorType::Rgba,
+            is_opaque: true,
+            display_width: None,
+            display_height: None,
+            resize: None,
+            transmit_time: crate::time::Instant::now(),
+        }
+    }
 
-        let size = CrosswordsSize::new(40, 20);
-        let window_id = crate::event::WindowId::from(0);
-        let mut cw = Crosswords::new(
-            size,
-            CursorShape::Block,
-            VoidListener {},
-            window_id,
-            0,
-            10_000,
-        );
-        // Unknown image: nothing to upload.
-        assert!(!cw.upload_for_virtual_placement(1234));
-
-        cw.graphics.store_kitty_image(
-            1234,
-            None,
-            GraphicData {
-                id: rio_graphics::GraphicId::new(1234),
-                width: 1,
-                height: 1,
-                pixels: vec![0u8; 4],
-                color_type: rio_graphics::ColorType::Rgba,
-                is_opaque: true,
-                display_width: None,
-                display_height: None,
-                resize: None,
-                transmit_time: crate::time::Instant::now(),
-            },
-        );
-        // `a=t` stored the image without uploading; the first virtual
-        // placement must queue the pixels …
-        assert!(cw.upload_for_virtual_placement(1234));
-        let placement = PlacementRequest {
-            image_id: 1234,
-            placement_id: 7,
+    fn virtual_request(
+        image_id: u32,
+        placement_id: u32,
+    ) -> crate::ansi::kitty_graphics_protocol::PlacementRequest {
+        crate::ansi::kitty_graphics_protocol::PlacementRequest {
+            image_id,
+            placement_id,
             x: 0,
             y: 0,
             width: 0,
@@ -9778,10 +9751,158 @@ mod tests {
             cursor_movement: 0,
             cell_x_offset: 0,
             cell_y_offset: 0,
-        };
-        assert!(cw.place_graphic(placement));
-        // … and a re-place of the same image must not resend them.
-        assert!(!cw.upload_for_virtual_placement(1234));
+        }
+    }
+
+    fn uploaded(cw: &Crosswords<VoidListener>, image_id: u32) -> bool {
+        cw.graphics
+            .get_kitty_image(image_id)
+            .map(|s| s.gpu_uploaded)
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn virtual_placement_uploads_pixels_once_per_image() {
+        let mut cw = make_crosswords();
+        // Unknown image: nothing to upload.
+        assert!(!cw.ensure_kitty_upload(1234));
+
+        // `a=t` stores without uploading; the first `a=p,U=1` queues
+        // the pixels, a re-place (relayout) must not resend them.
+        cw.store_graphic(kitty_test_image(1234, 1, 1));
+        assert!(!uploaded(&cw, 1234));
+        assert!(cw.place_graphic(virtual_request(1234, 7)));
+        assert!(uploaded(&cw, 1234));
+        assert!(!cw.ensure_kitty_upload(1234));
+        assert!(cw.place_graphic(virtual_request(1234, 7)));
+        assert!(cw.place_graphic(virtual_request(1234, 8)));
+        assert!(!cw.ensure_kitty_upload(1234));
+
+        // Deleting the placements but keeping the data leaves the
+        // texture valid, so placing again does not resend either.
+        cw.graphics.kitty_virtual_placements.clear();
+        assert!(cw.place_graphic(virtual_request(1234, 7)));
+        assert!(!cw.ensure_kitty_upload(1234));
+
+        // A retransmission of a placed id uploads the new pixels once.
+        cw.store_graphic(kitty_test_image(1234, 2, 2));
+        assert!(uploaded(&cw, 1234));
+        assert!(!cw.ensure_kitty_upload(1234));
+
+        // A retransmission of an unplaced id waits for the placement.
+        cw.graphics.kitty_virtual_placements.clear();
+        cw.store_graphic(kitty_test_image(1234, 3, 3));
+        assert!(!uploaded(&cw, 1234));
+        assert!(cw.ensure_kitty_upload(1234));
+    }
+
+    #[test]
+    fn transmit_and_display_virtual_uploads_once() {
+        let mut cw = make_crosswords();
+        cw.kitty_transmit_and_display(kitty_test_image(5, 2, 2), virtual_request(5, 1));
+        assert!(uploaded(&cw, 5));
+        assert!(cw.graphics.kitty_virtual_placements.contains_key(&(5, 1)));
+        assert!(!cw.ensure_kitty_upload(5));
+    }
+
+    #[test]
+    fn direct_placement_shares_texture_with_virtual_placement() {
+        use crate::ansi::kitty_graphics_protocol::PlacementRequest;
+        let mut cw = make_crosswords();
+        cw.graphics.cell_width = 10.0;
+        cw.graphics.cell_height = 20.0;
+        cw.store_graphic(kitty_test_image(3, 10, 20));
+        cw.place_graphic(PlacementRequest {
+            virtual_placement: false,
+            columns: 0,
+            rows: 0,
+            ..virtual_request(3, 1)
+        });
+        assert!(uploaded(&cw, 3));
+        assert!(!cw.ensure_kitty_upload(3));
+        cw.place_graphic(virtual_request(3, 2));
+        assert!(uploaded(&cw, 3));
+    }
+
+    #[test]
+    fn alt_screen_swap_reuploads_images_whose_texture_was_overwritten() {
+        let mut cw = make_crosswords();
+        cw.store_graphic(kitty_test_image(1, 1, 1));
+        cw.place_graphic(virtual_request(1, 1));
+        cw.store_graphic(kitty_test_image(2, 1, 1));
+        cw.place_graphic(virtual_request(2, 1));
+        assert!(uploaded(&cw, 1) && uploaded(&cw, 2));
+
+        // The alt screen transmits its own image 1, overwriting the
+        // window-wide texture, and a never-uploaded image 2.
+        cw.swap_alt();
+        assert!(cw.graphics.get_kitty_image(1).is_none());
+        cw.store_graphic(kitty_test_image(1, 2, 2));
+        cw.place_graphic(virtual_request(1, 1));
+        cw.store_graphic(kitty_test_image(2, 2, 2));
+        assert!(uploaded(&cw, 1) && !uploaded(&cw, 2));
+
+        // Back on the main screen: image 1 must be resent, image 2's
+        // texture was never touched so it is still current.
+        assert!(cw.graphics.swap_kitty_screen_state());
+        let queued: Vec<u32> = cw
+            .graphics
+            .pending_images
+            .iter()
+            .map(|(id, _)| *id)
+            .collect();
+        assert_eq!(queued, vec![1]);
+        assert_eq!(cw.graphics.pending_images[0].1.width, 1);
+        assert!(uploaded(&cw, 1) && uploaded(&cw, 2));
+        cw.graphics.pending_images.clear();
+
+        // And the alt screen's image 1 is stale again when it returns;
+        // its unplaced image 2 only gets marked, not resent.
+        assert!(cw.graphics.swap_kitty_screen_state());
+        let queued: Vec<u32> = cw
+            .graphics
+            .pending_images
+            .iter()
+            .map(|(id, _)| *id)
+            .collect();
+        assert_eq!(queued, vec![1]);
+        assert_eq!(cw.graphics.pending_images[0].1.width, 2);
+        assert!(!uploaded(&cw, 2));
+        cw.graphics.pending_images.clear();
+        cw.graphics.kitty_virtual_placements.clear();
+        cw.graphics
+            .kitty_inactive_screen
+            .kitty_virtual_placements
+            .clear();
+
+        // Without a placement on the incoming screen nothing is resent,
+        // but the marker is dropped so a later placement uploads.
+        assert!(!cw.graphics.swap_kitty_screen_state());
+        assert!(cw.graphics.pending_images.is_empty());
+        assert!(!uploaded(&cw, 1));
+        assert!(cw.ensure_kitty_upload(1));
+    }
+
+    #[test]
+    fn retransmit_resets_virtual_source_rect_outside_new_image() {
+        let mut cw = make_crosswords();
+        cw.store_graphic(kitty_test_image(9, 100, 100));
+        let mut req = virtual_request(9, 1);
+        req.x = 50;
+        req.y = 10;
+        req.width = 20;
+        req.height = 20;
+        cw.place_graphic(req);
+        let mut req = virtual_request(9, 2);
+        req.x = 5;
+        req.width = 10;
+        cw.place_graphic(req);
+
+        cw.store_graphic(kitty_test_image(9, 20, 20));
+        let stale = &cw.graphics.kitty_virtual_placements[&(9, 1)];
+        assert_eq!((stale.x, stale.y, stale.width, stale.height), (0, 0, 0, 0));
+        let kept = &cw.graphics.kitty_virtual_placements[&(9, 2)];
+        assert_eq!((kept.x, kept.width), (5, 10));
     }
 
     /// DECSTBM bounds where scrolling happens, not what is on screen. Both

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -4910,7 +4910,12 @@ impl<U: EventListener> Handler for Crosswords<U> {
             .graphics
             .kitty_placements
             .keys()
-            .any(|(id, _)| *id == image_id);
+            .any(|(id, _)| *id == image_id)
+            || self
+                .graphics
+                .kitty_virtual_placements
+                .keys()
+                .any(|(id, _)| *id == image_id);
         let image_width = graphic.width;
         let image_height = graphic.height;
         let pixel_data = has_placements.then(|| graphic.clone());
@@ -5004,6 +5009,14 @@ impl<U: EventListener> Handler for Crosswords<U> {
         // emits U+10EEEE placeholder cells itself. The renderer scans
         // visible cells and composites the image at those positions.
         if placement.virtual_placement {
+            // `a=t` deliberately defers the GPU upload to the placement
+            // (see `store_graphic`). The direct path does it in
+            // `place_kitty_overlay`; the virtual path has to do it here,
+            // otherwise the placeholder cells stay blank (this is the
+            // `a=t` + `a=p,U=1` sequence snacks.image and yazi emit).
+            // Upload once per image: clients re-place on every relayout,
+            // and that must not resend the pixels.
+            self.upload_for_virtual_placement(image_id);
             self.place_virtual_graphic(placement);
             return true;
         }
@@ -5776,6 +5789,33 @@ impl<U: EventListener> Crosswords<U> {
     /// decodes the image_id from the foreground color and the row/col
     /// indices from the combining-mark diacritics (kitty_virtual::*), and
     /// looks up the metadata stored here to know which image to composite.
+    /// Queue the stored pixels of `image_id` for the GPU before its first
+    /// virtual placement. Returns whether an upload was queued: `false`
+    /// when the image already has a virtual placement (pixels are on the
+    /// GPU) or is unknown.
+    fn upload_for_virtual_placement(&mut self, image_id: u32) -> bool {
+        let already_uploaded = self
+            .graphics
+            .kitty_virtual_placements
+            .keys()
+            .any(|(id, _)| *id == image_id);
+        if already_uploaded {
+            return false;
+        }
+        let pixel_data = self
+            .graphics
+            .get_kitty_image(image_id)
+            .map(|stored| stored.data.clone());
+        match pixel_data {
+            Some(pixel_data) => {
+                self.graphics.pending_images.push((image_id, pixel_data));
+                self.send_graphics_updates();
+                true
+            }
+            None => false,
+        }
+    }
+
     fn place_virtual_graphic(
         &mut self,
         placement: crate::ansi::kitty_graphics_protocol::PlacementRequest,
@@ -9685,6 +9725,63 @@ mod tests {
 
         // Cursor must be untouched.
         assert_eq!(cw.grid.cursor.pos, cursor_before);
+    }
+
+    #[test]
+    fn virtual_placement_uploads_pixels_once_per_image() {
+        use crate::ansi::kitty_graphics_protocol::PlacementRequest;
+
+        let size = CrosswordsSize::new(40, 20);
+        let window_id = crate::event::WindowId::from(0);
+        let mut cw = Crosswords::new(
+            size,
+            CursorShape::Block,
+            VoidListener {},
+            window_id,
+            0,
+            10_000,
+        );
+        // Unknown image: nothing to upload.
+        assert!(!cw.upload_for_virtual_placement(1234));
+
+        cw.graphics.store_kitty_image(
+            1234,
+            None,
+            GraphicData {
+                id: rio_graphics::GraphicId::new(1234),
+                width: 1,
+                height: 1,
+                pixels: vec![0u8; 4],
+                color_type: rio_graphics::ColorType::Rgba,
+                is_opaque: true,
+                display_width: None,
+                display_height: None,
+                resize: None,
+                transmit_time: crate::time::Instant::now(),
+            },
+        );
+        // `a=t` stored the image without uploading; the first virtual
+        // placement must queue the pixels …
+        assert!(cw.upload_for_virtual_placement(1234));
+        let placement = PlacementRequest {
+            image_id: 1234,
+            placement_id: 7,
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+            columns: 8,
+            rows: 4,
+            z_index: 0,
+            virtual_placement: true,
+            unicode_placeholder: 0,
+            cursor_movement: 0,
+            cell_x_offset: 0,
+            cell_y_offset: 0,
+        };
+        assert!(cw.place_graphic(placement));
+        // … and a re-place of the same image must not resend them.
+        assert!(!cw.upload_for_virtual_placement(1234));
     }
 
     /// DECSTBM bounds where scrolling happens, not what is on screen. Both

--- a/sugarloaf/src/lib.rs
+++ b/sugarloaf/src/lib.rs
@@ -37,9 +37,9 @@ pub use swash::{Attributes, Stretch, Style, Weight};
 pub use crate::font_cache::ResolvedGlyph;
 pub use crate::sugarloaf::{
     graphics::{
-        atlas_image_key, kitty_image_key, ColorType, Graphic, GraphicData,
-        GraphicDataEntry, GraphicId, GraphicOverlay, Graphics, ResizeCommand,
-        ResizeParameter, MAX_GRAPHIC_DIMENSIONS,
+        atlas_image_key, image_key_route, kitty_image_key, route_image_key, ColorType,
+        Graphic, GraphicData, GraphicDataEntry, GraphicId, GraphicOverlay, Graphics,
+        ResizeCommand, ResizeParameter, MAX_GRAPHIC_DIMENSIONS,
     },
     primitives::{
         is_private_user_area, Corners, CursorKind, ImageProperties, Quad, Rect,

--- a/sugarloaf/src/renderer/mod.rs
+++ b/sugarloaf/src/renderer/mod.rs
@@ -1662,6 +1662,18 @@ impl Renderer {
         }
     }
 
+    pub fn evict_route_textures(&mut self, route_id: usize) {
+        let mut freed = 0;
+        self.image_textures.retain(|key, entry| {
+            let keep = crate::sugarloaf::graphics::image_key_route(*key) != route_id;
+            if !keep {
+                freed += entry.bytes;
+            }
+            keep
+        });
+        self.image_texture_bytes -= freed;
+    }
+
     #[inline]
     pub fn clear_atlas(&mut self) {
         self.images.clear_atlas();

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -9,7 +9,7 @@ use crate::font::{fonts::SugarloafFont, FontLibrary};
 use crate::font_cache::{compute_advance, resolve_with, FontCache, ResolvedGlyph};
 use crate::layout::RootStyle;
 use crate::renderer::Renderer;
-use crate::sugarloaf::graphics::{GraphicDataEntry, Graphics};
+use crate::sugarloaf::graphics::{image_key_route, GraphicDataEntry, Graphics};
 use swash::Attributes;
 
 use crate::context::Context;
@@ -859,6 +859,14 @@ impl Sugarloaf<'_> {
     pub fn remove_image(&mut self, key: u64) {
         self.image_data.remove(&key);
         self.renderer.evict_image_texture(key);
+    }
+
+    /// Drop every image a closed terminal uploaded (keys namespaced
+    /// with `graphics::route_image_key`), pixel store and GPU textures.
+    pub fn remove_route_images(&mut self, route_id: usize) {
+        self.image_data
+            .retain(|key, _| image_key_route(*key) != route_id);
+        self.renderer.evict_route_textures(route_id);
     }
 
     /// Drop everything this frame's immediate-mode producers pushed

--- a/sugarloaf/src/sugarloaf/graphics.rs
+++ b/sugarloaf/src/sugarloaf/graphics.rs
@@ -15,8 +15,9 @@ use crate::sugarloaf::Handle;
 use rustc_hash::FxHashMap;
 
 pub use rio_graphics::{
-    atlas_image_key, kitty_image_key, ColorType, Graphic, GraphicData, GraphicId,
-    GraphicOverlay, ResizeCommand, ResizeParameter, MAX_GRAPHIC_DIMENSIONS,
+    atlas_image_key, image_key_route, kitty_image_key, route_image_key, ColorType,
+    Graphic, GraphicData, GraphicId, GraphicOverlay, ResizeCommand, ResizeParameter,
+    MAX_GRAPHIC_DIMENSIONS,
 };
 
 pub struct GraphicDataEntry {


### PR DESCRIPTION
Supersedes #1892 by @reminiscience (both original commits are kept as-is on this branch; thank you for the report and the fix). Fixes #1891.

## From #1892

- Placeholder cells whose underline color is absent or black decode to placement id 0; per the spec that means "any virtual placement of the image". `resolve_virtual_placement` now handles that (non-zero id must match exactly, id 0 picks the lowest id so the result does not depend on hash-map order). Neovim only emits SGR 58 for underlined cells, so snacks.image always hit this.
- `a=t` followed by `a=p,U=1` never uploaded the pixels to the GPU, so the placeholder cells rendered blank.

## Added on top

Deciding whether an image is on the GPU from "does it already have a virtual placement" broke in a few cases. Image stores and placements are per screen, but GPU textures are per window keyed by image id, so anything the alt screen does with the same id affects the main screen's texture:

- An alt-screen image reusing an id overwrote the main screen's texture; after `\e[?1049l` the main screen showed the alt pixels. Same outcome when the alt screen then retransmitted, deleted (`d=I`) or had that image evicted before switching back.
- Evicting the inactive screen's copy of an id freed the texture the active screen was still drawing.
- `a=d` then re-place, or a virtual placement following a direct one of the same image, resent pixels the texture already held.

`Graphics` now keeps `kitty_texture_contents`, a record (not swapped with the screens) of which store's pixels each image texture holds, keyed by `transmission_time`; this is the same `(id, transmit_time)` equality the reference renderers use, moved into the VT layer. Every upload path (direct, virtual, `a=T`, retransmit) consults and updates it; screen swaps and evictions re-queue placed active images whose record no longer matches. Texture release (eviction, delete with data, full reset) goes through one helper that frees the texture only when it holds the released store's pixels and cancels a pending upload of them. `store_kitty_image` guarantees a strictly increasing `transmission_time` per id across both screens (web_time on wasm only has millisecond resolution). The frontend applies texture removals before uploads so a batch that frees and resends a key keeps the new pixels.

Delete semantics checked against kitty and ghostty:
- `d=a` no longer clears virtual placements or the images they keep alive (kitty `clear_filter_func_noncell` skips virtual refs); the old test pinned the opposite. As in kitty, a client that only ever sends `d=A` keeps its virtual placements (and their images) alive until it deletes them by id.
- Deleting image data (`a=d` with the data flag, full reset) now returns the pixels to the 320 MB budget; before, `total_bytes` only ever shrank through eviction.
- `d=r` now removes virtual placements in range, and deleting image data sweeps the placements that pointed at it.
- Eviction protection, the dangling-placement sweep, and `collect_active_graphic_ids` (used by `a=d` with `d=C/P/X/Y/Z/Q` + delete data) count virtual placements as live.

Also:
- A retransmit whose new dimensions no longer contain a virtual placement's source rect falls back to the whole image instead of rendering nothing.
- `resolve_virtual_placement` tries `(image_id, 0)` before scanning, keeping the common case O(1) per placeholder run per frame.
- The direct placement path no longer clones and resends the pixels for every new placement of an already uploaded image.

Behavior note: on `main`, a placeholder with a non-zero id that did not match fell back to `(image_id, 0)`. The spec says a non-zero id must match exactly (kitty behaves the same), so that fallback is gone.

Cross-terminal collisions: the window's image store and texture cache were keyed by the bare kitty image id or atlas graphic id, so two tabs or splits in one window using the same id (kitty ids are client-chosen; sixel/iTerm2 ids are a per-terminal counter) overwrote each other's pixels. Keys are now namespaced by the terminal's route id (`route_image_key`; route 0 is the identity so `libsugarloaf` and the VT layer's keys are unchanged), and closing a tab or split drops that terminal's images and textures.

Tests: upload-once per image across re-place, delete and retransmit; `a=T,U=1`; direct and virtual placements sharing a texture; alt-screen swap after overwrite, retransmit and delete; eviction in both texture-ownership directions and cancelling a pending upload; delete and reset freeing textures only when owned; `d=a`, `d=r` and cursor delete semantics for virtual placements; retransmit source-rect fallback; strictly increasing transmission_time. route key packing (identity at route 0, disjoint across routes). `make lint` and `cargo test -p rio-vt -p rio-backend -p sugarloaf -p rio-graphics` pass.

