### PR TITLE
librio: expose bracketed paste via rio_surface_paste

### DIFF
--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -204,6 +204,8 @@ rio_surface_id_t rio_surface_id(const rio_surface_t *surface);
 
 /* Input entry points are callable from any thread. */
 void rio_surface_text(rio_surface_t *surface, const char *bytes, size_t len);
+/* Paste `bytes` (UTF-8), bracketed when the program has enabled mode 2004. */
+void rio_surface_paste(rio_surface_t *surface, const char *bytes, size_t len);
 /* Returns true when the event was consumed and encoded to the PTY. */
 bool rio_surface_key(rio_surface_t *surface, const rio_key_event_s *event);
 /* Whether alt acts as meta, prefixing with ESC, instead of letting the text

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -579,6 +579,21 @@ pub unsafe extern "C" fn rio_surface_text(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rio_surface_paste(
+    surface: *mut Surface,
+    bytes: *const c_char,
+    len: usize,
+) {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        if surface.is_null() || bytes.is_null() {
+            return;
+        }
+        let slice = unsafe { std::slice::from_raw_parts(bytes as *const u8, len) };
+        unsafe { &*surface }.paste(&String::from_utf8_lossy(slice));
+    }));
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rio_surface_key(
     surface: *mut Surface,
     event: *const rio_key_event_s,


### PR DESCRIPTION
**Problem.** librio's only C input entry point is `rio_surface_text`, which writes bytes raw. An embedder driving librio (e.g. an Emacs module) therefore can't perform a bracketed paste: it can neither send text atomically nor query mode 2004 to wrap the text itself — so a multi-line paste into a shell runs line by line.

**Solution.** `Surface::paste` already does this correctly (mode-2004 check, `\r` normalization, `ESC[200~…ESC[201~` markers), it just isn't reachable from C. Expose it as a thin `rio_surface_paste`, mirroring `rio_surface_text`. Purely additive; no behavior change.
