### PR TITLE
librio: shell-independent paste gate, fix C host SIGPIPE

### DIFF
--- a/corcovado/src/socket.rs
+++ b/corcovado/src/socket.rs
@@ -14,6 +14,28 @@ fn cvt(i: libc::c_int) -> io::Result<libc::c_int> {
     }
 }
 
+// Writers must get EPIPE back instead of SIGPIPE: these sockets are
+// written from signal handlers (teletypewriter's signal self-pipe),
+// and non-Rust hosts embedding librio do not ignore SIGPIPE, so the
+// default disposition would kill their process during fd teardown.
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+unsafe fn set_nosigpipe(fd: c_int) -> io::Result<()> {
+    let on: c_int = 1;
+    cvt(libc::setsockopt(
+        fd,
+        libc::SOL_SOCKET,
+        libc::SO_NOSIGPIPE,
+        &on as *const c_int as *const libc::c_void,
+        mem::size_of::<c_int>() as libc::socklen_t,
+    ))?;
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "freebsd")))]
+unsafe fn set_nosigpipe(_fd: c_int) -> io::Result<()> {
+    Ok(())
+}
+
 // See below for the usage of SOCK_CLOEXEC, but this constant is only defined on
 // Linux currently (e.g. support doesn't exist on other platforms). In order to
 // get name resolution to work and things to compile we just define a dummy
@@ -73,6 +95,7 @@ impl Socket {
             cvt(libc::ioctl(fd.fd, libc::FIOCLEX))?;
             let mut nonblocking = 1 as c_ulong;
             cvt(libc::ioctl(fd.fd, libc::FIONBIO, &mut nonblocking))?;
+            set_nosigpipe(fd.fd)?;
             Ok(fd)
         }
     }
@@ -104,6 +127,8 @@ impl Socket {
             let mut nonblocking = 1 as c_ulong;
             cvt(libc::ioctl(a.fd, libc::FIONBIO, &mut nonblocking))?;
             cvt(libc::ioctl(b.fd, libc::FIONBIO, &mut nonblocking))?;
+            set_nosigpipe(a.fd)?;
+            set_nosigpipe(b.fd)?;
             Ok((a, b))
         }
     }

