### PR TITLE
Fix URL hint matching and OSC 8 rule handling

### DIFF
--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -86,16 +86,19 @@ impl HintState {
             }
         };
 
-        // Find regex matches if regex is specified
-        if let Some(regex_pattern) = &hint.regex {
-            if let Ok(regex) = onig::Regex::new(regex_pattern) {
-                self.find_regex_matches(term, &regex, hint.clone());
-            }
+        let regex = match hint.regex.as_deref().map(onig::Regex::new) {
+            Some(Ok(regex)) => Some(regex),
+            Some(Err(_)) => return,
+            None => None,
+        };
+
+        if let Some(regex) = &regex {
+            self.find_regex_matches(term, regex, hint.clone());
         }
 
         // Find OSC 8 hyperlinks if enabled
         if hint.hyperlinks {
-            self.find_hyperlink_matches(term, hint.clone());
+            self.find_hyperlink_matches(term, regex.as_ref(), hint.clone());
         }
 
         // Cancel hint mode if no matches found
@@ -252,6 +255,7 @@ impl HintState {
     fn find_hyperlink_matches<T: EventListener>(
         &mut self,
         term: &rio_backend::crosswords::Crosswords<T>,
+        regex: Option<&onig::Regex>,
         hint: Rc<Hint>,
     ) {
         // Walk the visible region looking for OSC 8 hyperlink spans.
@@ -295,6 +299,10 @@ impl HintState {
 
                 // Look up the URI once for the whole span.
                 if let Some(hyperlink) = term.cell_hyperlink(line, Column(start_col)) {
+                    if !hyperlink_matches_rule(regex, hyperlink.uri()) {
+                        col = end_col;
+                        continue;
+                    }
                     let mut uri = hyperlink.uri().to_string();
                     if hint.post_processing {
                         uri = post_process_hyperlink_uri(&uri);
@@ -336,6 +344,10 @@ impl HintState {
             self.labels.push(generator.next());
         }
     }
+}
+
+pub(crate) fn hyperlink_matches_rule(regex: Option<&onig::Regex>, uri: &str) -> bool {
+    regex.is_none_or(|regex| regex.find(uri).is_some())
 }
 
 /// Generates hint labels using the specified alphabet
@@ -752,6 +764,13 @@ fn post_process_hyperlink_uri(uri: &str) -> String {
 mod tests {
     use super::*;
     use rio_backend::config::hints::{HintAction, HintInternalAction};
+
+    #[test]
+    fn hyperlink_rule_filters_osc8_uri() {
+        let file = onig::Regex::new(r"^file://").unwrap();
+        assert!(hyperlink_matches_rule(Some(&file), "file://host/tmp/a.md"));
+        assert!(!hyperlink_matches_rule(Some(&file), "https://example.com"));
+    }
 
     #[test]
     fn test_label_generator() {

--- a/frontends/rioterm/src/hints.rs
+++ b/frontends/rioterm/src/hints.rs
@@ -330,7 +330,7 @@ impl HintState {
 
         for col in 0..grid.columns() {
             let cell = &grid[line][Column(col)];
-            text.push(cell.c());
+            text.push(cell_char_for_regex(cell.c()));
         }
 
         text.trim_end().to_string()
@@ -343,6 +343,14 @@ impl HintState {
         for _ in 0..self.matches.len() {
             self.labels.push(generator.next());
         }
+    }
+}
+
+fn cell_char_for_regex(c: char) -> char {
+    if c == '\0' {
+        ' '
+    } else {
+        c
     }
 }
 
@@ -764,6 +772,18 @@ fn post_process_hyperlink_uri(uri: &str) -> String {
 mod tests {
     use super::*;
     use rio_backend::config::hints::{HintAction, HintInternalAction};
+
+    #[test]
+    fn empty_grid_cells_are_regex_whitespace() {
+        let line: String = "https://example.com"
+            .chars()
+            .chain(['\0', '\0'])
+            .map(cell_char_for_regex)
+            .collect();
+        let regex = onig::Regex::new(r"https?://[^\s]+").unwrap();
+
+        assert_eq!(regex.find_iter(&line).next(), Some((0, 19)));
+    }
 
     #[test]
     fn hyperlink_rule_filters_osc8_uri() {

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -2150,36 +2150,40 @@ impl Screen<'_> {
                 continue;
             }
 
+            let regex = match hint_config.regex.as_deref() {
+                Some(pattern) => match self.compiled_hint_regex(pattern) {
+                    Some(regex) => Some(regex),
+                    None => continue,
+                },
+                None => None,
+            };
+
             // Check hyperlinks if enabled
             if hint_config.hyperlinks {
-                if let Some(hyperlink_match) =
-                    self.find_hyperlink_at_point(terminal, point)
-                {
+                if let Some(hyperlink_match) = self.find_hyperlink_at_point(
+                    terminal,
+                    point,
+                    regex.as_deref(),
+                    hint_config.clone(),
+                ) {
                     return Some(hyperlink_match);
                 }
             }
 
             // Check regex patterns if specified
-            if let Some(regex_pattern) = &hint_config.regex {
-                if let Some(regex) = self.compiled_hint_regex(regex_pattern) {
-                    let line = logical_line.get_or_insert_with(|| {
-                        crate::hints::LogicalLine::extract(terminal, point)
+            if let Some(regex) = &regex {
+                let line = logical_line.get_or_insert_with(|| {
+                    crate::hints::LogicalLine::extract(terminal, point)
+                });
+                if let Some(m) = line.as_ref().and_then(|line| {
+                    line.match_at(terminal, point, regex, hint_config.post_processing)
+                }) {
+                    return Some(crate::hints::HintMatch {
+                        text: m.text,
+                        start: m.start,
+                        end: m.end,
+                        hint: hint_config.clone(),
                     });
-                    if let Some(m) = line.as_ref().and_then(|line| {
-                        line.match_at(
-                            terminal,
-                            point,
-                            &regex,
-                            hint_config.post_processing,
-                        )
-                    }) {
-                        return Some(crate::hints::HintMatch {
-                            text: m.text,
-                            start: m.start,
-                            end: m.end,
-                            hint: hint_config.clone(),
-                        });
-                    }
                 }
             }
         }
@@ -2192,6 +2196,8 @@ impl Screen<'_> {
         &self,
         terminal: &rio_backend::crosswords::Crosswords<EventProxy>,
         point: rio_backend::crosswords::pos::Pos,
+        regex: Option<&onig::Regex>,
+        hint_config: std::rc::Rc<rio_backend::config::hints::Hint>,
     ) -> Option<crate::hints::HintMatch> {
         let grid = &terminal.grid;
 
@@ -2207,6 +2213,9 @@ impl Screen<'_> {
         // a different id while belonging to the same link) to find the
         // span boundaries.
         let hyperlink = terminal.cell_hyperlink(point.row, point.col)?;
+        if !crate::hints::hyperlink_matches_rule(regex, hyperlink.uri()) {
+            return None;
+        }
 
         let mut start_col = point.col;
         let mut end_col = point.col;
@@ -2227,21 +2236,6 @@ impl Screen<'_> {
                 break;
             }
         }
-
-        // Build a synthetic hint config so the rest of the hint
-        // pipeline (highlighting, click action) treats this just like
-        // a regex/url match.
-        let hint_config = std::rc::Rc::new(rio_backend::config::hints::Hint {
-            regex: None,
-            hyperlinks: true,
-            post_processing: true,
-            persist: false,
-            action: rio_backend::config::hints::HintAction::Action {
-                action: rio_backend::config::hints::HintInternalAction::Open,
-            },
-            mouse: rio_backend::config::hints::HintMouse::default(),
-            binding: None,
-        });
 
         let mut uri = hyperlink.uri().to_string();
         if hint_config.post_processing {


### PR DESCRIPTION
## What changed

- Keep the configured hint rule for OSC 8 hyperlinks instead of replacing it with a synthetic `Open` rule.
- Apply the rule regex and post-processing setting to the hyperlink URI.
- Treat empty grid cells as whitespace during regex matching, so patterns such as `[^\s]+` stop at the visible end of the line.

## Why

OSC 8 hyperlinks currently bypass the configured rule action when clicked. Regex hint matching can also consume terminal padding because empty cells contain `\0`, which is not whitespace. Together these bugs produce the wrong action or match text for custom URL and path rules.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p rioterm --features wgpu`
- Manually tested on Windows for several days with URL and path hint rules
