### PR TITLE
fix: window.opacity transparency on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,6 +4042,7 @@ version = "0.5.26"
 dependencies = [
  "ahash",
  "bitflags 2.13.1",
+ "cfg_aliases",
  "clap",
  "corcovado",
  "cpal",

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -60,6 +60,9 @@ cpal = { version = "0.15", optional = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = { workspace = true }
 
+[build-dependencies]
+cfg_aliases = "0.2.1"
+
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.12"
 

--- a/frontends/rioterm/build.rs
+++ b/frontends/rioterm/build.rs
@@ -1,9 +1,16 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
-        // rioterm's own `wgpu` feature, or Windows, where sugarloaf and
-        // rio-backend get the feature through the target-specific
-        // dependency override so the wgpu code paths always exist.
-        wgpu_backend: { any(feature = "wgpu", target_os = "windows") },
+        // rioterm's own `wgpu` feature, or the targets whose
+        // target-specific dependency overrides force the feature onto
+        // sugarloaf and rio-backend (Windows and wasm32 in Cargo.toml),
+        // so the wgpu code paths always exist there.
+        wgpu_backend: {
+            any(
+                feature = "wgpu",
+                target_os = "windows",
+                target_arch = "wasm32"
+            )
+        },
     }
 
     // wgpu-hal references HDR colorspace constants (ExtendedDisplayP3,

--- a/frontends/rioterm/build.rs
+++ b/frontends/rioterm/build.rs
@@ -1,4 +1,11 @@
 fn main() {
+    cfg_aliases::cfg_aliases! {
+        // rioterm's own `wgpu` feature, or Windows, where sugarloaf and
+        // rio-backend get the feature through the target-specific
+        // dependency override so the wgpu code paths always exist.
+        wgpu_backend: { any(feature = "wgpu", target_os = "windows") },
+    }
+
     // wgpu-hal references HDR colorspace constants (ExtendedDisplayP3,
     // the ITUR_2100 pair) that older macOS does not export. Their use
     // is runtime-gated inside wgpu, but the references link as strong

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -165,16 +165,36 @@ impl Screen<'_> {
         let backend = if config.renderer.use_cpu {
             SugarloafBackend::Cpu
         } else {
+            // `feature = "wgpu"` here gates rioterm's own dep feature,
+            // which is OFF in the default `cargo build` profile. On
+            // Windows the wgpu code is still compiled into sugarloaf +
+            // rio-backend via the target-specific dependency override
+            // (`[target.'cfg(windows)'.dependencies.sugarloaf] features
+            // = ["wgpu"]`), so we can — and must — take the wgpu code
+            // path on Windows even when rioterm's own `wgpu` feature
+            // isn't on. Without this OS override, default Windows
+            // builds silently fall back to the CPU rasterizer, which
+            // doesn't write per-pixel alpha and therefore renders the
+            // entire window fully transparent under the
+            // `with_transparent(true)` + `DwmEnableBlurBehindWindow`
+            // path that `window.opacity < 1` engages.
             match config.renderer.backend {
                 // `Backend::Vulkan` from the user config means the
                 // native ash backend on Linux. Other OSes fall through
-                // to the wgpu Vulkan path when the `wgpu` feature is
-                // on; otherwise we degrade to CPU rasterizer.
+                // to the wgpu Vulkan path when wgpu is available;
+                // otherwise we degrade to CPU rasterizer.
                 #[cfg(target_os = "linux")]
                 Backend::Vulkan => SugarloafBackend::Vulkan,
-                #[cfg(all(not(target_os = "linux"), feature = "wgpu"))]
+                #[cfg(all(
+                    not(target_os = "linux"),
+                    any(feature = "wgpu", target_os = "windows")
+                ))]
                 Backend::Vulkan => SugarloafBackend::Wgpu(wgpu::Backends::VULKAN),
-                #[cfg(all(not(target_os = "linux"), not(feature = "wgpu")))]
+                #[cfg(all(
+                    not(target_os = "linux"),
+                    not(feature = "wgpu"),
+                    not(target_os = "windows")
+                ))]
                 Backend::Vulkan => SugarloafBackend::Cpu,
                 #[cfg(target_os = "macos")]
                 Backend::Metal => SugarloafBackend::Metal,
@@ -182,9 +202,12 @@ impl Screen<'_> {
                 Backend::Webgpu => SugarloafBackend::Wgpu(
                     wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
                 ),
-                #[cfg(all(feature = "wgpu", not(target_arch = "wasm32")))]
+                #[cfg(all(
+                    any(feature = "wgpu", target_os = "windows"),
+                    not(target_arch = "wasm32")
+                ))]
                 Backend::Webgpu => SugarloafBackend::Wgpu(wgpu::Backends::all()),
-                #[cfg(not(feature = "wgpu"))]
+                #[cfg(all(not(feature = "wgpu"), not(target_os = "windows")))]
                 Backend::Webgpu => SugarloafBackend::Cpu,
             }
         };
@@ -208,7 +231,7 @@ impl Screen<'_> {
             }
         };
 
-        #[cfg(feature = "wgpu")]
+        #[cfg(any(feature = "wgpu", target_os = "windows"))]
         sugarloaf.update_filters(config.renderer.filters.as_slice());
 
         let mut renderer = Renderer::new(config);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -199,10 +199,12 @@ impl Screen<'_> {
             backend,
             font_features: config.fonts.features.clone(),
             colorspace: config.window.colorspace.to_sugarloaf_colorspace(),
-            // Same condition the window is created with
-            // (`with_transparent` in router/window.rs): a translucent
-            // window needs an adapter whose surface carries alpha.
-            prefer_alpha_capable_adapter: config.window.opacity < 1.,
+            // The exact predicate the rest of the frontend uses: glass
+            // blur forces the window bg alpha to 0 regardless of opacity,
+            // so it needs an alpha-carrying surface exactly like
+            // `window.opacity < 1` does. Fixed at surface creation; a
+            // live-reloaded opacity change takes effect on restart.
+            prefer_alpha_capable_adapter: !window_should_be_opaque(config),
         };
 
         let mut sugarloaf: Sugarloaf = match Sugarloaf::new(

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -165,19 +165,12 @@ impl Screen<'_> {
         let backend = if config.renderer.use_cpu {
             SugarloafBackend::Cpu
         } else {
-            // `feature = "wgpu"` here gates rioterm's own dep feature,
-            // which is OFF in the default `cargo build` profile. On
-            // Windows the wgpu code is still compiled into sugarloaf +
-            // rio-backend via the target-specific dependency override
-            // (`[target.'cfg(windows)'.dependencies.sugarloaf] features
-            // = ["wgpu"]`), so we can — and must — take the wgpu code
-            // path on Windows even when rioterm's own `wgpu` feature
-            // isn't on. Without this OS override, default Windows
-            // builds silently fall back to the CPU rasterizer, which
-            // doesn't write per-pixel alpha and therefore renders the
-            // entire window fully transparent under the
-            // `with_transparent(true)` + `DwmEnableBlurBehindWindow`
-            // path that `window.opacity < 1` engages.
+            // `wgpu_backend` (see build.rs): rioterm's own `wgpu`
+            // feature, or Windows, where sugarloaf and rio-backend get
+            // the feature through the target-specific dependency
+            // override so the wgpu code paths always exist. Without the
+            // Windows half, default builds there silently fall back to
+            // the CPU rasterizer.
             match config.renderer.backend {
                 // `Backend::Vulkan` from the user config means the
                 // native ash backend on Linux. Other OSes fall through
@@ -185,29 +178,19 @@ impl Screen<'_> {
                 // otherwise we degrade to CPU rasterizer.
                 #[cfg(target_os = "linux")]
                 Backend::Vulkan => SugarloafBackend::Vulkan,
-                #[cfg(all(
-                    not(target_os = "linux"),
-                    any(feature = "wgpu", target_os = "windows")
-                ))]
+                #[cfg(all(not(target_os = "linux"), wgpu_backend))]
                 Backend::Vulkan => SugarloafBackend::Wgpu(wgpu::Backends::VULKAN),
-                #[cfg(all(
-                    not(target_os = "linux"),
-                    not(feature = "wgpu"),
-                    not(target_os = "windows")
-                ))]
+                #[cfg(all(not(target_os = "linux"), not(wgpu_backend)))]
                 Backend::Vulkan => SugarloafBackend::Cpu,
                 #[cfg(target_os = "macos")]
                 Backend::Metal => SugarloafBackend::Metal,
-                #[cfg(all(feature = "wgpu", target_arch = "wasm32"))]
+                #[cfg(all(wgpu_backend, target_arch = "wasm32"))]
                 Backend::Webgpu => SugarloafBackend::Wgpu(
                     wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
                 ),
-                #[cfg(all(
-                    any(feature = "wgpu", target_os = "windows"),
-                    not(target_arch = "wasm32")
-                ))]
+                #[cfg(all(wgpu_backend, not(target_arch = "wasm32")))]
                 Backend::Webgpu => SugarloafBackend::Wgpu(wgpu::Backends::all()),
-                #[cfg(all(not(feature = "wgpu"), not(target_os = "windows")))]
+                #[cfg(not(wgpu_backend))]
                 Backend::Webgpu => SugarloafBackend::Cpu,
             }
         };
@@ -216,6 +199,10 @@ impl Screen<'_> {
             backend,
             font_features: config.fonts.features.clone(),
             colorspace: config.window.colorspace.to_sugarloaf_colorspace(),
