### PR TITLE
librio ctest: paste after prompt is idle

### DIFF
--- a/librio/ctest/main.c
+++ b/librio/ctest/main.c
@@ -13,6 +13,30 @@ static void on_wakeup(void *userdata, rio_surface_id_t surface) {
   atomic_fetch_add(&wakeups, 1);
 }
 
+static int wait_for(rio_render_state_t *state, const char *needle) {
+  for (int attempt = 0; attempt < 200; attempt++) {
+    rio_render_state_update(state);
+    uint16_t lines = rio_render_state_lines(state);
+    uint16_t cols = rio_render_state_columns(state);
+    for (uint16_t line = 0; line < lines; line++) {
+      char text[512] = {0};
+      uint16_t limit = cols < 511 ? cols : 511;
+      for (uint16_t col = 0; col < limit; col++) {
+        rio_cell_s cell = rio_render_state_cell(state, line, col);
+        text[col] = (cell.codepoint >= 32 && cell.codepoint < 127)
+                        ? (char)cell.codepoint
+                        : ' ';
+      }
+      if (strstr(text, needle)) {
+        printf("row %u: %s\n", line, text);
+        return 1;
+      }
+    }
+    usleep(25 * 1000);
+  }
+  return 0;
+}
+
 int main(void) {
   rio_runtime_config_s config = {0};
   config.wakeup_cb = on_wakeup;
@@ -39,36 +63,14 @@ int main(void) {
   usleep(400 * 1000);
   const char *cmd = "printf '%s%s\\n' li brio-cgate\r";
   rio_surface_text(surface, cmd, strlen(cmd));
-  const char *pasted = "librio-pgate";
-  rio_surface_paste(surface, pasted, strlen(pasted));
 
   rio_render_state_t *state = rio_render_state_new(surface);
-  int found = 0;
-  int found_paste = 0;
-  for (int attempt = 0; attempt < 200 && !(found && found_paste); attempt++) {
-    rio_render_state_update(state);
-    uint16_t lines = rio_render_state_lines(state);
-    uint16_t cols = rio_render_state_columns(state);
-    for (uint16_t line = 0; line < lines; line++) {
-      char text[512] = {0};
-      uint16_t limit = cols < 511 ? cols : 511;
-      for (uint16_t col = 0; col < limit; col++) {
-        rio_cell_s cell = rio_render_state_cell(state, line, col);
-        text[col] = (cell.codepoint >= 32 && cell.codepoint < 127)
-                        ? (char)cell.codepoint
-                        : ' ';
-      }
-      if (!found && strstr(text, "librio-cgate")) {
-        printf("row %u: %s\n", line, text);
-        found = 1;
-      }
-      if (!found_paste && strstr(text, "librio-pgate")) {
-        printf("paste row %u: %s\n", line, text);
-        found_paste = 1;
-      }
-    }
-    usleep(25 * 1000);
-  }
+  int found = wait_for(state, "librio-cgate");
+
+  /* Paste at the idle prompt; echo of mid-command input is shell-dependent. */
+  const char *pasted = "librio-pgate";
+  rio_surface_paste(surface, pasted, strlen(pasted));
+  int found_paste = wait_for(state, "librio-pgate");
 
   rio_cursor_s cursor = rio_render_state_cursor(state);
   printf("wakeups=%d cursor=%u,%u found=%d found_paste=%d\n",


### PR DESCRIPTION
Fixes the librio C gate failure on CI introduced by #1896.

The gate pasted immediately after sending the printf command, while the shell was still executing it. Whether that type-ahead gets echoed depends on the shell and the tty state it happens to be in at that instant: it worked under local zsh but not under the runner's bash 3.2, where the paste was consumed without ever being displayed (found_paste=0).

The gate now waits until the first marker (librio-cgate) appears, meaning the shell is back at an idle prompt, and only then pastes. At an idle prompt every shell reliably displays incoming input. Verified locally against both zsh and bash 3.2 (via the surface config shell override); both pass. The duplicated scan loop is factored into a wait_for helper in passing.