### PR TITLE
librio: expose bracketed paste via rio_surface_paste

### DIFF
--- a/librio-wasm/src/lib.rs
+++ b/librio-wasm/src/lib.rs
@@ -301,8 +301,9 @@ impl RioTerm {
         self.flush();
     }
 
-    /// Paste text: newlines normalized to CR and wrapped in
-    /// bracketed-paste markers when the program enabled the mode.
+    /// Paste text: sent verbatim inside bracketed-paste markers (minus
+    /// ESC/ETX) when the program enabled mode 2004, otherwise with
+    /// newlines normalized to CR.
     pub fn paste(&self, text: &str) {
         self.surface.paste(text);
         self.flush();

--- a/librio-wasm/src/lib.rs
+++ b/librio-wasm/src/lib.rs
@@ -294,8 +294,8 @@ impl RioTerm {
         self.flush();
     }
 
-    /// Send text to the child (a paste, or synthetic input). Reaches JS
-    /// back through the `output` callback.
+    /// Send raw text to the child (synthetic input; use `paste` for
+    /// clipboard text). Reaches JS back through the `output` callback.
     pub fn send_text(&self, text: &str) {
         self.surface.text(text);
         self.flush();

--- a/librio/ctest/main.c
+++ b/librio/ctest/main.c
@@ -39,14 +39,17 @@ int main(void) {
   usleep(400 * 1000);
   const char *cmd = "printf '%s%s\\n' li brio-cgate\r";
   rio_surface_text(surface, cmd, strlen(cmd));
+  const char *pasted = "librio-pgate";
+  rio_surface_paste(surface, pasted, strlen(pasted));
 
   rio_render_state_t *state = rio_render_state_new(surface);
   int found = 0;
-  for (int attempt = 0; attempt < 200 && !found; attempt++) {
+  int found_paste = 0;
+  for (int attempt = 0; attempt < 200 && !(found && found_paste); attempt++) {
     rio_render_state_update(state);
     uint16_t lines = rio_render_state_lines(state);
     uint16_t cols = rio_render_state_columns(state);
-    for (uint16_t line = 0; line < lines && !found; line++) {
+    for (uint16_t line = 0; line < lines; line++) {
       char text[512] = {0};
       uint16_t limit = cols < 511 ? cols : 511;
       for (uint16_t col = 0; col < limit; col++) {
@@ -55,23 +58,28 @@ int main(void) {
                         ? (char)cell.codepoint
                         : ' ';
       }
-      if (strstr(text, "librio-cgate")) {
+      if (!found && strstr(text, "librio-cgate")) {
         printf("row %u: %s\n", line, text);
         found = 1;
+      }
+      if (!found_paste && strstr(text, "librio-pgate")) {
+        printf("paste row %u: %s\n", line, text);
+        found_paste = 1;
       }
     }
     usleep(25 * 1000);
   }
 
   rio_cursor_s cursor = rio_render_state_cursor(state);
-  printf("wakeups=%d cursor=%u,%u found=%d\n", atomic_load(&wakeups),
-         cursor.line, cursor.column, found);
+  printf("wakeups=%d cursor=%u,%u found=%d found_paste=%d\n",
+         atomic_load(&wakeups), cursor.line, cursor.column, found,
+         found_paste);
 
   rio_render_state_free(state);
   rio_surface_free(surface);
   rio_engine_free(engine);
 
-  if (!found || atomic_load(&wakeups) == 0) {
+  if (!found || !found_paste || atomic_load(&wakeups) == 0) {
     fprintf(stderr, "gate failed\n");
     return 1;
   }

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -204,6 +204,8 @@ rio_surface_id_t rio_surface_id(const rio_surface_t *surface);
 
 /* Input entry points are callable from any thread. */
 void rio_surface_text(rio_surface_t *surface, const char *bytes, size_t len);
+/* Paste `bytes` (UTF-8), bracketed when the program has enabled mode 2004. */
+void rio_surface_paste(rio_surface_t *surface, const char *bytes, size_t len);
 /* Returns true when the event was consumed and encoded to the PTY. */
 bool rio_surface_key(rio_surface_t *surface, const rio_key_event_s *event);
 /* Whether alt acts as meta, prefixing with ESC, instead of letting the text

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -579,6 +579,21 @@ pub unsafe extern "C" fn rio_surface_text(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rio_surface_paste(
+    surface: *mut Surface,
+    bytes: *const c_char,
+    len: usize,
+) {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        if surface.is_null() || bytes.is_null() {
+            return;
+        }
+        let slice = unsafe { std::slice::from_raw_parts(bytes as *const u8, len) };
+        unsafe { &*surface }.paste(&String::from_utf8_lossy(slice));
+    }));
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rio_surface_key(
     surface: *mut Surface,
     event: *const rio_key_event_s,

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -483,7 +483,7 @@ fn mouse_report(
 
 fn encode_paste(text: &str, bracketed: bool) -> Vec<u8> {
     if bracketed {
-        let filtered = text.replace(['\x1b', '\x03'], "");
+        let filtered = text.replace(['\x1b', '\x03', '\u{9b}'], "");
         format!("\x1b[200~{filtered}\x1b[201~").into_bytes()
     } else {
         text.replace("\r\n", "\r").replace('\n', "\r").into_bytes()
@@ -652,9 +652,10 @@ impl Surface {
 
     /// Paste text the way terminals do: when the program asked for
     /// bracketed paste (mode 2004) the text is sent verbatim inside
-    /// ESC[200~/ESC[201~ markers, minus ESC and ETX so the payload can
-    /// never close the bracket early and inject keystrokes; otherwise
-    /// newlines are normalized to CR, what the Enter key produces.
+    /// ESC[200~/ESC[201~ markers, minus ESC, ETX and the 8-bit CSI so
+    /// the payload can never close the bracket early and inject
+    /// keystrokes; otherwise newlines are normalized to CR, what the
+    /// Enter key produces.
     pub fn paste(&self, text: &str) {
         if text.is_empty() {
             return;
@@ -1517,15 +1518,18 @@ mod tests {
             b"\x1b[200~a[201~rm -rf /\x1b[201~".to_vec()
         );
         assert_eq!(
+            encode_paste("a\u{9b}201~oops", true),
+            b"\x1b[200~a201~oops\x1b[201~".to_vec()
+        );
+        assert_eq!(
             encode_paste("one\r\ntwo\nthree", false),
             b"one\rtwo\rthree".to_vec()
         );
     }
 
-    // Paste wraps in bracketed-paste markers exactly when the program
-    // turned the mode on.
+    // mode_bits mirrors the private modes programs toggle at runtime.
     #[test]
-    fn paste_brackets_when_the_program_asks() {
+    fn mode_bits_track_private_modes() {
         let delegate = Arc::new(CountingDelegate {
             wakeups: AtomicUsize::new(0),
         });
@@ -1539,6 +1543,44 @@ mod tests {
         assert_eq!(surface.mode_bits() & (1 << 3), 1 << 3);
         surface.inject_output(b"\x1b[?1h\x1b[?1049h\x1b[?1000h");
         assert_eq!(surface.mode_bits(), 0b1111);
+    }
+
+    // paste() keys off live terminal state: markers go to the child only
+    // once the program turned mode 2004 on. The sleeper child never reads,
+    // so what lands in the grid is the tty line discipline's echo, which
+    // renders the ESC of each marker as ^[ (ECHOCTL).
+    #[test]
+    fn paste_brackets_when_the_program_asks() {
+        let surface = quiet_surface(60, 10);
+        let mut state = RenderState::new(&surface);
+        std::thread::sleep(Duration::from_millis(150));
+
+        let grid_rows = |state: &mut RenderState, needle: &str| {
+            let deadline = Instant::now() + Duration::from_secs(8);
+            loop {
+                state.update();
+                let rows: Vec<String> =
+                    (0..state.lines()).map(|i| state.text_row(i)).collect();
+                if rows.iter().any(|row| row.contains(needle)) {
+                    return rows;
+                }
+                if Instant::now() >= deadline {
+                    panic!("echo of {needle:?} never reached the grid: {rows:?}");
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        };
+
+        surface.paste("plain\n");
+        let rows = grid_rows(&mut state, "plain");
+        assert!(
+            !rows.iter().any(|row| row.contains("^[[200~")),
+            "unbracketed paste must not emit markers: {rows:?}"
+        );
+
+        surface.inject_output(b"\x1b[?2004h");
+        surface.paste("wrapped");
+        grid_rows(&mut state, "^[[200~wrapped^[[201~");
     }
 
     // A child that never writes, so buffer contents are exactly what the

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -656,6 +656,9 @@ impl Surface {
     /// never close the bracket early and inject keystrokes; otherwise
     /// newlines are normalized to CR, what the Enter key produces.
     pub fn paste(&self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
         let bracketed = self.terminal.lock().mode().contains(Mode::BRACKETED_PASTE);
         self.write(encode_paste(text, bracketed));
     }

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -481,6 +481,15 @@ fn mouse_report(
     out
 }
 
+fn encode_paste(text: &str, bracketed: bool) -> Vec<u8> {
+    if bracketed {
+        let filtered = text.replace(['\x1b', '\x03'], "");
+        format!("\x1b[200~{filtered}\x1b[201~").into_bytes()
+    } else {
+        text.replace("\r\n", "\r").replace('\n', "\r").into_bytes()
+    }
+}
+
 impl Surface {
     fn new(
         engine: &Engine,
@@ -641,17 +650,14 @@ impl Surface {
         self.write(text.as_bytes().to_vec());
     }
 
-    /// Paste text the way terminals do: newlines normalized to CR, and the
-    /// whole run wrapped in bracketed-paste markers when the program asked
-    /// for them (so shells and editors can treat it as one atomic paste).
+    /// Paste text the way terminals do: when the program asked for
+    /// bracketed paste (mode 2004) the text is sent verbatim inside
+    /// ESC[200~/ESC[201~ markers, minus ESC and ETX so the payload can
+    /// never close the bracket early and inject keystrokes; otherwise
+    /// newlines are normalized to CR, what the Enter key produces.
     pub fn paste(&self, text: &str) {
-        let normalized = text.replace("\r\n", "\r").replace('\n', "\r");
         let bracketed = self.terminal.lock().mode().contains(Mode::BRACKETED_PASTE);
-        if bracketed {
-            self.write(format!("\x1b[200~{normalized}\x1b[201~").into_bytes());
-        } else {
-            self.write(normalized.into_bytes());
-        }
+        self.write(encode_paste(text, bracketed));
     }
 
     /// A stable, C-friendly view of the terminal modes an embedder needs
@@ -1494,8 +1500,27 @@ mod tests {
         assert_eq!(state.link_run(0, 0), None);
     }
 
+    // Bracketed paste sends the text verbatim minus ESC/ETX, so a
+    // malicious payload cannot close the bracket and inject keystrokes;
+    // unbracketed paste normalizes newlines to CR.
+    #[test]
+    fn paste_encoding_is_injection_safe() {
+        assert_eq!(
+            encode_paste("one\ntwo", true),
+            b"\x1b[200~one\ntwo\x1b[201~".to_vec()
+        );
+        assert_eq!(
+            encode_paste("a\x1b[201~rm -rf /\x03", true),
+            b"\x1b[200~a[201~rm -rf /\x1b[201~".to_vec()
+        );
+        assert_eq!(
+            encode_paste("one\r\ntwo\nthree", false),
+            b"one\rtwo\rthree".to_vec()
+        );
+    }
+
     // Paste wraps in bracketed-paste markers exactly when the program
-    // turned the mode on, and newlines never reach the shell as LF.
+    // turned the mode on.
     #[test]
     fn paste_brackets_when_the_program_asks() {
         let delegate = Arc::new(CountingDelegate {


### PR DESCRIPTION
Supersedes #1895 (keeps @ezemtsov's commit), adding two fixes to Surface::paste on top of the new C entry point.

**Escape filtering.** The bracketed payload previously went out unfiltered, so a clipboard containing `ESC[201~` could close the bracket early and inject keystrokes. ESC and ETX are now removed from the payload, the same filtering rioterm's Screen::paste already does.

**Verbatim payload when bracketed.** Newlines were normalized to CR even inside the brackets, defeating the point of mode 2004 (programs want to distinguish a pasted newline from Enter). The payload is now sent verbatim when bracketed; CR normalization applies only to unbracketed paste, again matching rioterm.

The encoding now lives in a pure `encode_paste` helper with byte-level tests covering both modes and the injection case. `rio_surface_paste` itself is unchanged from #1895.