### PR TITLE
librio tests: spawn sleeper via /bin/sh

### DIFF
--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -1584,15 +1584,16 @@ mod tests {
     }
 
     // A child that never writes, so buffer contents are exactly what the
-    // test injected and comparisons can't race the shell prompt.
+    // test injected and comparisons can't race the shell prompt. Spawned
+    // via /bin/sh, the one binary the nix build sandbox provides.
     fn quiet_surface(cols: u16, rows: u16) -> Surface {
         let engine = Engine::new(Arc::new(CountingDelegate {
             wakeups: AtomicUsize::new(0),
         }));
         engine
             .create_surface(&SurfaceDesc {
-                shell: Some("/bin/sleep".to_string()),
-                args: vec!["300".to_string()],
+                shell: Some("/bin/sh".to_string()),
+                args: vec!["-c".to_string(), "sleep 300".to_string()],
                 cols,
                 rows,
                 ..SurfaceDesc::default()


### PR DESCRIPTION
The Nix Build workflow has been failing on main for several days: 11 librio tests spawn /bin/sleep through the quiet_surface helper, and the nix build sandbox provides no /bin/sleep (only /bin/sh). The sleeper now spawns as /bin/sh -c 'sleep 300', which works in the sandbox and everywhere else.

Surfaced on #1898, whose Cargo.lock change happened to trigger the nix workflow on a PR; the failure predates it (every recent Nix Build run on main is red with the same 11 tests).