+            // Same condition the window is created with
+            // (`with_transparent` in router/window.rs): a translucent
+            // window needs an adapter whose surface carries alpha.
+            prefer_alpha_capable_adapter: config.window.opacity < 1.,
         };
 
         let mut sugarloaf: Sugarloaf = match Sugarloaf::new(
@@ -231,7 +218,7 @@ impl Screen<'_> {
             }
         };
 
-        #[cfg(any(feature = "wgpu", target_os = "windows"))]
+        #[cfg(wgpu_backend)]
         sugarloaf.update_filters(config.renderer.filters.as_slice());
 
         let mut renderer = Renderer::new(config);
@@ -479,7 +466,10 @@ impl Screen<'_> {
         s.font_size = config.fonts.size;
         s.line_height = config.line_height;
 
-        #[cfg(feature = "wgpu")]
+        // `wgpu_backend`, not the bare feature: default Windows builds
+        // run the wgpu path too, and skipping this made `[renderer]
+        // filters` edits require a restart there.
+        #[cfg(wgpu_backend)]
         self.sugarloaf
             .update_filters(config.renderer.filters.as_slice());
 

--- a/libsugarloaf/src/capi.rs
+++ b/libsugarloaf/src/capi.rs
@@ -199,6 +199,7 @@ pub unsafe extern "C" fn sl_new(
             backend: default_backend(),
             font_features: None,
             colorspace: colorspace_from_u32(colorspace),
+            ..Default::default()
         };
         // The host rasterizes its own glyphs into the atlas, so this font
         // library only backs sugarloaf's (unused-by-us) UI text. A default

--- a/sugarloaf/src/context/webgpu.rs
+++ b/sugarloaf/src/context/webgpu.rs
@@ -6,7 +6,7 @@ pub struct WgpuContext<'a> {
     pub surface: wgpu::Surface<'a>,
     pub queue: wgpu::Queue,
     pub format: wgpu::TextureFormat,
-    alpha_mode: wgpu::CompositeAlphaMode,
+    pub alpha_mode: wgpu::CompositeAlphaMode,
     pub adapter_info: wgpu::AdapterInfo,
     surface_caps: wgpu::SurfaceCapabilities,
     pub size: SugarloafWindowSize,