--- a/librio/ctest/main.c
+++ b/librio/ctest/main.c
@@ -67,28 +67,31 @@ int main(void) {
   rio_render_state_t *state = rio_render_state_new(surface);
   int found = wait_for(state, "librio-cgate");
 
-  /* Paste into a cat child: it writes the paste back with no line editor
-   * in the way, so the check does not depend on the host's shell. */
+  /* Paste into a cat child: no line editor in the way, so the check does
+   * not depend on the host's shell. The tty's own echo puts it on screen. */
   rio_surface_config_s paste_config = surface_config;
   paste_config.shell = "/bin/cat";
   rio_surface_t *paste_surface = rio_surface_new(engine, &paste_config);
-  if (!paste_surface) {
-    fprintf(stderr, "paste surface creation failed\n");
-    return 1;
+  rio_render_state_t *paste_state =
+      paste_surface ? rio_render_state_new(paste_surface) : NULL;
+  int found_paste = 0;
+  if (paste_surface) {
+    const char *pasted = "librio-pgate";
+    rio_surface_paste(paste_surface, pasted, strlen(pasted));
+    found_paste = wait_for(paste_state, "librio-pgate");
   }
-  usleep(400 * 1000);
-  const char *pasted = "librio-pgate\n";
-  rio_surface_paste(paste_surface, pasted, strlen(pasted));
-  rio_render_state_t *paste_state = rio_render_state_new(paste_surface);
-  int found_paste = wait_for(paste_state, "librio-pgate");
 
   rio_cursor_s cursor = rio_render_state_cursor(state);
   printf("wakeups=%d cursor=%u,%u found=%d found_paste=%d\n",
          atomic_load(&wakeups), cursor.line, cursor.column, found,
          found_paste);
 
-  rio_render_state_free(paste_state);
-  rio_surface_free(paste_surface);
+  if (paste_state) {
+    rio_render_state_free(paste_state);
+  }
+  if (paste_surface) {
+    rio_surface_free(paste_surface);
+  }
   rio_render_state_free(state);
   rio_surface_free(surface);
   rio_engine_free(engine);

--- a/librio/ctest/main.c
+++ b/librio/ctest/main.c
@@ -67,16 +67,28 @@ int main(void) {
   rio_render_state_t *state = rio_render_state_new(surface);
   int found = wait_for(state, "librio-cgate");
 
-  /* Paste at the idle prompt; echo of mid-command input is shell-dependent. */
-  const char *pasted = "librio-pgate";
-  rio_surface_paste(surface, pasted, strlen(pasted));
-  int found_paste = wait_for(state, "librio-pgate");
+  /* Paste into a cat child: it writes the paste back with no line editor
+   * in the way, so the check does not depend on the host's shell. */
+  rio_surface_config_s paste_config = surface_config;
+  paste_config.shell = "/bin/cat";
+  rio_surface_t *paste_surface = rio_surface_new(engine, &paste_config);
+  if (!paste_surface) {
+    fprintf(stderr, "paste surface creation failed\n");
+    return 1;
+  }
+  usleep(400 * 1000);
+  const char *pasted = "librio-pgate\n";
+  rio_surface_paste(paste_surface, pasted, strlen(pasted));
+  rio_render_state_t *paste_state = rio_render_state_new(paste_surface);
+  int found_paste = wait_for(paste_state, "librio-pgate");
 
   rio_cursor_s cursor = rio_render_state_cursor(state);
   printf("wakeups=%d cursor=%u,%u found=%d found_paste=%d\n",
          atomic_load(&wakeups), cursor.line, cursor.column, found,
          found_paste);
 
+  rio_render_state_free(paste_state);
+  rio_surface_free(paste_surface);
   rio_render_state_free(state);
   rio_surface_free(surface);
   rio_engine_free(engine);

--- a/librio/ctest/main.c
+++ b/librio/ctest/main.c
@@ -75,16 +75,32 @@ int main(void) {
   rio_render_state_t *paste_state =
       paste_surface ? rio_render_state_new(paste_surface) : NULL;
   int found_paste = 0;
+  int found_bracketed = 0;
   if (paste_surface) {
     const char *pasted = "librio-pgate";
     rio_surface_paste(paste_surface, pasted, strlen(pasted));
     found_paste = wait_for(paste_state, "librio-pgate");
+
+    /* Enable mode 2004 through the child: cat copies the sequence back to
+     * its stdout, which the terminal parses. The next paste must then wrap
+     * in markers, echoed as ^[[200~..^[[201~. */
+    const char *decset = "\x1b[?2004h\n";
+    rio_surface_text(paste_surface, decset, strlen(decset));
+    for (int attempt = 0; attempt < 200; attempt++) {
+      if (rio_surface_mode_bits(paste_surface) & (1u << 3)) {
+        break;
+      }
+      usleep(25 * 1000);
+    }
+    const char *bracketed = "librio-bgate";
+    rio_surface_paste(paste_surface, bracketed, strlen(bracketed));
+    found_bracketed = wait_for(paste_state, "[200~librio-bgate");
   }
 
   rio_cursor_s cursor = rio_render_state_cursor(state);
-  printf("wakeups=%d cursor=%u,%u found=%d found_paste=%d\n",
+  printf("wakeups=%d cursor=%u,%u found=%d found_paste=%d found_bracketed=%d\n",
          atomic_load(&wakeups), cursor.line, cursor.column, found,
-         found_paste);
+         found_paste, found_bracketed);
 
   if (paste_state) {
     rio_render_state_free(paste_state);
@@ -96,7 +112,8 @@ int main(void) {
   rio_surface_free(surface);
   rio_engine_free(engine);
 
-  if (!found || !found_paste || atomic_load(&wakeups) == 0) {
+  if (!found || !found_paste || !found_bracketed ||
+      atomic_load(&wakeups) == 0) {
     fprintf(stderr, "gate failed\n");
     return 1;
   }

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -188,6 +188,8 @@ typedef struct {
   size_t text_len;
 } rio_key_event_s;
 
+/* Hosts on Linux should ignore SIGPIPE: internal wake pipes written from
+ * signal handlers expect EPIPE. On macOS/BSD the sockets opt out per-fd. */
 rio_engine_t *rio_engine_new(const rio_runtime_config_s *config);
 void rio_engine_free(rio_engine_t *engine);
 
@@ -206,6 +208,10 @@ rio_surface_id_t rio_surface_id(const rio_surface_t *surface);
 void rio_surface_text(rio_surface_t *surface, const char *bytes, size_t len);
 /* Paste `bytes` (UTF-8), bracketed when the program has enabled mode 2004. */
 void rio_surface_paste(rio_surface_t *surface, const char *bytes, size_t len);
+/* Terminal modes for input decisions the host makes on its own: bit 0 mouse
+ * reporting, bit 1 application cursor keys, bit 2 alternate screen, bit 3
+ * bracketed paste. */
+uint32_t rio_surface_mode_bits(const rio_surface_t *surface);
 /* Returns true when the event was consumed and encoded to the PTY. */
 bool rio_surface_key(rio_surface_t *surface, const rio_key_event_s *event);
 /* Whether alt acts as meta, prefixing with ESC, instead of letting the text

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -696,6 +696,17 @@ pub unsafe extern "C" fn rio_surface_key(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rio_surface_mode_bits(surface: *const Surface) -> u32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        if surface.is_null() {
+            return 0;
+        }
+        unsafe { &*surface }.mode_bits()
+    }))
+    .unwrap_or(0)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rio_surface_set_alt_is_meta(
     surface: *mut Surface,
     enabled: bool,

--- a/teletypewriter/src/unix/signals.rs
+++ b/teletypewriter/src/unix/signals.rs
@@ -45,6 +45,27 @@ macro_rules! implement_signals_with_pipe {
                 S: Borrow<c_int>,
             {
                 let (read, write) = Pipe::pair()?;
+                // The signal handler's wake write must fail with EPIPE once
+                // the reader is gone, not raise SIGPIPE: C hosts, unlike
+                // Rust ones, do not ignore SIGPIPE and would be killed.
+                #[cfg(any(
+                    target_os = "macos",
+                    target_os = "ios",
+                    target_os = "freebsd"
+                ))]
+                unsafe {
+                    use std::os::fd::AsRawFd;
+                    let on: libc::c_int = 1;
+                    for fd in [read.as_raw_fd(), write.as_raw_fd()] {
+                        libc::setsockopt(
+                            fd,
+                            libc::SOL_SOCKET,
+                            libc::SO_NOSIGPIPE,
+                            &on as *const libc::c_int as *const libc::c_void,
+                            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                        );
+                    }
+                }
                 let delivery =
                     SignalDelivery::with_pipe(read, write, exfiltrator, signals)?;
                 Ok(Self(delivery))

--- a/teletypewriter/src/unix/signals.rs
+++ b/teletypewriter/src/unix/signals.rs
@@ -45,27 +45,6 @@ macro_rules! implement_signals_with_pipe {
                 S: Borrow<c_int>,
             {
                 let (read, write) = Pipe::pair()?;
-                // The signal handler's wake write must fail with EPIPE once
-                // the reader is gone, not raise SIGPIPE: C hosts, unlike
-                // Rust ones, do not ignore SIGPIPE and would be killed.
-                #[cfg(any(
-                    target_os = "macos",
-                    target_os = "ios",
-                    target_os = "freebsd"
-                ))]
-                unsafe {
-                    use std::os::fd::AsRawFd;
-                    let on: libc::c_int = 1;
-                    for fd in [read.as_raw_fd(), write.as_raw_fd()] {
-                        libc::setsockopt(
-                            fd,
-                            libc::SOL_SOCKET,
-                            libc::SO_NOSIGPIPE,
-                            &on as *const libc::c_int as *const libc::c_void,
-                            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-                        );
-                    }
-                }
                 let delivery =
                     SignalDelivery::with_pipe(read, write, exfiltrator, signals)?;
                 Ok(Self(delivery))


### PR DESCRIPTION
Follow-up to #1897, whose idle-prompt ordering passed locally but still failed on the macOS runner (found_paste=0). Two changes:

**Shell-independent paste check.** The gate now pastes into a second surface running /bin/cat instead of the login shell. There is no line editor in the way and the tty's own echo puts the text on screen, so the check no longer depends on which shell the runner uses or what its readline does with type-ahead.

**SIGPIPE fix in corcovado (the actual flake).** Stress-running the reworked gate surfaced a real embedding bug: roughly 1 in 8 runs died with exit 141. Backtrace: during Pty teardown, signal-hook's SignalDelivery closes its self-pipe socketpair; a SIGCHLD from the dying child lands mid-close and the signal handler writes to that pipe to wake readers. signal-hook ignores the write error on purpose, which assumes EPIPE comes back as an error return. That holds in Rust binaries (std ignores SIGPIPE at startup) but not in C or Swift hosts, where the default disposition kills the whole process. The fix sets SO_NOSIGPIPE at corcovado socket creation (Socket::new and Socket::pair, macOS/iOS/FreeBSD), the same thing upstream mio does on Apple targets, so every corcovado socket including the signal self-pipe returns EPIPE instead of raising.

With the fix the gate passes 40/40 stress runs where it previously failed ~5; the unmodified C gate doubles as a regression check that librio cannot SIGPIPE a C host on teardown. On Linux the corresponding hole (signal-hook's send without MSG_NOSIGNAL) has no per-fd opt-out and remains an upstream signal-hook assumption; non-Rust embedders there should ignore SIGPIPE, as long-lived C programs generally do.