### PR TITLE
fix(vt): preserve SGR 5/6/25 blink attributes in the style table

### DIFF
--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -127,6 +127,23 @@ typedef struct {
   uint16_t style_flags;
 } rio_cell_s;
 
+/* Bit assignments for rio_cell_s.style_flags. Bits 6-10 are the
+ * underline kind; at most one is set. At most one blink bit is set.
+ * Bit 15 is RIO_CELL_HAS_CLUSTER, not a style. */
+#define RIO_STYLE_INVERSE (1u << 0)
+#define RIO_STYLE_BOLD (1u << 1)
+#define RIO_STYLE_ITALIC (1u << 2)
+#define RIO_STYLE_DIM (1u << 3)
+#define RIO_STYLE_HIDDEN (1u << 4)
+#define RIO_STYLE_STRIKEOUT (1u << 5)
+#define RIO_STYLE_UNDERLINE (1u << 6)
+#define RIO_STYLE_DOUBLE_UNDERLINE (1u << 7)
+#define RIO_STYLE_UNDERCURL (1u << 8)
+#define RIO_STYLE_DOTTED_UNDERLINE (1u << 9)
+#define RIO_STYLE_DASHED_UNDERLINE (1u << 10)
+#define RIO_STYLE_SLOW_BLINK (1u << 11)
+#define RIO_STYLE_RAPID_BLINK (1u << 12)
+
 typedef struct {
   uint8_t r;
   uint8_t g;
@@ -286,8 +303,8 @@ void rio_render_state_reset_dirty(rio_render_state_t *state);
 /* Set in rio_cell_s.style_flags when the cell carries attached cluster
  * codepoints (combining marks, or a DEC-2027 grapheme cluster) beyond
  * `codepoint`. Fetch the full text with rio_render_state_cell_cluster
- * and draw that instead of the base char. StyleFlags proper occupies
- * bits 0..10; this is bit 15. */
+ * and draw that instead of the base char. Style flags proper occupy
+ * bits 0..12 (RIO_STYLE_*); this is bit 15. */
 #define RIO_CELL_HAS_CLUSTER (1u << 15)
 
 /* Write the full text of a cell (base codepoint plus attached cluster

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -304,7 +304,7 @@ void rio_render_state_reset_dirty(rio_render_state_t *state);
  * codepoints (combining marks, or a DEC-2027 grapheme cluster) beyond
  * `codepoint`. Fetch the full text with rio_render_state_cell_cluster
  * and draw that instead of the base char. Style flags proper occupy
- * bits 0..12 (RIO_STYLE_*); this is bit 15. */
+ * bits 0-12 (RIO_STYLE_*); this is bit 15. */
 #define RIO_CELL_HAS_CLUSTER (1u << 15)
 
 /* Write the full text of a cell (base codepoint plus attached cluster

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -113,11 +113,13 @@ typedef struct {
 
 typedef struct {
   /* Original form: RIO_COLOR_NAMED / _INDEXED / _RGB. `value` holds the
-     named-color id or palette index for the first two. */
+     named-color id or palette index for the first two. Kind
+     RIO_COLOR_NONE means no color at all: value and r/g/b are zero and
+     nothing should be drawn from them. */
   uint8_t kind;
   uint16_t value;
-  /* Always the resolved RGB, regardless of `kind`, so a CPU renderer can
-     read r/g/b directly without owning a palette. */
+  /* The resolved RGB for every kind except RIO_COLOR_NONE, so a CPU
+     renderer can read r/g/b directly without owning a palette. */
   uint8_t r;
   uint8_t g;
   uint8_t b;
@@ -340,7 +342,8 @@ rio_cell_s rio_render_state_cell(const rio_render_state_t *state, uint16_t line,
  * the fallback rio's own renderer applies. This is bit 14. */
 #define RIO_CELL_HAS_UNDERLINE_COLOR (1u << 14)
 /* The cell's explicit SGR 58 underline color, or kind RIO_COLOR_NONE
- * when the cell has none; see RIO_CELL_HAS_UNDERLINE_COLOR. */
+ * when the cell (or the call: NULL state, out-of-range cell) has none;
+ * see RIO_CELL_HAS_UNDERLINE_COLOR. */
 rio_color_s rio_render_state_cell_underline_color(const rio_render_state_t *state,
                                                   uint16_t line, uint16_t column);
 rio_cursor_s rio_render_state_cursor(const rio_render_state_t *state);

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -129,7 +129,7 @@ typedef struct {
 
 /* Bit assignments for rio_cell_s.style_flags. Bits 6-10 are the
  * underline kind; at most one is set. At most one blink bit is set.
- * Bit 15 is RIO_CELL_HAS_CLUSTER, not a style. */
+ * Bits 14-15 are the RIO_CELL_* markers, not styles. */
 #define RIO_STYLE_INVERSE (1u << 0)
 #define RIO_STYLE_BOLD (1u << 1)
 #define RIO_STYLE_ITALIC (1u << 2)
@@ -328,10 +328,14 @@ size_t rio_cluster_width(const uint32_t *codepoints, size_t len,
 
 rio_cell_s rio_render_state_cell(const rio_render_state_t *state, uint16_t line,
                                  uint16_t column);
-/* Color to draw the cell's underline with: the SGR 58 underline color when
- * the program set one, else the cell's foreground (the same preference
- * rio's own renderer applies). Only meaningful when the cell's style_flags
- * carry an underline kind bit. */
+/* Set in rio_cell_s.style_flags when the cell carries an explicit SGR 58
+ * underline color; fetch it with rio_render_state_cell_underline_color.
+ * Without this bit, draw the underline in the color used for the glyph
+ * (the fg after any INVERSE swap): the fallback rio's own renderer
+ * applies. This is bit 14. */
+#define RIO_CELL_HAS_UNDERLINE_COLOR (1u << 14)
+/* The cell's explicit SGR 58 underline color; meaningful only when
+ * style_flags carry RIO_CELL_HAS_UNDERLINE_COLOR. */
 rio_color_s rio_render_state_cell_underline_color(const rio_render_state_t *state,
                                                   uint16_t line, uint16_t column);
 rio_cursor_s rio_render_state_cursor(const rio_render_state_t *state);

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -25,6 +25,9 @@ typedef size_t rio_surface_id_t;
 #define RIO_COLOR_NAMED 0u
 #define RIO_COLOR_INDEXED 1u
 #define RIO_COLOR_RGB 2u
+/* An absent color (value and rgb are zero). Only returned by
+ * rio_render_state_cell_underline_color. */
+#define RIO_COLOR_NONE 3u
 
 #define RIO_KEY_CHAR 0u
 #define RIO_KEY_ENTER 1u
@@ -129,7 +132,10 @@ typedef struct {
 
 /* Bit assignments for rio_cell_s.style_flags. Bits 6-10 are the
  * underline kind; at most one is set. At most one blink bit is set.
- * Bits 14-15 are the RIO_CELL_* markers, not styles. */
+ * Bits 14-15 are the RIO_CELL_* markers, not styles.
+ *
+ * rio_cell_s.fg/bg are exported pre-swap: when RIO_STYLE_INVERSE is
+ * set the host swaps them when drawing, as rio's own renderer does. */
 #define RIO_STYLE_INVERSE (1u << 0)
 #define RIO_STYLE_BOLD (1u << 1)
 #define RIO_STYLE_ITALIC (1u << 2)
@@ -330,12 +336,11 @@ rio_cell_s rio_render_state_cell(const rio_render_state_t *state, uint16_t line,
                                  uint16_t column);
 /* Set in rio_cell_s.style_flags when the cell carries an explicit SGR 58
  * underline color; fetch it with rio_render_state_cell_underline_color.
- * Without this bit, draw the underline in the color used for the glyph
- * (the fg after any INVERSE swap): the fallback rio's own renderer
- * applies. This is bit 14. */
+ * Without this bit, draw the underline in the color used for the glyph:
+ * the fallback rio's own renderer applies. This is bit 14. */
 #define RIO_CELL_HAS_UNDERLINE_COLOR (1u << 14)
-/* The cell's explicit SGR 58 underline color; meaningful only when
- * style_flags carry RIO_CELL_HAS_UNDERLINE_COLOR. */
+/* The cell's explicit SGR 58 underline color, or kind RIO_COLOR_NONE
+ * when the cell has none; see RIO_CELL_HAS_UNDERLINE_COLOR. */
 rio_color_s rio_render_state_cell_underline_color(const rio_render_state_t *state,
                                                   uint16_t line, uint16_t column);
 rio_cursor_s rio_render_state_cursor(const rio_render_state_t *state);

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -328,6 +328,12 @@ size_t rio_cluster_width(const uint32_t *codepoints, size_t len,
 
 rio_cell_s rio_render_state_cell(const rio_render_state_t *state, uint16_t line,
                                  uint16_t column);
+/* Color to draw the cell's underline with: the SGR 58 underline color when
+ * the program set one, else the cell's foreground (the same preference
+ * rio's own renderer applies). Only meaningful when the cell's style_flags
+ * carry an underline kind bit. */
+rio_color_s rio_render_state_cell_underline_color(const rio_render_state_t *state,
+                                                  uint16_t line, uint16_t column);
 rio_cursor_s rio_render_state_cursor(const rio_render_state_t *state);
 
 /* This frame's dynamic (OSC 10/11/12) default colors. `which`: 0 =

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -25,8 +25,9 @@ typedef size_t rio_surface_id_t;
 #define RIO_COLOR_NAMED 0u
 #define RIO_COLOR_INDEXED 1u
 #define RIO_COLOR_RGB 2u
-/* An absent color (value and rgb are zero). Only returned by
- * rio_render_state_cell_underline_color. */
+/* An absent color (value and rgb are zero). Returned by
+ * rio_render_state_cell_underline_color for cells without an explicit
+ * underline color, and as the fg/bg of a missing cell. */
 #define RIO_COLOR_NONE 3u
 
 #define RIO_KEY_CHAR 0u
@@ -334,6 +335,10 @@ size_t rio_render_state_cell_cluster(const rio_render_state_t *state,
 size_t rio_cluster_width(const uint32_t *codepoints, size_t len,
                          uint8_t *out_width);
 
+/* The cell at (line, column). A NULL state or out-of-range query returns
+ * a blank cell whose fg/bg have kind RIO_COLOR_NONE, so a miss is never
+ * mistaken for a real black cell; real cells always carry a drawable
+ * fg/bg kind. */
 rio_cell_s rio_render_state_cell(const rio_render_state_t *state, uint16_t line,
                                  uint16_t column);
 /* Set in rio_cell_s.style_flags when the cell carries an explicit SGR 58
@@ -342,8 +347,8 @@ rio_cell_s rio_render_state_cell(const rio_render_state_t *state, uint16_t line,
  * the fallback rio's own renderer applies. This is bit 14. */
 #define RIO_CELL_HAS_UNDERLINE_COLOR (1u << 14)
 /* The cell's explicit SGR 58 underline color, or kind RIO_COLOR_NONE
- * when the cell (or the call: NULL state, out-of-range cell) has none;
- * see RIO_CELL_HAS_UNDERLINE_COLOR. */
+ * when the cell has none (also for a NULL state, an out-of-range cell,
+ * or an internal error); see RIO_CELL_HAS_UNDERLINE_COLOR. */
 rio_color_s rio_render_state_cell_underline_color(const rio_render_state_t *state,
                                                   uint16_t line, uint16_t column);
 rio_cursor_s rio_render_state_cursor(const rio_render_state_t *state);

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Action, Engine, Key, KeyAction, KeyEvent, Modifiers, RenderState, SelectionKind,
-    Side, StyleFlags, Surface, SurfaceDelegate, SurfaceDesc, SurfaceId,
+    Side, Square, Style, StyleFlags, Surface, SurfaceDelegate, SurfaceDesc, SurfaceId,
 };
 use rio_vt::config::colors::{AnsiColor, ColorRgb, NamedColor};
 use std::ffi::{c_char, c_void, CStr, CString};
@@ -1005,21 +1005,22 @@ pub unsafe extern "C" fn rio_render_state_cell(
             return empty;
         }
         let state = unsafe { &*state };
-        let Some(square) = state.square(line as usize, column as usize) else {
+        let Some((square, style)) = cell_style(state, line, column) else {
             return empty;
         };
-        let style = state.style_at(line as usize, column as usize, square);
-        let cluster = if state.cluster_of(square).is_some() {
-            RIO_CELL_HAS_CLUSTER
-        } else {
-            0
-        };
+        let mut markers = 0;
+        if state.cluster_of(square).is_some() {
+            markers |= RIO_CELL_HAS_CLUSTER;
+        }
+        if style.underline_color.is_some() {
+            markers |= RIO_CELL_HAS_UNDERLINE_COLOR;
+        }
         let tc = state.term_colors();
         rio_cell_s {
             codepoint: square.c() as u32,
             fg: resolve_cell_color(style.fg, tc),
             bg: resolve_cell_color(style.bg, tc),
-            style_flags: style.flags.bits() | cluster,
+            style_flags: style.flags.bits() | markers,
         }
     }))
     .unwrap_or(rio_cell_s {
@@ -1030,10 +1031,18 @@ pub unsafe extern "C" fn rio_render_state_cell(
     })
 }
 
-/// Color to draw the cell's underline with: the SGR 58 underline color
-/// when the program set one, else the cell's foreground — the same
-/// preference rio's own renderer applies. Only meaningful when the
-/// cell's `style_flags` carry an underline kind bit.
+/// Shared lookup for the per-cell accessors: the square at (line, column)
+/// and its resolved style, or `None` out of bounds.
+fn cell_style(state: &RenderState, line: u16, column: u16) -> Option<(&Square, Style)> {
+    let square = state.square(line as usize, column as usize)?;
+    let style = state.style_at(line as usize, column as usize, square);
+    Some((square, style))
+}
+
+/// The cell's explicit SGR 58 underline color. Meaningful only when the
+/// cell's `style_flags` carry [`RIO_CELL_HAS_UNDERLINE_COLOR`]; without
+/// that bit, draw the underline in the color used for the glyph (the fg
+/// after any INVERSE swap), the fallback rio's own renderer applies.
 #[no_mangle]
 pub unsafe extern "C" fn rio_render_state_cell_underline_color(
     state: *const RenderState,
@@ -1045,12 +1054,13 @@ pub unsafe extern "C" fn rio_render_state_cell_underline_color(
             return rio_color_s::default();
         }
         let state = unsafe { &*state };
-        let Some(square) = state.square(line as usize, column as usize) else {
+        let Some((_, style)) = cell_style(state, line, column) else {
             return rio_color_s::default();
         };
-        let style = state.style_at(line as usize, column as usize, square);
-        let tc = state.term_colors();
-        resolve_cell_color(style.underline_color.unwrap_or(style.fg), tc)
+        let Some(underline) = style.underline_color else {
+            return rio_color_s::default();
+        };
+        resolve_cell_color(underline, state.term_colors())
     }))
     .unwrap_or_default()
 }
@@ -1063,9 +1073,15 @@ pub unsafe extern "C" fn rio_render_state_cell_underline_color(
 /// `RIO_STYLE_*` constants in librio.h); this is bit 15.
 pub const RIO_CELL_HAS_CLUSTER: u16 = 1 << 15;
 
+/// Set in `rio_cell_s.style_flags` when the cell carries an explicit
+/// SGR 58 underline color; fetch it with
+/// [`rio_render_state_cell_underline_color`]. Without it the underline
+/// takes the glyph's color. This is bit 14.
+pub const RIO_CELL_HAS_UNDERLINE_COLOR: u16 = 1 << 14;
+
 // librio.h's RIO_STYLE_* defines hand-mirror these bit positions, and
-// StyleFlags shares the u16 with RIO_CELL_HAS_CLUSTER: renumbering or
-// colliding breaks the ABI silently, so pin every exported bit.
+// StyleFlags shares the u16 with the RIO_CELL_* marker bits: renumbering
+// or colliding breaks the ABI silently, so pin every exported bit.
 const _: () = {
     assert!(StyleFlags::INVERSE.bits() == 1 << 0);
     assert!(StyleFlags::BOLD.bits() == 1 << 1);
@@ -1080,7 +1096,10 @@ const _: () = {
     assert!(StyleFlags::DASHED_UNDERLINE.bits() == 1 << 10);
     assert!(StyleFlags::SLOW_BLINK.bits() == 1 << 11);
     assert!(StyleFlags::RAPID_BLINK.bits() == 1 << 12);
-    assert!(StyleFlags::all().bits() & RIO_CELL_HAS_CLUSTER == 0);
+    assert!(
+        StyleFlags::all().bits() & (RIO_CELL_HAS_CLUSTER | RIO_CELL_HAS_UNDERLINE_COLOR)
+            == 0
+    );
 };
 
 /// Write the full text of a cell (base codepoint plus attached

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -19,6 +19,9 @@ pub const RIO_ACTION_PROGRESS: u32 = 3;
 pub const RIO_COLOR_NAMED: u8 = 0;
 pub const RIO_COLOR_INDEXED: u8 = 1;
 pub const RIO_COLOR_RGB: u8 = 2;
+/// An absent color (value and rgb are zero). Only returned by
+/// [`rio_render_state_cell_underline_color`].
+pub const RIO_COLOR_NONE: u8 = 3;
 
 pub const RIO_KEY_CHAR: u32 = 0;
 pub const RIO_KEY_ENTER: u32 = 1;
@@ -105,6 +108,9 @@ pub struct rio_color_s {
     pub b: u8,
 }
 
+/// A renderable cell. `fg`/`bg` are exported pre-swap: when the flags
+/// carry `StyleFlags::INVERSE` the host swaps them when drawing, as
+/// rio's own renderer does.
 #[repr(C)]
 pub struct rio_cell_s {
     pub codepoint: u32,
@@ -1039,30 +1045,33 @@ fn cell_style(state: &RenderState, line: u16, column: u16) -> Option<(&Square, S
     Some((square, style))
 }
 
-/// The cell's explicit SGR 58 underline color. Meaningful only when the
-/// cell's `style_flags` carry [`RIO_CELL_HAS_UNDERLINE_COLOR`]; without
-/// that bit, draw the underline in the color used for the glyph (the fg
-/// after any INVERSE swap), the fallback rio's own renderer applies.
+/// The cell's explicit SGR 58 underline color, or kind
+/// [`RIO_COLOR_NONE`] when the cell (or the call) has none; see
+/// [`RIO_CELL_HAS_UNDERLINE_COLOR`].
 #[no_mangle]
 pub unsafe extern "C" fn rio_render_state_cell_underline_color(
     state: *const RenderState,
     line: u16,
     column: u16,
 ) -> rio_color_s {
+    let none = rio_color_s {
+        kind: RIO_COLOR_NONE,
+        ..rio_color_s::default()
+    };
     catch_unwind(AssertUnwindSafe(|| {
         if state.is_null() {
-            return rio_color_s::default();
+            return none;
         }
         let state = unsafe { &*state };
         let Some((_, style)) = cell_style(state, line, column) else {
-            return rio_color_s::default();
+            return none;
         };
         let Some(underline) = style.underline_color else {
-            return rio_color_s::default();
+            return none;
         };
         resolve_cell_color(underline, state.term_colors())
     }))
-    .unwrap_or_default()
+    .unwrap_or(none)
 }
 
 /// Set in `rio_cell_s.style_flags` when the cell carries attached

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Action, Engine, Key, KeyAction, KeyEvent, Modifiers, RenderState, SelectionKind,
-    Side, Surface, SurfaceDelegate, SurfaceDesc, SurfaceId,
+    Side, StyleFlags, Surface, SurfaceDelegate, SurfaceDesc, SurfaceId,
 };
 use rio_vt::config::colors::{AnsiColor, ColorRgb, NamedColor};
 use std::ffi::{c_char, c_void, CStr, CString};
@@ -1034,8 +1034,12 @@ pub unsafe extern "C" fn rio_render_state_cell(
 /// cluster codepoints (combining marks, or a mode-2027 grapheme
 /// cluster) beyond `codepoint`. Fetch the full text with
 /// [`rio_render_state_cell_cluster`] and draw that instead of the
-/// base char. StyleFlags proper occupies bits 0..10; this is bit 15.
+/// base char. StyleFlags proper occupies bits 0..12 (the
+/// `RIO_STYLE_*` constants in librio.h); this is bit 15.
 pub const RIO_CELL_HAS_CLUSTER: u16 = 1 << 15;
+
+// StyleFlags shares the u16 with this bit; a new flag must not collide.
+const _: () = assert!(StyleFlags::all().bits() & RIO_CELL_HAS_CLUSTER == 0);
 
 /// Write the full text of a cell (base codepoint plus attached
 /// cluster codepoints) as UTF-32 into `out` (capacity `cap` code

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -1030,6 +1030,31 @@ pub unsafe extern "C" fn rio_render_state_cell(
     })
 }
 
+/// Color to draw the cell's underline with: the SGR 58 underline color
+/// when the program set one, else the cell's foreground — the same
+/// preference rio's own renderer applies. Only meaningful when the
+/// cell's `style_flags` carry an underline kind bit.
+#[no_mangle]
+pub unsafe extern "C" fn rio_render_state_cell_underline_color(
+    state: *const RenderState,
+    line: u16,
+    column: u16,
+) -> rio_color_s {
+    catch_unwind(AssertUnwindSafe(|| {
+        if state.is_null() {
+            return rio_color_s::default();
+        }
+        let state = unsafe { &*state };
+        let Some(square) = state.square(line as usize, column as usize) else {
+            return rio_color_s::default();
+        };
+        let style = state.style_at(line as usize, column as usize, square);
+        let tc = state.term_colors();
+        resolve_cell_color(style.underline_color.unwrap_or(style.fg), tc)
+    }))
+    .unwrap_or_default()
+}
+
 /// Set in `rio_cell_s.style_flags` when the cell carries attached
 /// cluster codepoints (combining marks, or a mode-2027 grapheme
 /// cluster) beyond `codepoint`. Fetch the full text with

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -1034,12 +1034,29 @@ pub unsafe extern "C" fn rio_render_state_cell(
 /// cluster codepoints (combining marks, or a mode-2027 grapheme
 /// cluster) beyond `codepoint`. Fetch the full text with
 /// [`rio_render_state_cell_cluster`] and draw that instead of the
-/// base char. StyleFlags proper occupies bits 0..12 (the
+/// base char. StyleFlags proper occupies bits 0-12 (the
 /// `RIO_STYLE_*` constants in librio.h); this is bit 15.
 pub const RIO_CELL_HAS_CLUSTER: u16 = 1 << 15;
 
-// StyleFlags shares the u16 with this bit; a new flag must not collide.
-const _: () = assert!(StyleFlags::all().bits() & RIO_CELL_HAS_CLUSTER == 0);
+// librio.h's RIO_STYLE_* defines hand-mirror these bit positions, and
+// StyleFlags shares the u16 with RIO_CELL_HAS_CLUSTER: renumbering or
+// colliding breaks the ABI silently, so pin every exported bit.
+const _: () = {
+    assert!(StyleFlags::INVERSE.bits() == 1 << 0);
+    assert!(StyleFlags::BOLD.bits() == 1 << 1);
+    assert!(StyleFlags::ITALIC.bits() == 1 << 2);
+    assert!(StyleFlags::DIM.bits() == 1 << 3);
+    assert!(StyleFlags::HIDDEN.bits() == 1 << 4);
+    assert!(StyleFlags::STRIKEOUT.bits() == 1 << 5);
+    assert!(StyleFlags::UNDERLINE.bits() == 1 << 6);
+    assert!(StyleFlags::DOUBLE_UNDERLINE.bits() == 1 << 7);
+    assert!(StyleFlags::UNDERCURL.bits() == 1 << 8);
+    assert!(StyleFlags::DOTTED_UNDERLINE.bits() == 1 << 9);
+    assert!(StyleFlags::DASHED_UNDERLINE.bits() == 1 << 10);
+    assert!(StyleFlags::SLOW_BLINK.bits() == 1 << 11);
+    assert!(StyleFlags::RAPID_BLINK.bits() == 1 << 12);
+    assert!(StyleFlags::all().bits() & RIO_CELL_HAS_CLUSTER == 0);
+};
 
 /// Write the full text of a cell (base codepoint plus attached
 /// cluster codepoints) as UTF-32 into `out` (capacity `cap` code

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -98,6 +98,10 @@ pub struct rio_surface_config_s {
     pub args_len: usize,
 }
 
+/// A color in its original form (`RIO_COLOR_NAMED` / `_INDEXED` /
+/// `_RGB`; `value` holds the named id or palette index), with `r`/`g`/`b`
+/// resolved for every kind except [`RIO_COLOR_NONE`], which means no
+/// color at all: `value` and `r`/`g`/`b` are zero.
 #[repr(C)]
 #[derive(Clone, Copy, Default)]
 pub struct rio_color_s {
@@ -110,7 +114,8 @@ pub struct rio_color_s {
 
 /// A renderable cell. `fg`/`bg` are exported pre-swap: when the flags
 /// carry `StyleFlags::INVERSE` the host swaps them when drawing, as
-/// rio's own renderer does.
+/// rio's own renderer does. They have kind [`RIO_COLOR_NONE`] only on a
+/// missing cell (NULL state or out-of-range query).
 #[repr(C)]
 pub struct rio_cell_s {
     pub codepoint: u32,
@@ -444,9 +449,9 @@ fn named_rgb(t: &rio_vt::config::Colors, n: NamedColor) -> (u8, u8, u8) {
 }
 
 /// Convert a terminal color to the C representation. `kind`/`value` keep
-/// the original form (named / indexed / rgb) for callers that want it, but
-/// `r`/`g`/`b` are ALWAYS the resolved RGB so a CPU renderer can read them
-/// directly without owning a palette.
+/// the original form (named / indexed / rgb, never `RIO_COLOR_NONE`) for
+/// callers that want it, but `r`/`g`/`b` are always the resolved RGB so a
+/// CPU renderer can read them directly without owning a palette.
 fn color_to_c(color: AnsiColor) -> rio_color_s {
     let (r, g, b) = match color {
         AnsiColor::Named(named) => named_rgb(&theme_lock().read().unwrap(), named),
@@ -994,6 +999,26 @@ pub unsafe extern "C" fn rio_render_state_reset_dirty(state: *mut RenderState) {
     }));
 }
 
+/// The no-color value: kind [`RIO_COLOR_NONE`], everything else zero.
+fn none_color() -> rio_color_s {
+    rio_color_s {
+        kind: RIO_COLOR_NONE,
+        ..rio_color_s::default()
+    }
+}
+
+/// The "no such cell" result: a blank whose fg/bg have kind
+/// [`RIO_COLOR_NONE`], so a miss is detectable and never mistaken for a
+/// real black cell.
+fn empty_cell() -> rio_cell_s {
+    rio_cell_s {
+        codepoint: ' ' as u32,
+        fg: none_color(),
+        bg: none_color(),
+        style_flags: 0,
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn rio_render_state_cell(
     state: *const RenderState,
@@ -1001,18 +1026,12 @@ pub unsafe extern "C" fn rio_render_state_cell(
     column: u16,
 ) -> rio_cell_s {
     catch_unwind(AssertUnwindSafe(|| {
-        let empty = rio_cell_s {
-            codepoint: ' ' as u32,
-            fg: rio_color_s::default(),
-            bg: rio_color_s::default(),
-            style_flags: 0,
-        };
         if state.is_null() {
-            return empty;
+            return empty_cell();
         }
         let state = unsafe { &*state };
         let Some((square, style)) = cell_style(state, line, column) else {
-            return empty;
+            return empty_cell();
         };
         let mut markers = 0;
         if state.cluster_of(square).is_some() {
@@ -1029,12 +1048,7 @@ pub unsafe extern "C" fn rio_render_state_cell(
             style_flags: style.flags.bits() | markers,
         }
     }))
-    .unwrap_or(rio_cell_s {
-        codepoint: ' ' as u32,
-        fg: rio_color_s::default(),
-        bg: rio_color_s::default(),
-        style_flags: 0,
-    })
+    .unwrap_or_else(|_| empty_cell())
 }
 
 /// Shared lookup for the per-cell accessors: the square at (line, column)
@@ -1046,7 +1060,8 @@ fn cell_style(state: &RenderState, line: u16, column: u16) -> Option<(&Square, S
 }
 
 /// The cell's explicit SGR 58 underline color, or kind
-/// [`RIO_COLOR_NONE`] when the cell (or the call) has none; see
+/// [`RIO_COLOR_NONE`] when the cell has none (also for a NULL state, an
+/// out-of-range cell, or an internal error); see
 /// [`RIO_CELL_HAS_UNDERLINE_COLOR`].
 #[no_mangle]
 pub unsafe extern "C" fn rio_render_state_cell_underline_color(
@@ -1054,24 +1069,20 @@ pub unsafe extern "C" fn rio_render_state_cell_underline_color(
     line: u16,
     column: u16,
 ) -> rio_color_s {
-    let none = rio_color_s {
-        kind: RIO_COLOR_NONE,
-        ..rio_color_s::default()
-    };
     catch_unwind(AssertUnwindSafe(|| {
         if state.is_null() {
-            return none;
+            return none_color();
         }
         let state = unsafe { &*state };
         let Some((_, style)) = cell_style(state, line, column) else {
-            return none;
+            return none_color();
         };
         let Some(underline) = style.underline_color else {
-            return none;
+            return none_color();
         };
         resolve_cell_color(underline, state.term_colors())
     }))
-    .unwrap_or(none)
+    .unwrap_or_else(|_| none_color())
 }
 
 /// Set in `rio_cell_s.style_flags` when the cell carries attached
@@ -1088,10 +1099,15 @@ pub const RIO_CELL_HAS_CLUSTER: u16 = 1 << 15;
 /// takes the glyph's color. This is bit 14.
 pub const RIO_CELL_HAS_UNDERLINE_COLOR: u16 = 1 << 14;
 
-// librio.h's RIO_STYLE_* defines hand-mirror these bit positions, and
-// StyleFlags shares the u16 with the RIO_CELL_* marker bits: renumbering
-// or colliding breaks the ABI silently, so pin every exported bit.
+// librio.h's RIO_STYLE_* and RIO_COLOR_* defines hand-mirror these
+// values, and StyleFlags shares the u16 with the RIO_CELL_* marker bits:
+// renumbering or colliding breaks the ABI silently, so pin every
+// exported value.
 const _: () = {
+    assert!(RIO_COLOR_NAMED == 0);
+    assert!(RIO_COLOR_INDEXED == 1);
+    assert!(RIO_COLOR_RGB == 2);
+    assert!(RIO_COLOR_NONE == 3);
     assert!(StyleFlags::INVERSE.bits() == 1 << 0);
     assert!(StyleFlags::BOLD.bits() == 1 << 1);
     assert!(StyleFlags::ITALIC.bits() == 1 << 2);

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -1548,11 +1548,12 @@ mod tests {
     fn capi_reports_underline_color() {
         use crate::capi::{
             rio_render_state_cell, rio_render_state_cell_underline_color,
-            RIO_CELL_HAS_UNDERLINE_COLOR, RIO_COLOR_NONE, RIO_COLOR_RGB,
+            RIO_CELL_HAS_UNDERLINE_COLOR, RIO_COLOR_INDEXED, RIO_COLOR_NONE,
+            RIO_COLOR_RGB,
         };
 
         let surface = quiet_surface(10, 3);
-        surface.inject_output(b"\x1b[4;58;2;10;20;30ma\x1b[0mb");
+        surface.inject_output(b"\x1b[4;58;2;10;20;30ma\x1b[0mb\x1b[4;58;5;196mc\x1b[0m");
         let mut state = RenderState::new(&surface);
         state.update();
 
@@ -1569,6 +1570,24 @@ mod tests {
         assert_eq!(absent.kind, RIO_COLOR_NONE);
         assert_eq!(absent.value, 0);
         assert_eq!((absent.r, absent.g, absent.b), (0, 0, 0));
+
+        // Indexed colors keep their form and still resolve rgb (256-color
+        // cube index 196 is pure red).
+        let indexed = unsafe { rio_render_state_cell_underline_color(&state, 0, 2) };
+        assert_eq!(indexed.kind, RIO_COLOR_INDEXED);
+        assert_eq!(indexed.value, 196);
+        assert_eq!((indexed.r, indexed.g, indexed.b), (255, 0, 0));
+
+        // A NULL state and an out-of-range cell also answer NONE, and a
+        // missing cell's fg/bg carry the NONE kind.
+        let null =
+            unsafe { rio_render_state_cell_underline_color(std::ptr::null(), 0, 0) };
+        assert_eq!(null.kind, RIO_COLOR_NONE);
+        let oob = unsafe { rio_render_state_cell_underline_color(&state, 99, 99) };
+        assert_eq!(oob.kind, RIO_COLOR_NONE);
+        let missing = unsafe { rio_render_state_cell(&state, 99, 99) };
+        assert_eq!(missing.fg.kind, RIO_COLOR_NONE);
+        assert_eq!(missing.bg.kind, RIO_COLOR_NONE);
     }
 
     // Scrollback rows come first, and wrapped rows are emitted without a

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -1548,7 +1548,7 @@ mod tests {
     fn capi_reports_underline_color() {
         use crate::capi::{
             rio_render_state_cell, rio_render_state_cell_underline_color,
-            RIO_CELL_HAS_UNDERLINE_COLOR, RIO_COLOR_NONE,
+            RIO_CELL_HAS_UNDERLINE_COLOR, RIO_COLOR_NONE, RIO_COLOR_RGB,
         };
 
         let surface = quiet_surface(10, 3);
@@ -1559,12 +1559,16 @@ mod tests {
         let marked = unsafe { rio_render_state_cell(&state, 0, 0) };
         assert_ne!(marked.style_flags & RIO_CELL_HAS_UNDERLINE_COLOR, 0);
         let color = unsafe { rio_render_state_cell_underline_color(&state, 0, 0) };
+        assert_eq!(color.kind, RIO_COLOR_RGB);
         assert_eq!((color.r, color.g, color.b), (10, 20, 30));
 
         let plain = unsafe { rio_render_state_cell(&state, 0, 1) };
         assert_eq!(plain.style_flags & RIO_CELL_HAS_UNDERLINE_COLOR, 0);
+        // The NONE sentinel promises zeroed value and rgb.
         let absent = unsafe { rio_render_state_cell_underline_color(&state, 0, 1) };
         assert_eq!(absent.kind, RIO_COLOR_NONE);
+        assert_eq!(absent.value, 0);
+        assert_eq!((absent.r, absent.g, absent.b), (0, 0, 0));
     }
 
     // Scrollback rows come first, and wrapped rows are emitted without a

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -1542,6 +1542,29 @@ mod tests {
         assert_eq!(replica.serialize(), first);
     }
 
+    // The C ABI marks cells carrying an explicit SGR 58 underline color
+    // and hands the color out; unmarked cells take the glyph's color.
+    #[test]
+    fn capi_reports_underline_color() {
+        use crate::capi::{
+            rio_render_state_cell, rio_render_state_cell_underline_color,
+            RIO_CELL_HAS_UNDERLINE_COLOR,
+        };
+
+        let surface = quiet_surface(10, 3);
+        surface.inject_output(b"\x1b[4;58;2;10;20;30ma\x1b[0mb");
+        let mut state = RenderState::new(&surface);
+        state.update();
+
+        let marked = unsafe { rio_render_state_cell(&state, 0, 0) };
+        assert_ne!(marked.style_flags & RIO_CELL_HAS_UNDERLINE_COLOR, 0);
+        let color = unsafe { rio_render_state_cell_underline_color(&state, 0, 0) };
+        assert_eq!((color.r, color.g, color.b), (10, 20, 30));
+
+        let plain = unsafe { rio_render_state_cell(&state, 0, 1) };
+        assert_eq!(plain.style_flags & RIO_CELL_HAS_UNDERLINE_COLOR, 0);
+    }
+
     // Scrollback rows come first, and wrapped rows are emitted without a
     // newline so the replica re-wraps them at the same width.
     #[test]

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -334,94 +334,6 @@ fn trailing_url_punctuation(text: &str) -> usize {
     trimmed
 }
 
-/// Emit `\x1b[0m` plus the minimal SGR codes reproducing `style`.
-fn serialize_style(out: &mut String, style: &Style) {
-    use std::fmt::Write as _;
-
-    out.push_str("\x1b[0");
-    let color = |prefix38: bool, color: &AnsiColor| match color {
-        AnsiColor::Named(n) => {
-            let n = *n as u16;
-            let code = match (n, prefix38) {
-                (0..=7, true) => 30 + n,
-                (0..=7, false) => 40 + n,
-                (8..=15, true) => 90 + (n - 8),
-                (8..=15, false) => 100 + (n - 8),
-                (_, true) => 39,
-                (_, false) => 49,
-            };
-            format!(";{code}")
-        }
-        AnsiColor::Indexed(i) => {
-            format!(";{};5;{i}", if prefix38 { 38 } else { 48 })
-        }
-        AnsiColor::Spec(rgb) => {
-            format!(
-                ";{};2;{};{};{}",
-                if prefix38 { 38 } else { 48 },
-                rgb.r,
-                rgb.g,
-                rgb.b
-            )
-        }
-    };
-    let fg = color(true, &style.fg);
-    let bg = color(false, &style.bg);
-    out.push_str(&fg);
-    out.push_str(&bg);
-
-    let flags = style.flags;
-    if flags.contains(StyleFlags::BOLD) {
-        out.push_str(";1");
-    }
-    if flags.contains(StyleFlags::DIM) {
-        out.push_str(";2");
-    }
-    if flags.contains(StyleFlags::ITALIC) {
-        out.push_str(";3");
-    }
-    if flags.contains(StyleFlags::UNDERLINE) {
-        out.push_str(";4");
-    } else if flags.contains(StyleFlags::DOUBLE_UNDERLINE) {
-        out.push_str(";4:2");
-    } else if flags.contains(StyleFlags::UNDERCURL) {
-        out.push_str(";4:3");
-    } else if flags.contains(StyleFlags::DOTTED_UNDERLINE) {
-        out.push_str(";4:4");
-    } else if flags.contains(StyleFlags::DASHED_UNDERLINE) {
-        out.push_str(";4:5");
-    }
-    if flags.contains(StyleFlags::SLOW_BLINK) {
-        out.push_str(";5");
-    } else if flags.contains(StyleFlags::RAPID_BLINK) {
-        out.push_str(";6");
-    }
-    if flags.contains(StyleFlags::INVERSE) {
-        out.push_str(";7");
-    }
-    if flags.contains(StyleFlags::HIDDEN) {
-        out.push_str(";8");
-    }
-    if flags.contains(StyleFlags::STRIKEOUT) {
-        out.push_str(";9");
-    }
-    out.push('m');
-
-    if let Some(underline) = &style.underline_color {
-        match underline {
-            AnsiColor::Indexed(i) => {
-                let _ = write!(out, "\x1b[58;5;{i}m");
-            }
-            AnsiColor::Spec(rgb) => {
-                let _ = write!(out, "\x1b[58;2;{};{};{}m", rgb.r, rgb.g, rgb.b);
-            }
-            AnsiColor::Named(n) => {
-                let _ = write!(out, "\x1b[58;5;{}m", *n as u16);
-            }
-        }
-    }
-}
-
 pub struct Surface {
     id: SurfaceId,
     alt_is_meta: std::sync::atomic::AtomicBool,
@@ -1034,7 +946,7 @@ impl Surface {
 
                 let cell_style = grid.style_of(&square);
                 if cell_style != style {
-                    serialize_style(&mut out, &cell_style);
+                    rio_vt::crosswords::formatter::write_sgr(&mut out, &cell_style);
                     style = cell_style;
                 }
 
@@ -1687,8 +1599,9 @@ mod tests {
         surface.inject_output(b"1mred");
         let dump = surface.dump();
         assert_eq!(dump.trim_end(), "red", "no literal escape tail: {dump:?}");
-        // The style applied: serialize carries the red foreground.
-        assert!(surface.serialize().contains("\x1b[0;31;49m"));
+        // The style applied: serialize carries the red foreground (the
+        // default bg is covered by the leading reset).
+        assert!(surface.serialize().contains("\x1b[0;31m"));
 
         // Split inside an OSC title too.
         surface.inject_output(b"\x1b]0;hel");

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -391,6 +391,11 @@ fn serialize_style(out: &mut String, style: &Style) {
     } else if flags.contains(StyleFlags::DASHED_UNDERLINE) {
         out.push_str(";4:5");
     }
+    if flags.contains(StyleFlags::SLOW_BLINK) {
+        out.push_str(";5");
+    } else if flags.contains(StyleFlags::RAPID_BLINK) {
+        out.push_str(";6");
+    }
     if flags.contains(StyleFlags::INVERSE) {
         out.push_str(";7");
     }
@@ -1611,10 +1616,13 @@ mod tests {
             b"\x1b[31mred\x1b[0m plain \x1b[1;4;38;5;208morange\x1b[0m\r\n\
               \x1b[48;2;10;20;30mrgb bg\x1b[0m \
               \x1b]8;;https://rioterm.com\x1b\\link\x1b]8;;\x1b\\\r\n\
+              \x1b[5mslow\x1b[0m \x1b[6mfast\x1b[0m\r\n\
               wide: \xe4\xbd\xa0\xe5\xa5\xbd",
         );
         let first = surface.serialize();
         assert!(first.contains("\x1b]8;;https://rioterm.com\x1b\\"));
+        assert!(first.contains(";5m"), "missing slow blink: {first:?}");
+        assert!(first.contains(";6m"), "missing rapid blink: {first:?}");
 
         let replica = quiet_surface(40, 10);
         replica.inject_output(first.as_bytes());

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -1548,7 +1548,7 @@ mod tests {
     fn capi_reports_underline_color() {
         use crate::capi::{
             rio_render_state_cell, rio_render_state_cell_underline_color,
-            RIO_CELL_HAS_UNDERLINE_COLOR,
+            RIO_CELL_HAS_UNDERLINE_COLOR, RIO_COLOR_NONE,
         };
 
         let surface = quiet_surface(10, 3);
@@ -1563,6 +1563,8 @@ mod tests {
 
         let plain = unsafe { rio_render_state_cell(&state, 0, 1) };
         assert_eq!(plain.style_flags & RIO_CELL_HAS_UNDERLINE_COLOR, 0);
+        let absent = unsafe { rio_render_state_cell_underline_color(&state, 0, 1) };
+        assert_eq!(absent.kind, RIO_COLOR_NONE);
     }
 
     // Scrollback rows come first, and wrapped rows are emitted without a

--- a/rio-grid/src/lib.rs
+++ b/rio-grid/src/lib.rs
@@ -33,7 +33,7 @@ use rio_backend::crosswords::grid::row::Row;
 use rio_backend::crosswords::pos::{Column, Line, Pos};
 use rio_backend::crosswords::search::Match;
 use rio_backend::crosswords::square::{ContentTag, Extras, Square};
-use rio_backend::crosswords::style::{Style, StyleFlags};
+use rio_backend::crosswords::style::{Style, StyleFlags, UnderlineKind};
 use rio_backend::selection::SelectionRange;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
@@ -975,23 +975,16 @@ fn ensure_decoration_slot(
 }
 
 /// Pick the decoration enum value for a cell's `StyleFlags`, or `None`
-/// if the cell has no underline. Bit-test order matches StyleFlags
-/// ordering in `rio-backend/src/crosswords/style.rs`.
+/// if the cell has no underline.
 #[inline]
 fn underline_style_from_flags(flags: StyleFlags) -> Option<DecorationStyle> {
-    if flags.contains(StyleFlags::UNDERLINE) {
-        Some(DecorationStyle::Underline)
-    } else if flags.contains(StyleFlags::DOUBLE_UNDERLINE) {
-        Some(DecorationStyle::DoubleUnderline)
-    } else if flags.contains(StyleFlags::UNDERCURL) {
-        Some(DecorationStyle::CurlyUnderline)
-    } else if flags.contains(StyleFlags::DOTTED_UNDERLINE) {
-        Some(DecorationStyle::DottedUnderline)
-    } else if flags.contains(StyleFlags::DASHED_UNDERLINE) {
-        Some(DecorationStyle::DashedUnderline)
-    } else {
-        None
-    }
+    flags.underline_kind().map(|kind| match kind {
+        UnderlineKind::Single => DecorationStyle::Underline,
+        UnderlineKind::Double => DecorationStyle::DoubleUnderline,
+        UnderlineKind::Curly => DecorationStyle::CurlyUnderline,
+        UnderlineKind::Dotted => DecorationStyle::DottedUnderline,
+        UnderlineKind::Dashed => DecorationStyle::DashedUnderline,
+    })
 }
 
 /// Decoration color: SGR 58 `underline_color` if set, else the cell's

--- a/rio-vt/src/crosswords/formatter.rs
+++ b/rio-vt/src/crosswords/formatter.rs
@@ -190,6 +190,11 @@ fn write_sgr(out: &mut String, style: &Style) {
     if flags.contains(StyleFlags::UNDERLINE) {
         out.push_str(";4");
     }
+    if flags.contains(StyleFlags::SLOW_BLINK) {
+        out.push_str(";5");
+    } else if flags.contains(StyleFlags::RAPID_BLINK) {
+        out.push_str(";6");
+    }
     if flags.contains(StyleFlags::INVERSE) {
         out.push_str(";7");
     }
@@ -257,8 +262,8 @@ mod tests {
     #[test]
     fn vt_roundtrip_preserves_text_and_style() {
         let mut a = term(20, 4);
-        // red "hello", default space, bold-blue "world".
-        feed(&mut a, b"\x1b[31mhello\x1b[0m \x1b[1;34mworld\x1b[0m");
+        // rapid-blink red "hello", default space, bold-blink-blue "world".
+        feed(&mut a, b"\x1b[6;31mhello\x1b[0m \x1b[1;5;34mworld\x1b[0m");
         let snapshot = a.contents_formatted();
 
         // The snapshot must carry the colors (index form, not resolved rgb).
@@ -281,6 +286,9 @@ mod tests {
         assert_eq!(sb.c(), 'w');
         assert_eq!(a.grid.style_of(&sa).fg, b.grid.style_of(&sb).fg);
         assert!(b.grid.style_of(&sb).flags.contains(StyleFlags::BOLD));
+        assert!(b.grid.style_of(&sb).flags.contains(StyleFlags::SLOW_BLINK));
+        let hb = *(&b.grid[Line(0)][Column(0)] as &Square);
+        assert!(b.grid.style_of(&hb).flags.contains(StyleFlags::RAPID_BLINK));
     }
 
     #[test]

--- a/rio-vt/src/crosswords/formatter.rs
+++ b/rio-vt/src/crosswords/formatter.rs
@@ -189,6 +189,14 @@ fn write_sgr(out: &mut String, style: &Style) {
     }
     if flags.contains(StyleFlags::UNDERLINE) {
         out.push_str(";4");
+    } else if flags.contains(StyleFlags::DOUBLE_UNDERLINE) {
+        out.push_str(";4:2");
+    } else if flags.contains(StyleFlags::UNDERCURL) {
+        out.push_str(";4:3");
+    } else if flags.contains(StyleFlags::DOTTED_UNDERLINE) {
+        out.push_str(";4:4");
+    } else if flags.contains(StyleFlags::DASHED_UNDERLINE) {
+        out.push_str(";4:5");
     }
     if flags.contains(StyleFlags::SLOW_BLINK) {
         out.push_str(";5");
@@ -207,6 +215,22 @@ fn write_sgr(out: &mut String, style: &Style) {
     push_color(out, style.fg, true);
     push_color(out, style.bg, false);
     out.push('m');
+
+    // Underline color travels as its own sequence; the leading reset
+    // already cleared any previous one.
+    if let Some(underline) = style.underline_color {
+        match underline {
+            AnsiColor::Indexed(i) => {
+                let _ = write!(out, "\x1b[58;5;{i}m");
+            }
+            AnsiColor::Spec(rgb) => {
+                let _ = write!(out, "\x1b[58;2;{};{};{}m", rgb.r, rgb.g, rgb.b);
+            }
+            AnsiColor::Named(n) => {
+                let _ = write!(out, "\x1b[58;5;{}m", n as u16);
+            }
+        }
+    }
 }
 
 fn push_color(params: &mut String, color: AnsiColor, fg: bool) {
@@ -262,8 +286,13 @@ mod tests {
     #[test]
     fn vt_roundtrip_preserves_text_and_style() {
         let mut a = term(20, 4);
-        // rapid-blink red "hello", default space, bold-blink-blue "world".
-        feed(&mut a, b"\x1b[6;31mhello\x1b[0m \x1b[1;5;34mworld\x1b[0m");
+        // rapid-blink red "hello", default space, bold-blink-blue "world",
+        // then a red-undercurled "curl" on the next line.
+        feed(
+            &mut a,
+            b"\x1b[6;31mhello\x1b[0m \x1b[1;5;34mworld\x1b[0m\r\n\
+                      \x1b[4:3;58;2;255;0;0mcurl\x1b[0m",
+        );
         let snapshot = a.contents_formatted();
 
         // The snapshot must carry the colors (index form, not resolved rgb).
@@ -289,6 +318,20 @@ mod tests {
         assert!(b.grid.style_of(&sb).flags.contains(StyleFlags::SLOW_BLINK));
         let hb = *(&b.grid[Line(0)][Column(0)] as &Square);
         assert!(b.grid.style_of(&hb).flags.contains(StyleFlags::RAPID_BLINK));
+
+        // Underline kind and color survive too. 'c' of "curl" is at (1, 0).
+        let cb = *(&b.grid[Line(1)][Column(0)] as &Square);
+        assert_eq!(cb.c(), 'c');
+        let curl = b.grid.style_of(&cb);
+        assert!(curl.flags.contains(StyleFlags::UNDERCURL));
+        assert_eq!(
+            curl.underline_color,
+            Some(AnsiColor::Spec(crate::config::colors::ColorRgb {
+                r: 255,
+                g: 0,
+                b: 0
+            }))
+        );
     }
 
     #[test]

--- a/rio-vt/src/crosswords/formatter.rs
+++ b/rio-vt/src/crosswords/formatter.rs
@@ -175,10 +175,13 @@ impl<U: EventListener> Crosswords<U> {
 }
 
 /// Write the SGR sequence for `style` directly into `out`, starting with `0`
-/// (reset) then re-applying. Written inline (no intermediate allocation);
-/// the caller only calls this when the style actually changes. Colors keep
-/// their original named / indexed / rgb form.
-fn write_sgr(out: &mut String, style: &Style) {
+/// (reset) then re-applying: styles are fully self-contained. Written inline
+/// (no intermediate allocation); call it only when the style actually
+/// changes. Colors keep their original named / indexed / rgb form. Also the
+/// style emitter for librio's `Surface::serialize`.
+pub fn write_sgr(out: &mut String, style: &Style) {
+    use crate::crosswords::style::UnderlineKind;
+
     out.push_str("\x1b[0");
     let flags = style.flags;
     if flags.contains(StyleFlags::BOLD) {
@@ -190,16 +193,13 @@ fn write_sgr(out: &mut String, style: &Style) {
     if flags.contains(StyleFlags::ITALIC) {
         out.push_str(";3");
     }
-    if flags.contains(StyleFlags::UNDERLINE) {
-        out.push_str(";4");
-    } else if flags.contains(StyleFlags::DOUBLE_UNDERLINE) {
-        out.push_str(";4:2");
-    } else if flags.contains(StyleFlags::UNDERCURL) {
-        out.push_str(";4:3");
-    } else if flags.contains(StyleFlags::DOTTED_UNDERLINE) {
-        out.push_str(";4:4");
-    } else if flags.contains(StyleFlags::DASHED_UNDERLINE) {
-        out.push_str(";4:5");
+    match flags.underline_kind() {
+        None => {}
+        Some(UnderlineKind::Single) => out.push_str(";4"),
+        Some(UnderlineKind::Double) => out.push_str(";4:2"),
+        Some(UnderlineKind::Curly) => out.push_str(";4:3"),
+        Some(UnderlineKind::Dotted) => out.push_str(";4:4"),
+        Some(UnderlineKind::Dashed) => out.push_str(";4:5"),
     }
     if flags.contains(StyleFlags::SLOW_BLINK) {
         out.push_str(";5");
@@ -230,7 +230,12 @@ fn write_sgr(out: &mut String, style: &Style) {
                 let _ = write!(out, "\x1b[58;2;{};{};{}m", rgb.r, rgb.g, rgb.b);
             }
             AnsiColor::Named(n) => {
-                let _ = write!(out, "\x1b[58;5;{}m", n as u16);
+                // Specials (Foreground = 256 and up) have no palette
+                // index; SGR 58 cannot express them, so leave the reset's
+                // unset underline color rather than emit an invalid index.
+                if let Ok(idx) = u8::try_from(n as u16) {
+                    let _ = write!(out, "\x1b[58;5;{idx}m");
+                }
             }
         }
     }

--- a/rio-vt/src/crosswords/formatter.rs
+++ b/rio-vt/src/crosswords/formatter.rs
@@ -158,15 +158,18 @@ impl<U: EventListener> Crosswords<U> {
         self.row_last_content_col(line as i32, cols, true).is_some()
     }
 
-    /// Rightmost column with a non-blank glyph, or `None` for a blank row.
+    /// Rightmost column with a non-blank glyph or a non-default style (a
+    /// bg-colored or underlined blank still renders, so it is content),
+    /// or `None` for a row with neither.
     fn row_last_content_col(&self, line: i32, cols: usize, trim: bool) -> Option<usize> {
         if !trim {
             return Some(cols.saturating_sub(1));
         }
         let row = &self.grid[Line(line)];
         (0..cols).rev().find(|&col| {
-            let c = row[Column(col)].c();
-            c != ' ' && c != '\0'
+            let square = &row[Column(col)];
+            let c = square.c();
+            (c != ' ' && c != '\0') || self.grid.style_of(square) != Style::default()
         })
     }
 }
@@ -332,6 +335,30 @@ mod tests {
                 b: 0
             }))
         );
+    }
+
+    #[test]
+    fn vt_roundtrip_preserves_styled_blanks() {
+        use crate::config::colors::NamedColor;
+
+        // Red-background trailing spaces after "AB" render, so the trim
+        // must keep them.
+        let mut a = term(20, 4);
+        feed(&mut a, b"AB\x1b[41m   \x1b[0m");
+        let snapshot = a.contents_formatted();
+        let text = String::from_utf8(snapshot.clone()).unwrap();
+        assert!(text.contains(";41"), "missing red bg: {text:?}");
+
+        let mut b = term(20, 4);
+        feed(&mut b, &snapshot);
+        let sb = *(&b.grid[Line(0)][Column(3)] as &Square);
+        assert_eq!(b.grid.style_of(&sb).bg, AnsiColor::Named(NamedColor::Red));
+
+        // A row made only of styled blanks must not be dropped as blank.
+        let mut c = term(20, 4);
+        feed(&mut c, b"top\r\n\x1b[44m    \x1b[0m");
+        let text = String::from_utf8(c.contents_formatted()).unwrap();
+        assert!(text.contains(";44"), "styled-blank row dropped: {text:?}");
     }
 
     #[test]

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -3375,7 +3375,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
     #[inline]
     fn terminal_attribute(&mut self, attr: Attr) {
         trace!("Setting attribute: {:?}", attr);
-        use crate::crosswords::style::StyleFlags;
+        use crate::crosswords::style::{StyleFlags, UnderlineKind};
         match attr {
             Attr::Foreground(color) => self.grid.update_template_style(|s| s.fg = color),
             Attr::Background(color) => self.grid.update_template_style(|s| s.bg = color),
@@ -3410,24 +3410,19 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 .grid
                 .update_template_style(|s| s.flags.remove(StyleFlags::ITALIC)),
             Attr::Underline => self.grid.update_template_style(|s| {
-                s.flags.remove(StyleFlags::ALL_UNDERLINES);
-                s.flags.insert(StyleFlags::UNDERLINE);
+                s.flags.set_underline(Some(UnderlineKind::Single))
             }),
             Attr::DoubleUnderline => self.grid.update_template_style(|s| {
-                s.flags.remove(StyleFlags::ALL_UNDERLINES);
-                s.flags.insert(StyleFlags::DOUBLE_UNDERLINE);
+                s.flags.set_underline(Some(UnderlineKind::Double))
             }),
             Attr::Undercurl => self.grid.update_template_style(|s| {
-                s.flags.remove(StyleFlags::ALL_UNDERLINES);
-                s.flags.insert(StyleFlags::UNDERCURL);
+                s.flags.set_underline(Some(UnderlineKind::Curly))
             }),
             Attr::DottedUnderline => self.grid.update_template_style(|s| {
-                s.flags.remove(StyleFlags::ALL_UNDERLINES);
-                s.flags.insert(StyleFlags::DOTTED_UNDERLINE);
+                s.flags.set_underline(Some(UnderlineKind::Dotted))
             }),
             Attr::DashedUnderline => self.grid.update_template_style(|s| {
-                s.flags.remove(StyleFlags::ALL_UNDERLINES);
-                s.flags.insert(StyleFlags::DASHED_UNDERLINE);
+                s.flags.set_underline(Some(UnderlineKind::Dashed))
             }),
             Attr::BlinkSlow => self.grid.update_template_style(|s| {
                 s.flags.remove(StyleFlags::ALL_BLINK);
@@ -3442,7 +3437,7 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 .update_template_style(|s| s.flags.remove(StyleFlags::ALL_BLINK)),
             Attr::CancelUnderline => self
                 .grid
-                .update_template_style(|s| s.flags.remove(StyleFlags::ALL_UNDERLINES)),
+                .update_template_style(|s| s.flags.set_underline(None)),
             Attr::Hidden => self
                 .grid
                 .update_template_style(|s| s.flags.insert(StyleFlags::HIDDEN)),

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -3429,9 +3429,17 @@ impl<U: EventListener> Handler for Crosswords<U> {
                 s.flags.remove(StyleFlags::ALL_UNDERLINES);
                 s.flags.insert(StyleFlags::DASHED_UNDERLINE);
             }),
-            Attr::BlinkSlow | Attr::BlinkFast | Attr::CancelBlink => {
-                info!("Term got unhandled attr: {:?}", attr);
-            }
+            Attr::BlinkSlow => self.grid.update_template_style(|s| {
+                s.flags.remove(StyleFlags::ALL_BLINK);
+                s.flags.insert(StyleFlags::SLOW_BLINK);
+            }),
+            Attr::BlinkFast => self.grid.update_template_style(|s| {
+                s.flags.remove(StyleFlags::ALL_BLINK);
+                s.flags.insert(StyleFlags::RAPID_BLINK);
+            }),
+            Attr::CancelBlink => self
+                .grid
+                .update_template_style(|s| s.flags.remove(StyleFlags::ALL_BLINK)),
             Attr::CancelUnderline => self
                 .grid
                 .update_template_style(|s| s.flags.remove(StyleFlags::ALL_UNDERLINES)),
@@ -6093,6 +6101,32 @@ mod tests {
                 .any(|sq| !sq.is_bg_only() && cw.grid.style_of(sq).bg == green)
         });
         assert!(found, "cached row lost its style across shrink/grow");
+    }
+
+    #[test]
+    fn terminal_attributes_preserve_blink_kind() {
+        use crate::crosswords::style::StyleFlags;
+
+        let mut cw = make_crosswords();
+        cw.terminal_attribute(Attr::BlinkSlow);
+        let style = cw.grid.template_style();
+        assert!(style.flags.contains(StyleFlags::SLOW_BLINK));
+        assert!(!style.flags.contains(StyleFlags::RAPID_BLINK));
+
+        cw.terminal_attribute(Attr::BlinkFast);
+        let style = cw.grid.template_style();
+        assert!(!style.flags.contains(StyleFlags::SLOW_BLINK));
+        assert!(style.flags.contains(StyleFlags::RAPID_BLINK));
+
+        cw.terminal_attribute(Attr::CancelBlink);
+        let style = cw.grid.template_style();
+        assert!(!style.flags.intersects(StyleFlags::ALL_BLINK));
+
+        // And the flags survive interning when a glyph is written.
+        cw.terminal_attribute(Attr::BlinkSlow);
+        cw.input('x');
+        let sq = cw.grid[Line(0)][Column(0)];
+        assert!(cw.grid.style_of(&sq).flags.contains(StyleFlags::SLOW_BLINK));
     }
 
     // Minimum-valid simple glyph: one contour, one on-curve point.

--- a/rio-vt/src/crosswords/style.rs
+++ b/rio-vt/src/crosswords/style.rs
@@ -39,8 +39,9 @@ bitflags! {
         const UNDERCURL        = 1 << 8;
         const DOTTED_UNDERLINE = 1 << 9;
         const DASHED_UNDERLINE = 1 << 10;
-        const SLOW_BLINK        = 1 << 11;
-        const RAPID_BLINK       = 1 << 12;
+        const SLOW_BLINK       = 1 << 11;
+        const RAPID_BLINK      = 1 << 12;
+        const ALL_BLINK        = Self::SLOW_BLINK.bits() | Self::RAPID_BLINK.bits();
         const ALL_UNDERLINES   = Self::UNDERLINE.bits()
                                | Self::DOUBLE_UNDERLINE.bits()
                                | Self::UNDERCURL.bits()
@@ -48,7 +49,6 @@ bitflags! {
                                | Self::DASHED_UNDERLINE.bits();
         // Combined intensity for shaping decisions.
         const DIM_BOLD         = Self::DIM.bits() | Self::BOLD.bits();
-        const ALL_BLINK         = Self::SLOW_BLINK.bits() | Self::RAPID_BLINK.bits();
     }
 }
 

--- a/rio-vt/src/crosswords/style.rs
+++ b/rio-vt/src/crosswords/style.rs
@@ -33,7 +33,7 @@ bitflags! {
         const DIM              = 1 << 3;
         const HIDDEN           = 1 << 4;
         const STRIKEOUT        = 1 << 5;
-        // 3-bit underline kind packed into bits 6-8.
+        // One-hot underline kind in bits 6-10; at most one is set.
         const UNDERLINE        = 1 << 6;
         const DOUBLE_UNDERLINE = 1 << 7;
         const UNDERCURL        = 1 << 8;

--- a/rio-vt/src/crosswords/style.rs
+++ b/rio-vt/src/crosswords/style.rs
@@ -52,6 +52,38 @@ bitflags! {
     }
 }
 
+/// The five one-hot underline kinds behind `StyleFlags` bits 6-10.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnderlineKind {
+    Single,
+    Double,
+    Curly,
+    Dotted,
+    Dashed,
+}
+
+impl StyleFlags {
+    /// The underline kind these flags carry, or `None` without one. The
+    /// kind bits are one-hot (the parser clears `ALL_UNDERLINES` before
+    /// setting one); the priority order here settles any corrupt state.
+    #[inline]
+    pub fn underline_kind(self) -> Option<UnderlineKind> {
+        if self.contains(StyleFlags::UNDERLINE) {
+            Some(UnderlineKind::Single)
+        } else if self.contains(StyleFlags::DOUBLE_UNDERLINE) {
+            Some(UnderlineKind::Double)
+        } else if self.contains(StyleFlags::UNDERCURL) {
+            Some(UnderlineKind::Curly)
+        } else if self.contains(StyleFlags::DOTTED_UNDERLINE) {
+            Some(UnderlineKind::Dotted)
+        } else if self.contains(StyleFlags::DASHED_UNDERLINE) {
+            Some(UnderlineKind::Dashed)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Style {
     pub fg: AnsiColor,

--- a/rio-vt/src/crosswords/style.rs
+++ b/rio-vt/src/crosswords/style.rs
@@ -39,6 +39,8 @@ bitflags! {
         const UNDERCURL        = 1 << 8;
         const DOTTED_UNDERLINE = 1 << 9;
         const DASHED_UNDERLINE = 1 << 10;
+        const SLOW_BLINK        = 1 << 11;
+        const RAPID_BLINK       = 1 << 12;
         const ALL_UNDERLINES   = Self::UNDERLINE.bits()
                                | Self::DOUBLE_UNDERLINE.bits()
                                | Self::UNDERCURL.bits()
@@ -46,6 +48,7 @@ bitflags! {
                                | Self::DASHED_UNDERLINE.bits();
         // Combined intensity for shaping decisions.
         const DIM_BOLD         = Self::DIM.bits() | Self::BOLD.bits();
+        const ALL_BLINK         = Self::SLOW_BLINK.bits() | Self::RAPID_BLINK.bits();
     }
 }
 

--- a/rio-vt/src/crosswords/style.rs
+++ b/rio-vt/src/crosswords/style.rs
@@ -62,10 +62,34 @@ pub enum UnderlineKind {
     Dashed,
 }
 
+impl UnderlineKind {
+    /// The one-hot `StyleFlags` bit for this kind.
+    #[inline]
+    pub fn flag(self) -> StyleFlags {
+        match self {
+            UnderlineKind::Single => StyleFlags::UNDERLINE,
+            UnderlineKind::Double => StyleFlags::DOUBLE_UNDERLINE,
+            UnderlineKind::Curly => StyleFlags::UNDERCURL,
+            UnderlineKind::Dotted => StyleFlags::DOTTED_UNDERLINE,
+            UnderlineKind::Dashed => StyleFlags::DASHED_UNDERLINE,
+        }
+    }
+}
+
 impl StyleFlags {
+    /// Replace the underline kind (`None` removes it), keeping the kind
+    /// bits one-hot. The write side of `underline_kind`.
+    #[inline]
+    pub fn set_underline(&mut self, kind: Option<UnderlineKind>) {
+        self.remove(StyleFlags::ALL_UNDERLINES);
+        if let Some(kind) = kind {
+            self.insert(kind.flag());
+        }
+    }
+
     /// The underline kind these flags carry, or `None` without one. The
-    /// kind bits are one-hot (the parser clears `ALL_UNDERLINES` before
-    /// setting one); the priority order here settles any corrupt state.
+    /// kind bits are one-hot (`set_underline` keeps them so); the
+    /// priority order here settles any corrupt state.
     #[inline]
     pub fn underline_kind(self) -> Option<UnderlineKind> {
         if self.contains(StyleFlags::UNDERLINE) {


### PR DESCRIPTION
Fixes #1910.

## Summary

- add `StyleFlags::SLOW_BLINK` / `RAPID_BLINK` (bits 11/12 of the existing `u16`, plus an `ALL_BLINK` convenience mask)
- handle `Attr::BlinkSlow`, `Attr::BlinkFast`, and `Attr::CancelBlink` in `Crosswords::terminal_attribute` instead of logging them as unhandled, mirroring the underline-kind pattern (each blink kind clears the other; SGR 25 clears both)
- add a test covering the pending SGR state for all three attributes and that the flags survive interning into the style table when a glyph is written

This only records the attribute in the style table; presentation stays entirely up to the renderer, so Rio itself can keep ignoring blink if desired while VT-engine embedders gain access to it.

## Testing

- `cargo test -p rio-vt --lib` (529 passed)
- `cargo clippy -p rio-vt --all-targets`
- `cargo fmt -p rio-vt -- --check`
- exercised downstream in a Ratatui-based embedder: SGR 5/6 now reach the renderer and animate, SGR 25 stops them