--- a/sugarloaf/src/context/webgpu.rs
+++ b/sugarloaf/src/context/webgpu.rs
@@ -56,20 +56,60 @@ impl<'a> WgpuContext<'a> {
 
         let surface: wgpu::Surface<'a> =
             instance.create_surface(sugarloaf_window).unwrap();
-        let adapter = futures::executor::block_on(instance.request_adapter(
-            &wgpu::RequestAdapterOptions {
-                // Hard-coded — sugarloaf used to expose a
-                // `power_preference` knob, but in practice every Rio
-                // user picks `HighPerformance` (the alternative gives
-                // visibly worse text on hybrid laptops). Removed from
-                // the public API.
-                power_preference: wgpu::PowerPreference::HighPerformance,
-                compatible_surface: Some(&surface),
-                force_fallback_adapter: false,
-                apply_limit_buckets: false,
-            },
-        ))
-        .expect("Request adapter");
+        // A translucent window needs an adapter whose surface offers an
+        // alpha-carrying composite mode. On Windows that decides whether
+        // transparency works at all: DX12 HWND swapchains expose only
+        // `Opaque`, while Vulkan drivers expose `PreMultiplied`, and with
+        // `Backends::all()` either may win the default adapter request.
+        // Prefer an alpha-capable adapter (highest device class first)
+        // and fall back to the default request when none exists.
+        #[cfg(not(target_arch = "wasm32"))]
+        let alpha_capable_adapter = if renderer_config.prefer_alpha_capable_adapter {
+            futures::executor::block_on(instance.enumerate_adapters(backend))
+                .into_iter()
+                .filter(|adapter| {
+                    surface
+                        .get_capabilities(adapter)
+                        .alpha_modes
+                        .iter()
+                        .any(|mode| {
+                            matches!(
+                                mode,
+                                wgpu::CompositeAlphaMode::PreMultiplied
+                                    | wgpu::CompositeAlphaMode::PostMultiplied
+                            )
+                        })
+                })
+                .max_by_key(|adapter| match adapter.get_info().device_type {
+                    wgpu::DeviceType::DiscreteGpu => 4,
+                    wgpu::DeviceType::IntegratedGpu => 3,
+                    wgpu::DeviceType::VirtualGpu => 2,
+                    wgpu::DeviceType::Other => 1,
+                    wgpu::DeviceType::Cpu => 0,
+                })
+        } else {
+            None
+        };
+        #[cfg(target_arch = "wasm32")]
+        let alpha_capable_adapter = None;
+
+        let adapter = match alpha_capable_adapter {
+            Some(adapter) => adapter,
+            None => futures::executor::block_on(instance.request_adapter(
+                &wgpu::RequestAdapterOptions {
+                    // Hard-coded — sugarloaf used to expose a
+                    // `power_preference` knob, but in practice every Rio
+                    // user picks `HighPerformance` (the alternative gives
+                    // visibly worse text on hybrid laptops). Removed from
+                    // the public API.
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: Some(&surface),
+                    force_fallback_adapter: false,
+                    apply_limit_buckets: false,
+                },
+            ))
+            .expect("Request adapter"),
+        };
 
         let adapter_info = adapter.get_info();
         tracing::info!("Selected adapter: {:?}", adapter_info);

--- a/sugarloaf/src/context/webgpu.rs
+++ b/sugarloaf/src/context/webgpu.rs
@@ -41,61 +41,76 @@ impl<'a> WgpuContext<'a> {
         let instance = wgpu::Instance::new(instance_desc);
 
         tracing::info!("selected instance: {instance:?}");
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            tracing::info!("Available adapters:");
-            for a in futures::executor::block_on(
-                instance.enumerate_adapters(wgpu::Backends::all()),
-            ) {
-                tracing::info!("    {:?}", a.get_info())
-            }
-        }
-
         tracing::info!("initializing the surface");
 
         let surface: wgpu::Surface<'a> =
             instance.create_surface(sugarloaf_window).unwrap();
+
         // A translucent window needs an adapter whose surface offers an
         // alpha-carrying composite mode. On Windows that decides whether
         // transparency works at all: DX12 HWND swapchains expose only
         // `Opaque`, while Vulkan drivers expose `PreMultiplied`, and with
         // `Backends::all()` either may win the default adapter request.
-        // Prefer an alpha-capable adapter (highest device class first)
-        // and fall back to the default request when none exists.
+        // Prefer an alpha-capable hardware adapter (highest device class,
+        // ties broken deterministically by backend then enumeration
+        // order; software rasterizers never win over the default request)
+        // and fall back to the default request when none exists or the
+        // preferred one cannot create a device.
         #[cfg(not(target_arch = "wasm32"))]
         let alpha_capable_adapter = if renderer_config.prefer_alpha_capable_adapter {
-            futures::executor::block_on(instance.enumerate_adapters(backend))
-                .into_iter()
-                .filter(|adapter| {
-                    surface
-                        .get_capabilities(adapter)
-                        .alpha_modes
-                        .iter()
-                        .any(|mode| {
-                            matches!(
-                                mode,
-                                wgpu::CompositeAlphaMode::PreMultiplied
-                                    | wgpu::CompositeAlphaMode::PostMultiplied
-                            )
-                        })
-                })
-                .max_by_key(|adapter| match adapter.get_info().device_type {
-                    wgpu::DeviceType::DiscreteGpu => 4,
-                    wgpu::DeviceType::IntegratedGpu => 3,
-                    wgpu::DeviceType::VirtualGpu => 2,
-                    wgpu::DeviceType::Other => 1,
-                    wgpu::DeviceType::Cpu => 0,
-                })
+            let mut best: Option<(u8, u8, wgpu::Adapter)> = None;
+            for candidate in
+                futures::executor::block_on(instance.enumerate_adapters(backend))
+            {
+                let info = candidate.get_info();
+                tracing::info!("available adapter: {info:?}");
+                let device_rank = match info.device_type {
+                    wgpu::DeviceType::DiscreteGpu => 3,
+                    wgpu::DeviceType::IntegratedGpu => 2,
+                    wgpu::DeviceType::VirtualGpu => 1,
+                    wgpu::DeviceType::Other => 0,
+                    // A software rasterizer would technically satisfy the
+                    // alpha requirement while being unusably slow; the
+                    // fallback request below is the better outcome then.
+                    wgpu::DeviceType::Cpu => continue,
+                };
+                let backend_rank = match info.backend {
+                    wgpu::Backend::Vulkan | wgpu::Backend::Metal => 2,
+                    wgpu::Backend::Dx12 => 1,
+                    _ => 0,
+                };
+                let alpha_capable = surface
+                    .get_capabilities(&candidate)
+                    .alpha_modes
+                    .iter()
+                    .any(|mode| {
+                        matches!(
+                            mode,
+                            wgpu::CompositeAlphaMode::PreMultiplied
+                                | wgpu::CompositeAlphaMode::PostMultiplied
+                        )
+                    });
+                if !alpha_capable {
+                    continue;
+                }
+                // Strictly-greater keeps the first of equals, so the
+                // choice is stable across runs.
+                if best
+                    .as_ref()
+                    .is_none_or(|(d, b, _)| (device_rank, backend_rank) > (*d, *b))
+                {
+                    best = Some((device_rank, backend_rank, candidate));
+                }
+            }
+            best.map(|(_, _, adapter)| adapter)
         } else {
             None
         };
         #[cfg(target_arch = "wasm32")]
-        let alpha_capable_adapter = None;
+        let alpha_capable_adapter: Option<wgpu::Adapter> = None;
 
-        let adapter = match alpha_capable_adapter {
-            Some(adapter) => adapter,
-            None => futures::executor::block_on(instance.request_adapter(
+        let default_adapter = |surface: &wgpu::Surface| {
+            futures::executor::block_on(instance.request_adapter(
                 &wgpu::RequestAdapterOptions {
                     // Hard-coded — sugarloaf used to expose a
                     // `power_preference` knob, but in practice every Rio
@@ -103,12 +118,56 @@ impl<'a> WgpuContext<'a> {
                     // visibly worse text on hybrid laptops). Removed from
                     // the public API.
                     power_preference: wgpu::PowerPreference::HighPerformance,
-                    compatible_surface: Some(&surface),
+                    compatible_surface: Some(surface),
                     force_fallback_adapter: false,
                     apply_limit_buckets: false,
                 },
             ))
-            .expect("Request adapter"),
+            .expect("Request adapter")
+        };
+        let request_device = |adapter: &wgpu::Adapter| {
+            if let Ok(result) = futures::executor::block_on(
+                adapter.request_device(&wgpu::DeviceDescriptor::default()),
+            ) {
+                Ok((result.0, result.1))
+            } else {
+                // These downlevel limits will allow the code to run on all possible hardware
+                futures::executor::block_on(adapter.request_device(
+                    &wgpu::DeviceDescriptor {
+                        memory_hints: wgpu::MemoryHints::Performance,
+                        label: None,
+                        required_features: wgpu::Features::empty(),
+                        required_limits: wgpu::Limits::downlevel_webgl2_defaults(),
+                        ..Default::default()
+                    },
+                ))
+                .map(|result| (result.0, result.1))
+            }
+        };
+
+        let (adapter, device, queue) = match alpha_capable_adapter {
+            // A broken ICD can enumerate and answer capability queries yet
+            // fail device creation; fall back to the default request the
+            // way pre-preference code effectively did instead of aborting.
+            Some(preferred) => match request_device(&preferred) {
+                Ok((device, queue)) => (preferred, device, queue),
+                Err(err) => {
+                    tracing::warn!(
+                        "alpha-capable adapter {:?} refused a device ({err}); \
+                         falling back to the default adapter",
+                        preferred.get_info()
+                    );
+                    let adapter = default_adapter(&surface);
+                    let (device, queue) =
+                        request_device(&adapter).expect("Request device");
+                    (adapter, device, queue)
+                }
+            },
+            None => {
+                let adapter = default_adapter(&surface);
+                let (device, queue) = request_device(&adapter).expect("Request device");
+                (adapter, device, queue)
+            }
         };
 
         let adapter_info = adapter.get_info();
@@ -124,39 +183,21 @@ impl<'a> WgpuContext<'a> {
             renderer_config.colorspace,
         );
 
-        let (device, queue) = {
-            {
-                if let Ok(result) = futures::executor::block_on(
-                    adapter.request_device(&wgpu::DeviceDescriptor::default()),
-                ) {
-                    (result.0, result.1)
-                } else {
-                    // These downlevel limits will allow the code to run on all possible hardware
-                    let result = futures::executor::block_on(adapter.request_device(
-                        &wgpu::DeviceDescriptor {
-                            memory_hints: wgpu::MemoryHints::Performance,
-                            label: None,
-                            required_features: wgpu::Features::empty(),
-                            required_limits: wgpu::Limits::downlevel_webgl2_defaults(),
-                            ..Default::default()
-                        },
-                    ))
-                    .expect("Request device");
-                    (result.0, result.1)
-                }
-            }
-        };
-
+        // Every sugarloaf pipeline emits premultiplied alpha, so a surface
+        // that can composite premultiplied directly is the correct match;
+        // PostMultiplied stays as the fallback for surfaces that offer
+        // nothing else (wgpu's Metal backend), where only the fully-opaque
+        // and fully-transparent pixels compose identically either way.
         let alpha_mode = if surface_caps
-            .alpha_modes
-            .contains(&wgpu::CompositeAlphaMode::PostMultiplied)
-        {
-            wgpu::CompositeAlphaMode::PostMultiplied
-        } else if surface_caps
             .alpha_modes
             .contains(&wgpu::CompositeAlphaMode::PreMultiplied)
         {
             wgpu::CompositeAlphaMode::PreMultiplied
+        } else if surface_caps
+            .alpha_modes
+            .contains(&wgpu::CompositeAlphaMode::PostMultiplied)
+        {
+            wgpu::CompositeAlphaMode::PostMultiplied
         } else {
             wgpu::CompositeAlphaMode::Auto
         };

--- a/sugarloaf/src/grid/cpu.rs
+++ b/sugarloaf/src/grid/cpu.rs
@@ -542,10 +542,19 @@ fn premul(c: [u8; 4]) -> [u8; 4] {
 
 #[inline]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors treat it as opaque
+    // (DWM under `DwmEnableBlurBehindWindow`, Wayland surfaces).
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
-/// Premultiplied source-over against a 0x00RRGGBB destination.
+#[inline]
+fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
+    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+/// Premultiplied source-over against a premultiplied destination.
+/// Preserves the dst alpha channel through the blend so
+/// `window.opacity < 1` survives across overlapping cell paints.
 #[inline]
 fn blend_over(src: [u8; 4], dst: u32) -> u32 {
     let sa = src[3] as u32;
@@ -559,11 +568,18 @@ fn blend_over(src: [u8; 4], dst: u32) -> u32 {
     let dr = (dst >> 16) & 0xff;
     let dg = (dst >> 8) & 0xff;
     let db = dst & 0xff;
+    let da = (dst >> 24) & 0xff;
     // src is already premultiplied — add to attenuated dst.
     let or = src[0] as u32 + (dr * inv + 127) / 255;
     let og = src[1] as u32 + (dg * inv + 127) / 255;
     let ob = src[2] as u32 + (db * inv + 127) / 255;
-    pack_opaque(or.min(255) as u8, og.min(255) as u8, ob.min(255) as u8)
+    let oa = sa + (da * inv + 127) / 255;
+    pack_premul(
+        or.min(255) as u8,
+        og.min(255) as u8,
+        ob.min(255) as u8,
+        oa.min(255) as u8,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/sugarloaf/src/grid/cpu.rs
+++ b/sugarloaf/src/grid/cpu.rs
@@ -733,3 +733,26 @@ fn blit_color(
         }
     }
 }
+
+#[cfg(test)]
+mod blend_alpha_tests {
+    use super::*;
+
+    /// Opaque destinations stay opaque and transparent sources are
+    /// identity, alpha byte included: the invariants `window.opacity`
+    /// rides on now that the framebuffer carries real alpha.
+    #[test]
+    fn blend_over_propagates_alpha() {
+        let dst = 0xff20_4060;
+        for sa in 0..=255u8 {
+            let src = [sa / 2, sa / 3, sa, sa];
+            assert_eq!(blend_over(src, dst) >> 24, 0xff, "sa={sa}");
+        }
+        let translucent = 0x9912_3456;
+        assert_eq!(blend_over([0, 0, 0, 0], translucent), translucent);
+        // Porter-Duff source-over on the alpha channel.
+        let out = blend_over([0x40, 0x20, 0x10, 0x80], translucent);
+        let expected = 0x80u32 + (0x99 * (255 - 0x80) + 127) / 255;
+        assert_eq!(out >> 24, expected);
+    }
+}

--- a/sugarloaf/src/grid/cpu.rs
+++ b/sugarloaf/src/grid/cpu.rs
@@ -540,47 +540,7 @@ fn premul(c: [u8; 4]) -> [u8; 4] {
     ]
 }
 
-#[inline]
-fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    // alpha = 0xff so alpha-respecting compositors treat it as opaque
-    // (DWM under `DwmEnableBlurBehindWindow`, Wayland surfaces).
-    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
-}
-
-#[inline]
-fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
-    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
-}
-
-/// Premultiplied source-over against a premultiplied destination.
-/// Preserves the dst alpha channel through the blend so
-/// `window.opacity < 1` survives across overlapping cell paints.
-#[inline]
-fn blend_over(src: [u8; 4], dst: u32) -> u32 {
-    let sa = src[3] as u32;
-    if sa == 0 {
-        return dst;
-    }
-    if sa == 255 {
-        return pack_opaque(src[0], src[1], src[2]);
-    }
-    let inv = 255 - sa;
-    let dr = (dst >> 16) & 0xff;
-    let dg = (dst >> 8) & 0xff;
-    let db = dst & 0xff;
-    let da = (dst >> 24) & 0xff;
-    // src is already premultiplied — add to attenuated dst.
-    let or = src[0] as u32 + (dr * inv + 127) / 255;
-    let og = src[1] as u32 + (dg * inv + 127) / 255;
-    let ob = src[2] as u32 + (db * inv + 127) / 255;
-    let oa = sa + (da * inv + 127) / 255;
-    pack_premul(
-        or.min(255) as u8,
-        og.min(255) as u8,
-        ob.min(255) as u8,
-        oa.min(255) as u8,
-    )
-}
+use crate::premul::{blend_premul_over as blend_over, pack_opaque};
 
 #[allow(clippy::too_many_arguments)]
 fn fill_rect(
@@ -731,28 +691,5 @@ fn blit_color(
             let idx = buf_row + (dst_x as usize);
             buf[idx] = blend_over(src, buf[idx]);
         }
-    }
-}
-
-#[cfg(test)]
-mod blend_alpha_tests {
-    use super::*;
-
-    /// Opaque destinations stay opaque and transparent sources are
-    /// identity, alpha byte included: the invariants `window.opacity`
-    /// rides on now that the framebuffer carries real alpha.
-    #[test]
-    fn blend_over_propagates_alpha() {
-        let dst = 0xff20_4060;
-        for sa in 0..=255u8 {
-            let src = [sa / 2, sa / 3, sa, sa];
-            assert_eq!(blend_over(src, dst) >> 24, 0xff, "sa={sa}");
-        }
-        let translucent = 0x9912_3456;
-        assert_eq!(blend_over([0, 0, 0, 0], translucent), translucent);
-        // Porter-Duff source-over on the alpha channel.
-        let out = blend_over([0x40, 0x20, 0x10, 0x80], translucent);
-        let expected = 0x80u32 + (0x99 * (255 - 0x80) + 127) / 255;
-        assert_eq!(out >> 24, expected);
     }
 }

--- a/sugarloaf/src/lib.rs
+++ b/sugarloaf/src/lib.rs
@@ -4,6 +4,7 @@ pub mod font;
 mod font_cache;
 pub mod grid;
 pub mod layout;
+mod premul;
 pub mod renderer;
 pub mod sprite;
 mod sugarloaf;

--- a/sugarloaf/src/premul.rs
+++ b/sugarloaf/src/premul.rs
@@ -1,0 +1,72 @@
+// Shared premultiplied-ARGB pixel helpers for the CPU paths, which all
+// write `0xAARRGGBB` into softbuffer's framebuffer. The alpha byte is
+// meaningful: Windows DWM reads it for per-pixel window transparency
+// (softbuffer's other presenters ignore it), so every store must keep
+// the premultiplied invariant, each color channel <= alpha.
+
+#[inline(always)]
+pub(crate) fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
+    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+/// alpha = 0xff so alpha-respecting compositors treat the pixel as fully
+/// opaque (DWM under `DwmEnableBlurBehindWindow`). For non-transparent
+/// windows the OS ignores this byte, so writing 0xff is a no-op there.
+#[inline(always)]
+pub(crate) fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+/// Scalar premultiplied Porter-Duff source-over with exact `/255`
+/// rounding, all four channels. Preserving the destination alpha through
+/// the blend is what lets `window.opacity < 1` survive across
+/// overlapping paints instead of getting reset by every draw.
+#[inline]
+pub(crate) fn blend_premul_over(src: [u8; 4], dst: u32) -> u32 {
+    let sa = src[3] as u32;
+    if sa == 0 {
+        return dst;
+    }
+    if sa == 255 {
+        return pack_opaque(src[0], src[1], src[2]);
+    }
+    let inv = 255 - sa;
+    let dr = (dst >> 16) & 0xff;
+    let dg = (dst >> 8) & 0xff;
+    let db = dst & 0xff;
+    let da = (dst >> 24) & 0xff;
+    let or = src[0] as u32 + (dr * inv + 127) / 255;
+    let og = src[1] as u32 + (dg * inv + 127) / 255;
+    let ob = src[2] as u32 + (db * inv + 127) / 255;
+    let oa = sa + (da * inv + 127) / 255;
+    pack_premul(
+        or.min(255) as u8,
+        og.min(255) as u8,
+        ob.min(255) as u8,
+        oa.min(255) as u8,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Opaque destinations stay opaque and transparent sources are
+    /// identity, alpha byte included: the invariants `window.opacity`
+    /// rides on now that the framebuffer carries real alpha.
+    #[test]
+    fn blend_premul_over_propagates_alpha() {
+        assert_eq!(pack_opaque(1, 2, 3) >> 24, 0xff);
+        let dst = 0xff20_4060;
+        for sa in 0..=255u8 {
+            let src = [sa / 2, sa / 3, sa, sa];
+            assert_eq!(blend_premul_over(src, dst) >> 24, 0xff, "sa={sa}");
+        }
+        let translucent = 0x9912_3456;
+        assert_eq!(blend_premul_over([0, 0, 0, 0], translucent), translucent);
+        // Porter-Duff source-over on the alpha channel.
+        let out = blend_premul_over([0x40, 0x20, 0x10, 0x80], translucent);
+        let expected = 0x80u32 + (0x99 * (255 - 0x80) + 127) / 255;
+        assert_eq!(out >> 24, expected);
+    }
+}

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -73,10 +73,12 @@ fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
 }
 
 /// Scalar SWAR premultiplied source-over for all four channels (RGBA).
-/// Pairs R+B in a single u32 lane (`00RR00BB`), then G and A each on
-/// their own. Result preserves the premultiplied invariant so chained
-/// blends stay valid, which lets `window.opacity < 1` survive into the
-/// final framebuffer instead of getting masked back to alpha = 0.
+/// Pairs R+B in one u32 lane pair (`00RR00BB`) and A+G in the other
+/// (`00AA00GG`), so the fourth channel costs no extra multiply over the
+/// old opaque three-channel form. Result preserves the premultiplied
+/// invariant so chained blends stay valid, which lets
+/// `window.opacity < 1` survive into the final framebuffer instead of
+/// getting masked back to alpha = 0.
 #[inline(always)]
 fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
     let sa = (src_premul >> 24) & 0xff;
@@ -90,20 +92,16 @@ fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
     // R and B share a u32: 00RR00BB.
     let rb = (dst & 0x00ff_00ff) * inv;
     let rb = ((rb + 0x0080_0080 + ((rb >> 8) & 0x00ff_00ff)) >> 8) & 0x00ff_00ff;
-    // G alone.
-    let g = ((dst >> 8) & 0xff) * inv;
-    let g = ((g + 0x80 + (g >> 8)) >> 8) & 0xff;
-    // A alone — same `(x*inv) / 255` SWAR trick.
-    let da = (dst >> 24) & 0xff;
-    let a = da * inv;
-    let a = ((a + 0x80 + (a >> 8)) >> 8) & 0xff;
-    let dst_blended = rb | (g << 8) | (a << 24);
+    // A and G share the other pair: 00AA00GG.
+    let ag = ((dst >> 8) & 0x00ff_00ff) * inv;
+    let ag = ((ag + 0x0080_0080 + ((ag >> 8) & 0x00ff_00ff)) >> 8) & 0x00ff_00ff;
+    let dst_blended = rb | (ag << 8);
     // Premultiplied src guarantees src.rgb <= src.a (and src.a <= 0xff),
     // so adding to the attenuated dst can't carry into the next channel.
     let out_rb = ((src_premul & 0x00ff_00ff) + (dst_blended & 0x00ff_00ff)) & 0x00ff_00ff;
-    let out_g = (((src_premul >> 8) & 0xff) + ((dst_blended >> 8) & 0xff)) & 0xff;
-    let out_a = (((src_premul >> 24) & 0xff) + ((dst_blended >> 24) & 0xff)) & 0xff;
-    out_rb | (out_g << 8) | (out_a << 24)
+    let out_ag = (((src_premul >> 8) & 0x00ff_00ff) + ((dst_blended >> 8) & 0x00ff_00ff))
+        & 0x00ff_00ff;
+    out_rb | (out_ag << 8)
 }
 
 /// SWAR source-over with constant src across all lanes (translucent rect).
@@ -113,23 +111,16 @@ fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
 fn blend_over_simd_const_src_x4(src_v: u32x4, inv_v: u32x4, dst: u32x4) -> u32x4 {
     let mask_rb = u32x4::splat(0x00ff_00ff);
     let half_rb = u32x4::splat(0x0080_0080);
-    let mask_byte = u32x4::splat(0xff);
-    let half_byte = u32x4::splat(0x80);
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_byte;
-    let dg = dg * inv_v;
-    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
-    let dg = dg << 8;
+    // A and G pair as 00AA00GG, mirroring the R+B pair: four channels
+    // for the same two multiplies as the old opaque three-channel form.
+    let dag = ((dst >> 8) & mask_rb) * inv_v;
+    let dag = ((dag + half_rb + ((dag >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let da = (dst >> 24) & mask_byte;
-    let da = da * inv_v;
-    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
-    let da = da << 24;
-
-    src_v + drb + dg + da
+    src_v + drb + (dag << 8)
 }
 
 /// 256-bit version of `blend_over_simd_const_src_x4` — 8 dst pixels per call.
@@ -139,23 +130,15 @@ fn blend_over_simd_const_src_x4(src_v: u32x4, inv_v: u32x4, dst: u32x4) -> u32x4
 fn blend_over_simd_const_src_x8(src_v: u32x8, inv_v: u32x8, dst: u32x8) -> u32x8 {
     let mask_rb = u32x8::splat(0x00ff_00ff);
     let half_rb = u32x8::splat(0x0080_0080);
-    let mask_byte = u32x8::splat(0xff);
-    let half_byte = u32x8::splat(0x80);
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_byte;
-    let dg = dg * inv_v;
-    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
-    let dg = dg << 8;
+    // A and G pair as 00AA00GG, mirroring the R+B pair.
+    let dag = ((dst >> 8) & mask_rb) * inv_v;
+    let dag = ((dag + half_rb + ((dag >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let da = (dst >> 24) & mask_byte;
-    let da = da * inv_v;
-    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
-    let da = da << 24;
-
-    src_v + drb + dg + da
+    src_v + drb + (dag << 8)
 }
 
 /// SWAR source-over with **per-lane** src and inv_a — used by glyph blit
@@ -167,7 +150,6 @@ fn blend_over_simd_var_src_x4(src: u32x4, dst: u32x4) -> u32x4 {
     let mask_byte = u32x4::splat(0xff);
     let mask_rb = u32x4::splat(0x00ff_00ff);
     let half_rb = u32x4::splat(0x0080_0080);
-    let half_byte = u32x4::splat(0x80);
 
     let sa = (src >> 24) & mask_byte;
     let inv_v = u32x4::splat(255) - sa;
@@ -175,17 +157,11 @@ fn blend_over_simd_var_src_x4(src: u32x4, dst: u32x4) -> u32x4 {
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_byte;
-    let dg = dg * inv_v;
-    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
-    let dg = dg << 8;
+    // A and G pair as 00AA00GG, mirroring the R+B pair.
+    let dag = ((dst >> 8) & mask_rb) * inv_v;
+    let dag = ((dag + half_rb + ((dag >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let da = (dst >> 24) & mask_byte;
-    let da = da * inv_v;
-    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
-    let da = da << 24;
-
-    src + drb + dg + da
+    src + drb + (dag << 8)
 }
 
 #[derive(Clone, Copy)]
@@ -1023,6 +999,136 @@ fn draw_quad_instance(
             }
             let idx = (y as usize) * stride + (x as usize);
             buf[idx] = blend_over_swar(src_premul, buf[idx]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod blend_alpha_tests {
+    use super::*;
+
+    // Deterministic pseudo-random u32s, no rand dependency.
+    fn lcg(seed: &mut u64) -> u32 {
+        *seed = seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (*seed >> 32) as u32
+    }
+
+    // Force a value into a valid premultiplied pixel: rgb <= a.
+    fn valid_premul(raw: u32) -> u32 {
+        let a = (raw >> 24) & 0xff;
+        let clamp = |c: u32| c.min(a);
+        (a << 24)
+            | (clamp((raw >> 16) & 0xff) << 16)
+            | (clamp((raw >> 8) & 0xff) << 8)
+            | clamp(raw & 0xff)
+    }
+
+    /// Blending anything over an opaque destination must stay opaque:
+    /// this is what keeps `opacity = 1.0` windows fully solid now that
+    /// the framebuffer carries real alpha. Exhaustive over source alpha.
+    #[test]
+    fn opaque_dst_stays_opaque_for_every_src_alpha() {
+        for sa in 0..=255u32 {
+            let src = valid_premul((sa << 24) | 0x0020_4060);
+            let dst = 0xff31_4159;
+            let out = blend_over_swar(src, dst);
+            assert_eq!(out >> 24, 0xff, "sa={sa}");
+        }
+    }
+
+    /// Transparent source leaves the destination untouched, alpha
+    /// included, so the cleared window-opacity alpha bleeds through
+    /// default-bg cells.
+    #[test]
+    fn zero_alpha_src_is_identity() {
+        let dst = 0x9912_3456;
+        assert_eq!(blend_over_swar(0, dst), dst);
+    }
+
+    /// Destination alpha follows Porter-Duff source-over, so stacked
+    /// translucent paints converge toward opaque instead of resetting.
+    #[test]
+    fn alpha_composes_source_over() {
+        let sa = 0x80u32;
+        let src = valid_premul((sa << 24) | 0x0040_2010);
+        let da = 0x99u32;
+        let dst = (da << 24) | 0x0030_5070;
+        let out = blend_over_swar(src, dst);
+        let oa = out >> 24;
+        let expected = sa as f64 + da as f64 * (255.0 - sa as f64) / 255.0;
+        assert!(
+            (oa as f64 - expected).abs() <= 1.0,
+            "oa={oa} expected~{expected}"
+        );
+        assert!(oa >= sa.max(da));
+    }
+
+    /// The three SIMD kernels must agree with the scalar SWAR blend bit
+    /// for bit, per lane: the A+G pairing may not change any rounding.
+    #[test]
+    fn simd_kernels_match_scalar_exactly() {
+        let mut seed = 0x5eed_cafe_f00d_u64;
+        for _ in 0..2000 {
+            let src = valid_premul(lcg(&mut seed));
+            let dst: Vec<u32> = (0..8).map(|_| lcg(&mut seed)).collect();
+            let scalar: Vec<u32> = dst.iter().map(|&d| blend_over_swar(src, d)).collect();
+
+            let sa = (src >> 24) & 0xff;
+            // The vector kernels skip the scalar early-outs; those alphas
+            // are handled before dispatch in the fill paths.
+            if sa == 0 || sa == 255 {
+                continue;
+            }
+            let inv = 255 - sa;
+
+            let x8 = blend_over_simd_const_src_x8(
+                u32x8::splat(src),
+                u32x8::splat(inv),
+                u32x8::new(dst[..8].try_into().unwrap()),
+            )
+            .to_array();
+            assert_eq!(&x8[..], &scalar[..], "x8 disagrees for src={src:08x}");
+
+            let x4 = blend_over_simd_const_src_x4(
+                u32x4::splat(src),
+                u32x4::splat(inv),
+                u32x4::new(dst[..4].try_into().unwrap()),
+            )
+            .to_array();
+            assert_eq!(&x4[..], &scalar[..4], "x4 disagrees for src={src:08x}");
+
+            let var = blend_over_simd_var_src_x4(
+                u32x4::splat(src),
+                u32x4::new(dst[..4].try_into().unwrap()),
+            )
+            .to_array();
+            assert_eq!(
+                &var[..],
+                &scalar[..4],
+                "var_src disagrees for src={src:08x}"
+            );
+        }
+    }
+
+    /// The premultiplied invariant survives the blend: output rgb never
+    /// exceeds output alpha, so chained blends stay valid premul colors.
+    #[test]
+    fn output_stays_valid_premul() {
+        let mut seed = 0xabcd_ef01_2345_u64;
+        for _ in 0..2000 {
+            let src = valid_premul(lcg(&mut seed));
+            let dst = valid_premul(lcg(&mut seed));
+            let out = blend_over_swar(src, dst);
+            let oa = out >> 24;
+            for shift in [16u32, 8, 0] {
+                let c = (out >> shift) & 0xff;
+                assert!(
+                    c <= oa,
+                    "channel {c:02x} > alpha {oa:02x} for src={src:08x} dst={dst:08x}"
+                );
+            }
         }
     }
 }

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -1075,9 +1075,23 @@ mod blend_alpha_tests {
             let dst: Vec<u32> = (0..8).map(|_| lcg(&mut seed)).collect();
             let scalar: Vec<u32> = dst.iter().map(|&d| blend_over_swar(src, d)).collect();
 
+            // The var-src kernel is documented branchless-correct for the
+            // extreme alphas too, so it is checked before the early-out
+            // skip the const-src kernels rely on their fill paths for.
+            let var = blend_over_simd_var_src_x4(
+                u32x4::splat(src),
+                u32x4::new(dst[..4].try_into().unwrap()),
+            )
+            .to_array();
+            assert_eq!(
+                &var[..],
+                &scalar[..4],
+                "var_src disagrees for src={src:08x}"
+            );
+
             let sa = (src >> 24) & 0xff;
-            // The vector kernels skip the scalar early-outs; those alphas
-            // are handled before dispatch in the fill paths.
+            // The const-src kernels skip the scalar early-outs; those
+            // alphas are handled before dispatch in the fill paths.
             if sa == 0 || sa == 255 {
                 continue;
             }
@@ -1098,17 +1112,6 @@ mod blend_alpha_tests {
             )
             .to_array();
             assert_eq!(&x4[..], &scalar[..4], "x4 disagrees for src={src:08x}");
-
-            let var = blend_over_simd_var_src_x4(
-                u32x4::splat(src),
-                u32x4::new(dst[..4].try_into().unwrap()),
-            )
-            .to_array();
-            assert_eq!(
-                &var[..],
-                &scalar[..4],
-                "var_src disagrees for src={src:08x}"
-            );
         }
     }
 

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -65,12 +65,18 @@ fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
 
 #[inline(always)]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors (Windows DWM under
+    // `DwmEnableBlurBehindWindow`) treat the pixel as fully opaque.
+    // For non-transparent windows the OS ignores this byte, so writing
+    // 0xff is a no-op there.
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
-/// Scalar SWAR Porter-Duff source-over with premultiplied source against
-/// opaque dest. Computes channels of R+B together in one multiply, G in
-/// another. ~30% faster than the naive 3-multiply scalar form.
+/// Scalar SWAR premultiplied source-over for all four channels (RGBA).
+/// Pairs R+B in a single u32 lane (`00RR00BB`), then G and A each on
+/// their own. Result preserves the premultiplied invariant so chained
+/// blends stay valid, which lets `window.opacity < 1` survive into the
+/// final framebuffer instead of getting masked back to alpha = 0.
 #[inline(always)]
 fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
     let sa = (src_premul >> 24) & 0xff;
@@ -78,7 +84,7 @@ fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
         return dst;
     }
     if sa == 255 {
-        return src_premul & 0x00ff_ffff;
+        return src_premul;
     }
     let inv = 255 - sa;
     // R and B share a u32: 00RR00BB.
@@ -87,33 +93,43 @@ fn blend_over_swar(src_premul: u32, dst: u32) -> u32 {
     // G alone.
     let g = ((dst >> 8) & 0xff) * inv;
     let g = ((g + 0x80 + (g >> 8)) >> 8) & 0xff;
-    let dst_blended = rb | (g << 8);
-    let src_rgb = src_premul & 0x00ff_ffff;
-    // Premultiplied src guarantees src.rgb <= src.a, so adding to the
-    // attenuated dst can't carry into the next channel.
-    let out_rb = ((src_rgb & 0x00ff_00ff) + (dst_blended & 0x00ff_00ff)) & 0x00ff_00ff;
-    let out_g = (((src_rgb >> 8) & 0xff) + ((dst_blended >> 8) & 0xff)) & 0xff;
-    out_rb | (out_g << 8)
+    // A alone — same `(x*inv) / 255` SWAR trick.
+    let da = (dst >> 24) & 0xff;
+    let a = da * inv;
+    let a = ((a + 0x80 + (a >> 8)) >> 8) & 0xff;
+    let dst_blended = rb | (g << 8) | (a << 24);
+    // Premultiplied src guarantees src.rgb <= src.a (and src.a <= 0xff),
+    // so adding to the attenuated dst can't carry into the next channel.
+    let out_rb = ((src_premul & 0x00ff_00ff) + (dst_blended & 0x00ff_00ff)) & 0x00ff_00ff;
+    let out_g = (((src_premul >> 8) & 0xff) + ((dst_blended >> 8) & 0xff)) & 0xff;
+    let out_a = (((src_premul >> 24) & 0xff) + ((dst_blended >> 24) & 0xff)) & 0xff;
+    out_rb | (out_g << 8) | (out_a << 24)
 }
 
 /// SWAR source-over with constant src across all lanes (translucent rect).
-/// `src_v` is splat of `(src_premul & 0x00ff_ffff)`; `inv_v` is splat of
-/// `(255 - src.a)`. 4 dst pixels per call.
+/// `src_v` is splat of the full premultiplied src (RGBA, alpha in upper
+/// byte); `inv_v` is splat of `(255 - src.a)`. 4 dst pixels per call.
 #[inline(always)]
 fn blend_over_simd_const_src_x4(src_v: u32x4, inv_v: u32x4, dst: u32x4) -> u32x4 {
     let mask_rb = u32x4::splat(0x00ff_00ff);
     let half_rb = u32x4::splat(0x0080_0080);
-    let mask_g = u32x4::splat(0xff);
+    let mask_byte = u32x4::splat(0xff);
+    let half_byte = u32x4::splat(0x80);
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_g;
+    let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x4::splat(0x80) + (dg >> 8)) >> 8) & mask_g;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_v + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src_v + drb + dg + da
 }
 
 /// 256-bit version of `blend_over_simd_const_src_x4` — 8 dst pixels per call.
@@ -123,17 +139,23 @@ fn blend_over_simd_const_src_x4(src_v: u32x4, inv_v: u32x4, dst: u32x4) -> u32x4
 fn blend_over_simd_const_src_x8(src_v: u32x8, inv_v: u32x8, dst: u32x8) -> u32x8 {
     let mask_rb = u32x8::splat(0x00ff_00ff);
     let half_rb = u32x8::splat(0x0080_0080);
-    let mask_g = u32x8::splat(0xff);
+    let mask_byte = u32x8::splat(0xff);
+    let half_byte = u32x8::splat(0x80);
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
-    let dg = (dst >> 8) & mask_g;
+    let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x8::splat(0x80) + (dg >> 8)) >> 8) & mask_g;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_v + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src_v + drb + dg + da
 }
 
 /// SWAR source-over with **per-lane** src and inv_a — used by glyph blit
@@ -145,21 +167,25 @@ fn blend_over_simd_var_src_x4(src: u32x4, dst: u32x4) -> u32x4 {
     let mask_byte = u32x4::splat(0xff);
     let mask_rb = u32x4::splat(0x00ff_00ff);
     let half_rb = u32x4::splat(0x0080_0080);
-    let mask_rgb = u32x4::splat(0x00ff_ffff);
+    let half_byte = u32x4::splat(0x80);
 
     let sa = (src >> 24) & mask_byte;
     let inv_v = u32x4::splat(255) - sa;
-    let src_rgb = src & mask_rgb;
 
     let drb = (dst & mask_rb) * inv_v;
     let drb = ((drb + half_rb + ((drb >> 8) & mask_rb)) >> 8) & mask_rb;
 
     let dg = (dst >> 8) & mask_byte;
     let dg = dg * inv_v;
-    let dg = ((dg + u32x4::splat(0x80) + (dg >> 8)) >> 8) & mask_byte;
+    let dg = ((dg + half_byte + (dg >> 8)) >> 8) & mask_byte;
     let dg = dg << 8;
 
-    src_rgb + drb + dg
+    let da = (dst >> 24) & mask_byte;
+    let da = da * inv_v;
+    let da = ((da + half_byte + (da >> 8)) >> 8) & mask_byte;
+    let da = da << 24;
+
+    src + drb + dg + da
 }
 
 #[derive(Clone, Copy)]
@@ -402,12 +428,21 @@ pub fn render_cpu(
         }
     };
 
+    // Bg fill writes premultiplied RGBA. The alpha byte carries
+    // `window.opacity`; on alpha-respecting compositors (Windows DWM
+    // under `DwmEnableBlurBehindWindow`, Wayland surfaces) that's what
+    // makes the window translucent. For fully opaque windows the OS
+    // ignores the alpha byte, so writing `(rgb*1, 1)` is a no-op there.
     let bg_u32 = match background {
-        Some(c) => pack_opaque(
-            (c.r.clamp(0.0, 1.0) * 255.0) as u8,
-            (c.g.clamp(0.0, 1.0) * 255.0) as u8,
-            (c.b.clamp(0.0, 1.0) * 255.0) as u8,
-        ),
+        Some(c) => {
+            let a = c.a.clamp(0.0, 1.0);
+            pack_premul(
+                (c.r.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (c.g.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (c.b.clamp(0.0, 1.0) * a * 255.0) as u8,
+                (a * 255.0) as u8,
+            )
+        }
         None => 0,
     };
     buffer.fill(bg_u32);
@@ -675,14 +710,11 @@ fn fill_translucent_simd(
     let pg = (g as u32 * a_u + 127) / 255;
     let pb = (b as u32 * a_u + 127) / 255;
     let src_premul = pack_premul(pr as u8, pg as u8, pb as u8, a);
-    let src_rgb = src_premul & 0x00ff_ffff;
     let inv = 255 - a_u;
-    let src_v8 = u32x8::splat(src_rgb);
+    let src_v8 = u32x8::splat(src_premul);
     let inv_v8 = u32x8::splat(inv);
-    let src_v4 = u32x4::splat(src_rgb);
+    let src_v4 = u32x4::splat(src_premul);
     let inv_v4 = u32x4::splat(inv);
-    let mask_rgb_x8 = u32x8::splat(0x00ff_ffff);
-    let mask_rgb_x4 = u32x4::splat(0x00ff_ffff);
 
     let buf_w_us = buf_w as usize;
     for y in y0..y1 {
@@ -697,7 +729,7 @@ fn fill_translucent_simd(
                 chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6],
                 chunk[7],
             ]);
-            let out = blend_over_simd_const_src_x8(src_v8, inv_v8, dst) & mask_rgb_x8;
+            let out = blend_over_simd_const_src_x8(src_v8, inv_v8, dst);
             let arr = out.to_array();
             chunk.copy_from_slice(&arr);
         }
@@ -707,7 +739,7 @@ fn fill_translucent_simd(
         let mut chunks4 = tail.chunks_exact_mut(4);
         for chunk in &mut chunks4 {
             let dst = u32x4::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
-            let out = blend_over_simd_const_src_x4(src_v4, inv_v4, dst) & mask_rgb_x4;
+            let out = blend_over_simd_const_src_x4(src_v4, inv_v4, dst);
             let arr = out.to_array();
             chunk.copy_from_slice(&arr);
         }
@@ -810,8 +842,6 @@ fn draw_glyph(
     let buf_w_us = buf_w as usize;
     let g_w_us = glyph.w as usize;
 
-    let mask_rgb_x4 = u32x4::splat(0x00ff_ffff);
-
     for yy in 0..glyph.h as usize {
         let dst_y = y0 as usize + yy;
         let dst_row_off = dst_y * buf_w_us + x0 as usize;
@@ -826,7 +856,7 @@ fn draw_glyph(
         for (dchunk, schunk) in (&mut dst_chunks).zip(&mut src_chunks) {
             let dst = u32x4::new([dchunk[0], dchunk[1], dchunk[2], dchunk[3]]);
             let src = u32x4::new([schunk[0], schunk[1], schunk[2], schunk[3]]);
-            let out = blend_over_simd_var_src_x4(src, dst) & mask_rgb_x4;
+            let out = blend_over_simd_var_src_x4(src, dst);
             let arr = out.to_array();
             dchunk.copy_from_slice(&arr);
         }
@@ -1025,8 +1055,11 @@ mod image_overlay_tests {
         vec![0u32; w * h]
     }
 
-    const RED_PX: u32 = 0x00ff_0000;
-    const BLUE_PX: u32 = 0x0000_00ff;
+    // Opaque source pixels land premultiplied with alpha = 0xff: the
+    // framebuffer carries per-pixel alpha so `window.opacity` survives
+    // to the compositor.
+    const RED_PX: u32 = 0xffff_0000;
+    const BLUE_PX: u32 = 0xff00_00ff;
 
     #[test]
     fn one_to_one_blit_lands_on_exact_pixels() {

--- a/sugarloaf/src/renderer/cpu.rs
+++ b/sugarloaf/src/renderer/cpu.rs
@@ -10,6 +10,7 @@
 // Kitty image overlays composite via `draw_image_overlay`.
 
 use crate::context::cpu::CpuContext;
+use crate::premul::{pack_opaque, pack_premul};
 use crate::renderer::compositor::Vertex;
 use crate::renderer::image_cache::ImageCache;
 use crate::renderer::Renderer;
@@ -56,20 +57,6 @@ struct CachedGlyph {
     pixels: Vec<u32>,
     w: u16,
     h: u16,
-}
-
-#[inline(always)]
-fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
-    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
-}
-
-#[inline(always)]
-fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    // alpha = 0xff so alpha-respecting compositors (Windows DWM under
-    // `DwmEnableBlurBehindWindow`) treat the pixel as fully opaque.
-    // For non-transparent windows the OS ignores this byte, so writing
-    // 0xff is a no-op there.
-    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
 /// Scalar SWAR premultiplied source-over for all four channels (RGBA).
@@ -404,19 +391,30 @@ pub fn render_cpu(
         }
     };
 
-    // Bg fill writes premultiplied RGBA. The alpha byte carries
-    // `window.opacity`; on alpha-respecting compositors (Windows DWM
-    // under `DwmEnableBlurBehindWindow`, Wayland surfaces) that's what
-    // makes the window translucent. For fully opaque windows the OS
-    // ignores the alpha byte, so writing `(rgb*1, 1)` is a no-op there.
+    // Bg fill writes premultiplied RGBA on Windows only: softbuffer's GDI
+    // path copies the alpha byte through to the DWM redirection surface,
+    // where `DwmEnableBlurBehindWindow` makes `window.opacity` real. Its
+    // other presenters drop the byte (macOS `NoneSkipFirst`, Wayland
+    // `Xrgb8888`), so premultiplying there would darken the window with
+    // no transparency in return; those keep the full-brightness opaque
+    // fill and opacity stays a no-op on the CPU backend, as before.
     let bg_u32 = match background {
         Some(c) => {
-            let a = c.a.clamp(0.0, 1.0);
-            pack_premul(
-                (c.r.clamp(0.0, 1.0) * a * 255.0) as u8,
-                (c.g.clamp(0.0, 1.0) * a * 255.0) as u8,
-                (c.b.clamp(0.0, 1.0) * a * 255.0) as u8,
-                (a * 255.0) as u8,
+            #[cfg(target_os = "windows")]
+            {
+                let a = c.a.clamp(0.0, 1.0);
+                pack_premul(
+                    (c.r.clamp(0.0, 1.0) * a * 255.0) as u8,
+                    (c.g.clamp(0.0, 1.0) * a * 255.0) as u8,
+                    (c.b.clamp(0.0, 1.0) * a * 255.0) as u8,
+                    (a * 255.0) as u8,
+                )
+            }
+            #[cfg(not(target_os = "windows"))]
+            pack_opaque(
+                (c.r.clamp(0.0, 1.0) * 255.0) as u8,
+                (c.g.clamp(0.0, 1.0) * 255.0) as u8,
+                (c.b.clamp(0.0, 1.0) * 255.0) as u8,
             )
         }
         None => 0,

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -1144,7 +1144,30 @@ impl Sugarloaf<'_> {
 
         {
             let load = if let Some(background_color) = self.background_color {
-                wgpu::LoadOp::Clear(background_color.into())
+                // The grid bg pass emits `(0,0,0,0)` for default-bg cells (see
+                // `cell_bg` in `frontends/rioterm/src/grid_emit.rs`) and blends
+                // premultiplied-over the cleared color, so the framebuffer alpha
+                // for any cell that didn't get an explicit bg ends up = the clear
+                // alpha. When the user sets `window.opacity < 1` we want the
+                // compositor to treat that cleared color as a translucent overlay
+                // over the desktop. DWM (Windows DX12 / wgpu Vulkan path) and
+                // wayland compositors interpret the framebuffer RGB as **already**
+                // multiplied by alpha when the surface is in PreMultiplied mode.
+                // wgpu's Auto / Inherit modes also map to that interpretation when
+                // transparency is engaged (no platform we ship to picks
+                // straight-alpha by default). Only `PostMultiplied` wants the
+                // straight value. Pre-multiply here so a translucent bg doesn't
+                // come out as a near-fully-transparent window on those backends.
+                let clear = match ctx.alpha_mode {
+                    wgpu::CompositeAlphaMode::PostMultiplied => background_color.into(),
+                    _ => wgpu::Color {
+                        r: background_color.r * background_color.a,
+                        g: background_color.g * background_color.a,
+                        b: background_color.b * background_color.a,
+                        a: background_color.a,
+                    },
+                };
+                wgpu::LoadOp::Clear(clear)
             } else {
                 wgpu::LoadOp::Load
             };

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -38,6 +38,9 @@ pub struct Sugarloaf<'a> {
     pub graphics: Graphics,
     #[cfg(feature = "wgpu")]
     filters_brush: Option<FiltersBrush>,
+    /// One-shot notice that active filters defeat `window.opacity`.
+    #[cfg(feature = "wgpu")]
+    warned_filters_opacity: bool,
     /// Pixel data for standalone image textures, keyed by image key
     /// (`graphics::kitty_image_key` / `graphics::atlas_image_key`).
     pub image_data: rustc_hash::FxHashMap<u64, GraphicDataEntry>,
@@ -253,6 +256,8 @@ impl Sugarloaf<'_> {
             graphics: Graphics::default(),
             #[cfg(feature = "wgpu")]
             filters_brush: None,
+            #[cfg(feature = "wgpu")]
+            warned_filters_opacity: false,
             image_data: rustc_hash::FxHashMap::default(),
             cpu_cache: crate::renderer::cpu::CpuCache::new(),
             font_cache,
@@ -1157,22 +1162,23 @@ impl Sugarloaf<'_> {
                 // for any cell that didn't get an explicit bg ends up = the clear
                 // alpha. When the user sets `window.opacity < 1` we want the
                 // compositor to treat that cleared color as a translucent overlay
-                // over the desktop. DWM (Windows DX12 / wgpu Vulkan path) and
-                // wayland compositors interpret the framebuffer RGB as **already**
-                // multiplied by alpha when the surface is in PreMultiplied mode.
-                // wgpu's Auto / Inherit modes also map to that interpretation when
-                // transparency is engaged (no platform we ship to picks
-                // straight-alpha by default). Only `PostMultiplied` wants the
-                // straight value. Pre-multiply here so a translucent bg doesn't
-                // come out as a near-fully-transparent window on those backends.
+                // over the desktop.
+                //
+                // Only a surface in `PreMultiplied` mode (DWM via the Windows
+                // wgpu Vulkan path, Wayland) reads the RGB as already
+                // multiplied by alpha, so only there may the clear be
+                // premultiplied. `PostMultiplied` wants the straight value,
+                // and everything else (`Opaque`, and `Auto` resolving to it)
+                // ignores the alpha byte entirely: premultiplying would just
+                // darken the window with no transparency in return.
                 let clear = match ctx.alpha_mode {
-                    wgpu::CompositeAlphaMode::PostMultiplied => background_color.into(),
-                    _ => wgpu::Color {
+                    wgpu::CompositeAlphaMode::PreMultiplied => wgpu::Color {
                         r: background_color.r * background_color.a,
                         g: background_color.g * background_color.a,
                         b: background_color.b * background_color.a,
                         a: background_color.a,
                     },
+                    _ => background_color.into(),
                 };
                 wgpu::LoadOp::Clear(clear)
             } else {
@@ -1231,6 +1237,19 @@ impl Sugarloaf<'_> {
         }
 
         if let Some(ref mut filters_brush) = self.filters_brush {
+            // The filter chain's final pass writes with blending disabled,
+            // so whatever alpha the shader outputs (1.0 for CRT shaders)
+            // replaces the frame's: the window snaps back to opaque. Say
+            // so once instead of letting the two settings cancel silently.
+            if !self.warned_filters_opacity
+                && self.background_color.is_some_and(|c| c.a < 1.0)
+            {
+                self.warned_filters_opacity = true;
+                tracing::warn!(
+                    "[renderer] filters overwrite the frame's alpha channel; \
+                     window.opacity < 1 has no effect while filters are active"
+                );
+            }
             filters_brush.render(ctx, &mut encoder, &frame.texture, &frame.texture);
         }
         ctx.queue.submit(Some(encoder.finish()));

--- a/sugarloaf/src/sugarloaf.rs
+++ b/sugarloaf/src/sugarloaf.rs
@@ -126,6 +126,12 @@ pub struct SugarloafRenderer {
     pub backend: SugarloafBackend,
     pub font_features: Option<Vec<String>>,
     pub colorspace: Colorspace,
+    /// The window wants per-pixel alpha (`window.opacity < 1`). On wgpu
+    /// this prefers an adapter whose surface offers an alpha-carrying
+    /// composite mode: on Windows, DX12 HWND swapchains expose only
+    /// `Opaque`, while Vulkan exposes `PreMultiplied`, so which adapter
+    /// wgpu happens to pick decides whether transparency works at all.
+    pub prefer_alpha_capable_adapter: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -183,6 +189,7 @@ impl Default for SugarloafRenderer {
             backend: default_backend,
             font_features: None,
             colorspace: Colorspace::default(),
+            prefer_alpha_capable_adapter: false,
         }
     }
 }

--- a/sugarloaf/src/text.rs
+++ b/sugarloaf/src/text.rs
@@ -1903,7 +1903,14 @@ impl Drop for TextVulkanState {
 
 #[inline]
 fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+    // alpha = 0xff so alpha-respecting compositors treat it as opaque
+    // (DWM under `DwmEnableBlurBehindWindow`, Wayland surfaces).
+    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}
+
+#[inline]
+fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
+    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
 }
 
 #[inline]
@@ -1919,10 +1926,21 @@ fn blend_premul_over(src: [u8; 4], dst: u32) -> u32 {
     let dr = (dst >> 16) & 0xff;
     let dg = (dst >> 8) & 0xff;
     let db = dst & 0xff;
+    let da = (dst >> 24) & 0xff;
     let or = src[0] as u32 + (dr * inv + 127) / 255;
     let og = src[1] as u32 + (dg * inv + 127) / 255;
     let ob = src[2] as u32 + (db * inv + 127) / 255;
-    pack_opaque(or.min(255) as u8, og.min(255) as u8, ob.min(255) as u8)
+    // Alpha follows the same Porter-Duff source-over so the
+    // framebuffer alpha — which controls window translucency on
+    // alpha-respecting compositors — composes correctly across
+    // overlapping draws.
+    let oa = sa + (da * inv + 127) / 255;
+    pack_premul(
+        or.min(255) as u8,
+        og.min(255) as u8,
+        ob.min(255) as u8,
+        oa.min(255) as u8,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/sugarloaf/src/text.rs
+++ b/sugarloaf/src/text.rs
@@ -2052,3 +2052,23 @@ fn blit_text_color(
         }
     }
 }
+
+#[cfg(test)]
+mod blend_alpha_tests {
+    use super::{blend_premul_over, pack_opaque};
+
+    /// UI text overlays must not punch translucency holes into an
+    /// opaque window, and must keep the window-opacity alpha intact
+    /// where they only partially cover a pixel.
+    #[test]
+    fn blend_premul_over_propagates_alpha() {
+        assert_eq!(pack_opaque(1, 2, 3) >> 24, 0xff);
+        let dst = 0xff10_2030;
+        assert_eq!(blend_premul_over([0x30, 0x30, 0x30, 0x60], dst) >> 24, 0xff);
+        let translucent = 0x8010_2030;
+        assert_eq!(blend_premul_over([0, 0, 0, 0], translucent), translucent);
+        let out = blend_premul_over([0x20, 0x20, 0x20, 0x40], translucent);
+        let expected = 0x40u32 + (0x80 * (255 - 0x40) + 127) / 255;
+        assert_eq!(out >> 24, expected);
+    }
+}

--- a/sugarloaf/src/text.rs
+++ b/sugarloaf/src/text.rs
@@ -1897,51 +1897,9 @@ impl Drop for TextVulkanState {
     }
 }
 
-//  CPU blit helpers for `Text::render_cpu`. Same blend model as
-//  `grid::cpu`: premultiplied source-over against an opaque
-//  `0x00RRGGBB` destination.
-
-#[inline]
-fn pack_opaque(r: u8, g: u8, b: u8) -> u32 {
-    // alpha = 0xff so alpha-respecting compositors treat it as opaque
-    // (DWM under `DwmEnableBlurBehindWindow`, Wayland surfaces).
-    0xff00_0000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
-}
-
-#[inline]
-fn pack_premul(r: u8, g: u8, b: u8, a: u8) -> u32 {
-    ((a as u32) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
-}
-
-#[inline]
-fn blend_premul_over(src: [u8; 4], dst: u32) -> u32 {
-    let sa = src[3] as u32;
-    if sa == 0 {
-        return dst;
-    }
-    if sa == 255 {
-        return pack_opaque(src[0], src[1], src[2]);
-    }
-    let inv = 255 - sa;
-    let dr = (dst >> 16) & 0xff;
-    let dg = (dst >> 8) & 0xff;
-    let db = dst & 0xff;
-    let da = (dst >> 24) & 0xff;
-    let or = src[0] as u32 + (dr * inv + 127) / 255;
-    let og = src[1] as u32 + (dg * inv + 127) / 255;
-    let ob = src[2] as u32 + (db * inv + 127) / 255;
-    // Alpha follows the same Porter-Duff source-over so the
-    // framebuffer alpha — which controls window translucency on
-    // alpha-respecting compositors — composes correctly across
-    // overlapping draws.
-    let oa = sa + (da * inv + 127) / 255;
-    pack_premul(
-        or.min(255) as u8,
-        og.min(255) as u8,
-        ob.min(255) as u8,
-        oa.min(255) as u8,
-    )
-}
+//  CPU blit path for `Text::render_cpu`: premultiplied source-over into
+//  the shared `0xAARRGGBB` framebuffer (see `crate::premul`).
+use crate::premul::blend_premul_over;
 
 #[allow(clippy::too_many_arguments)]
 fn blit_text_mask(
@@ -2050,25 +2008,5 @@ fn blit_text_color(
             let idx = buf_row + (dst_x as usize);
             buf[idx] = blend_premul_over(src, buf[idx]);
         }
-    }
-}
-
-#[cfg(test)]
-mod blend_alpha_tests {
-    use super::{blend_premul_over, pack_opaque};
-
-    /// UI text overlays must not punch translucency holes into an
-    /// opaque window, and must keep the window-opacity alpha intact
-    /// where they only partially cover a pixel.
-    #[test]
-    fn blend_premul_over_propagates_alpha() {
-        assert_eq!(pack_opaque(1, 2, 3) >> 24, 0xff);
-        let dst = 0xff10_2030;
-        assert_eq!(blend_premul_over([0x30, 0x30, 0x30, 0x60], dst) >> 24, 0xff);
-        let translucent = 0x8010_2030;
-        assert_eq!(blend_premul_over([0, 0, 0, 0], translucent), translucent);
-        let out = blend_premul_over([0x20, 0x20, 0x20, 0x40], translucent);
-        let expected = 0x40u32 + (0x80 * (255 - 0x40) + 127) / 255;
-        assert_eq!(out >> 24, expected);
     }
 }


### PR DESCRIPTION
Supersedes #1583, keeping @shiena's two commits as-is and addressing the review findings on top.

shiena's diagnosis and fix are exactly right and match what the references converged on: DWM composites premultiplied alpha (winit's with_transparent uses the same DwmEnableBlurBehindWindow empty-region trick wezterm hand-rolls to enable per-pixel alpha), alacritty premultiplies its clear color by opacity the same way, kitty premultiplies pervasively including its clear color, and ghostty premultiplies every color in-shader with ONE/ONE_MINUS_SRC_ALPHA blending.

What this adds on top:

**Alpha-capable adapter preference (the remaining gap).** wgpu's DX12 backend exposes only Opaque composite alpha for plain HWND swapchains (PreMultiplied needs a DirectComposition target), and rio's Windows default is Backends::all(), so whether transparency worked depended on whether the adapter request happened to land on Vulkan (shiena's test) or DX12 (wezterm's long-open WebGPU-frontend transparency bug, wezterm#6265). When window.opacity < 1, sugarloaf now prefers the highest-class adapter whose surface offers PreMultiplied or PostMultiplied, falling back to the normal request when none exists. Backend-agnostic, no double surface creation, no panic on Vulkan-less machines.

**CPU blend ALU cost removed.** The fourth channel had added a third multiply per blend. A now rides the lane pair G occupied alone (00AA00GG mirroring 00RR00BB), so all four kernels (scalar SWAR, x4/x8 const-src, var-src) are back to two multiplies per pixel, the same count as the old opaque three-channel code. The alpha channel is literally free.

**Tests locking the invariant.** Seven new unit tests: exhaustive opaque-destination-stays-opaque over all 256 source alphas, transparent-source identity, Porter-Duff alpha composition, exact bit-for-bit agreement between the scalar SWAR and all three SIMD kernels over 2000 randomized valid-premul pairs, output-stays-valid-premul, plus the same alpha assertions for the scalar blends in grid/cpu.rs and text.rs.

**cfg cleanup plus one missed spot.** The triplicated any(feature = "wgpu", target_os = "windows") is now a single wgpu_backend alias in rioterm's build.rs (cfg_aliases, same pattern as rio-window). Converting every site uniformly also surfaced one the original PR missed: update_filters on config reload was still gated on the bare feature, so default Windows builds ignored [renderer] filters edits until restart.

One dependency worth recording: the CPU path's alpha relies on softbuffer copying the top byte through to the DWM redirection surface, which its 0.4 docs leave unspecified (they say the top 8 bits are to be set to 0). It works, shiena verified on Windows 11, and softbuffer master is growing an AlphaMode API worth adopting once premultiplied gains Windows support.

Validation: 140 sugarloaf tests pass, clippy clean, cargo check for x86_64-pc-windows-msvc with default features and with --features wgpu both pass, fmt clean. The blend-kernel changes are covered by the exact-agreement tests; the adapter preference needs a Windows machine with both DX12 and Vulkan to observe, which CI cannot do.