### PR TITLE
navigation: window buttons, window drag and wheel tab switching on Linux and Windows

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -1369,6 +1369,36 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                                 );
 
                             if handled_by_island {
+                                use crate::renderer::island::WindowButton;
+                                match route.window.screen.take_window_button_action() {
+                                    Some(WindowButton::Minimize) => {
+                                        route.window.winit_window.set_minimized(true);
+                                    }
+                                    Some(WindowButton::Maximize) => {
+                                        let maximized =
+                                            route.window.winit_window.is_maximized();
+                                        route
+                                            .window
+                                            .winit_window
+                                            .set_maximized(!maximized);
+                                    }
+                                    Some(WindowButton::Close) => {
+                                        // Same contract as `CloseRequested` from
+                                        // the window system: confirm when the
+                                        // config asks for it, else drop the
+                                        // window and exit once none remain.
+                                        if self.config.confirm_before_quit {
+                                            route.confirm_quit();
+                                            return;
+                                        }
+                                        self.router.routes.remove(&window_id);
+                                        if self.router.routes.is_empty() {
+                                            event_loop.exit();
+                                        }
+                                        return;
+                                    }
+                                    None => {}
+                                }
                                 route.request_redraw();
                                 return;
                             }
@@ -1930,6 +1960,23 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                 if self.config.hide_cursor_when_typing {
                     route.window.winit_window.set_cursor_visible(true);
+                }
+
+                // `navigation.scroll-tabs`: a wheel over the strip flips
+                // tabs instead of scrolling the terminal underneath.
+                {
+                    use crate::renderer::island::WHEEL_PX_PER_TAB;
+                    let delta_lines = match delta {
+                        MouseScrollDelta::LineDelta(_, lines) => lines,
+                        MouseScrollDelta::PixelDelta(p) => {
+                            let scale = route.window.screen.sugarloaf.scale_factor();
+                            p.y as f32 / scale / WHEEL_PX_PER_TAB
+                        }
+                    };
+                    if route.window.screen.scroll_tabs_over_strip(delta_lines) {
+                        route.request_redraw();
+                        return;
+                    }
                 }
 
                 match delta {

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -75,6 +75,145 @@ const CLOSE_ALPHA_HOVER: f32 = 0.95;
 const CLOSE_STROKE_WIDTH: f32 = 1.2;
 const INACTIVE_CUSTOM_MUTE: f32 = 0.55;
 
+/// Window buttons (minimize / maximize / close) drawn at the right end of
+/// the strip when `navigation.window-buttons` is on (Linux and Windows).
+/// Sized like the buttons of a typical desktop title bar so the strip can
+/// stand in for one under `window.decorations = "Disabled"`.
+const WINDOW_BUTTON_WIDTH: f32 = 36.0;
+const WINDOW_BUTTON_COUNT: usize = 3;
+const WINDOW_BUTTON_MARGIN_RIGHT: f32 = 4.0;
+const WINDOW_BUTTON_GLYPH_HALF: f32 = 4.5;
+const WINDOW_BUTTON_HOVER_INSET_X: f32 = 3.0;
+const WINDOW_BUTTON_HOVER_INSET_Y: f32 = 5.0;
+const WINDOW_BUTTON_HOVER_RADIUS: f32 = 5.0;
+const WINDOW_BUTTON_ALPHA_IDLE: f32 = 0.7;
+const WINDOW_BUTTON_ALPHA_HOVER: f32 = 1.0;
+const WINDOW_BUTTON_STROKE_WIDTH: f32 = 1.2;
+/// Close hovers red on every desktop that draws its own buttons.
+const WINDOW_BUTTON_CLOSE_HOVER: [f32; 4] = [0.91, 0.07, 0.14, 1.0];
+const WINDOW_BUTTON_CLOSE_HOVER_GLYPH: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+/// `navigation.scroll-tabs`: logical pixels of touchpad travel per tab.
+pub const WHEEL_PX_PER_TAB: f32 = 40.0;
+
+/// One of the strip's window buttons, left to right.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowButton {
+    Minimize,
+    Maximize,
+    Close,
+}
+
+impl WindowButton {
+    const ALL: [WindowButton; WINDOW_BUTTON_COUNT] = [
+        WindowButton::Minimize,
+        WindowButton::Maximize,
+        WindowButton::Close,
+    ];
+}
+
+/// Logical width the window buttons take away from the tab slots.
+#[inline]
+pub fn window_buttons_width(enabled: bool) -> f32 {
+    if enabled {
+        WINDOW_BUTTON_WIDTH * WINDOW_BUTTON_COUNT as f32 + WINDOW_BUTTON_MARGIN_RIGHT
+    } else {
+        0.0
+    }
+}
+
+/// Left edge (logical px) of the first window button.
+#[inline]
+fn window_buttons_x(window_width: f32, scale_factor: f32) -> f32 {
+    (window_width / scale_factor)
+        - WINDOW_BUTTON_MARGIN_RIGHT
+        - WINDOW_BUTTON_WIDTH * WINDOW_BUTTON_COUNT as f32
+}
+
+/// Which window button, if any, sits under `x_unscaled` (logical px). The
+/// caller has already established the pointer is inside the strip band.
+#[inline]
+pub fn window_button_hit(
+    enabled: bool,
+    window_width: f32,
+    scale_factor: f32,
+    x_unscaled: f32,
+) -> Option<WindowButton> {
+    if !enabled {
+        return None;
+    }
+    let x0 = window_buttons_x(window_width, scale_factor);
+    if x_unscaled < x0 {
+        return None;
+    }
+    let index = ((x_unscaled - x0) / WINDOW_BUTTON_WIDTH) as usize;
+    WindowButton::ALL.get(index).copied()
+}
+
+fn draw_window_buttons(
+    sugarloaf: &mut Sugarloaf,
+    window_width: f32,
+    scale_factor: f32,
+    fills: &IslandFills,
+    color: [f32; 4],
+    hover: Option<WindowButton>,
+) {
+    let x0 = window_buttons_x(window_width, scale_factor);
+    let cy = ISLAND_HEIGHT / 2.0;
+    let r = WINDOW_BUTTON_GLYPH_HALF;
+    let w = WINDOW_BUTTON_STROKE_WIDTH;
+
+    for (i, button) in WindowButton::ALL.iter().enumerate() {
+        let bx = x0 + i as f32 * WINDOW_BUTTON_WIDTH;
+        let cx = bx + WINDOW_BUTTON_WIDTH / 2.0;
+        let hovered = hover == Some(*button);
+
+        let mut glyph = color;
+        glyph[3] *= if hovered {
+            WINDOW_BUTTON_ALPHA_HOVER
+        } else {
+            WINDOW_BUTTON_ALPHA_IDLE
+        };
+
+        if hovered {
+            let backdrop = if *button == WindowButton::Close {
+                glyph = WINDOW_BUTTON_CLOSE_HOVER_GLYPH;
+                WINDOW_BUTTON_CLOSE_HOVER
+            } else {
+                fills.close_hover
+            };
+            sugarloaf.rounded_rect(
+                None,
+                bx + WINDOW_BUTTON_HOVER_INSET_X,
+                WINDOW_BUTTON_HOVER_INSET_Y,
+                WINDOW_BUTTON_WIDTH - WINDOW_BUTTON_HOVER_INSET_X * 2.0,
+                ISLAND_HEIGHT - WINDOW_BUTTON_HOVER_INSET_Y * 2.0,
+                backdrop,
+                0.05,
+                WINDOW_BUTTON_HOVER_RADIUS,
+                1,
+            );
+        }
+
+        match button {
+            WindowButton::Minimize => {
+                sugarloaf.line(cx - r, cy, cx + r, cy, w, 0.0, glyph, 2);
+            }
+            WindowButton::Maximize => {
+                // Square outline: four strokes, corners overlapping.
+                let (l, t, rt, b) = (cx - r, cy - r, cx + r, cy + r);
+                sugarloaf.line(l, t, rt, t, w, 0.0, glyph, 2);
+                sugarloaf.line(rt, t, rt, b, w, 0.0, glyph, 2);
+                sugarloaf.line(rt, b, l, b, w, 0.0, glyph, 2);
+                sugarloaf.line(l, b, l, t, w, 0.0, glyph, 2);
+            }
+            WindowButton::Close => {
+                sugarloaf.line(cx - r, cy - r, cx + r, cy + r, w, 0.0, glyph, 2);
+                sugarloaf.line(cx - r, cy + r, cx + r, cy - r, w, 0.0, glyph, 2);
+            }
+        }
+    }
+}
+
 struct TabDrag {
     // Index of the dragged tab, follows the tab as it reorders.
     tab_index: usize,
@@ -136,19 +275,24 @@ pub struct TabStripLayout {
 
 /// Compute the tab strip layout from the physical window width.
 /// `max_tab_width` comes from `navigation.max-tab-width` (logical px).
+/// `reserved_right` is logical width kept free at the right end of the
+/// strip (the window buttons, see [`window_buttons_width`]).
 pub fn tab_strip_layout(
     window_width: f32,
     scale_factor: f32,
     num_tabs: usize,
     max_tab_width: f32,
+    reserved_right: f32,
 ) -> TabStripLayout {
     #[cfg(target_os = "macos")]
     let left_margin = ISLAND_MARGIN_LEFT_MACOS;
     #[cfg(not(target_os = "macos"))]
     let left_margin = 0.0;
 
-    let available_width =
-        (window_width / scale_factor) - ISLAND_MARGIN_RIGHT - left_margin;
+    let available_width = (window_width / scale_factor)
+        - ISLAND_MARGIN_RIGHT
+        - left_margin
+        - reserved_right.max(0.0);
     let tab_width =
         (available_width / num_tabs.max(1) as f32).clamp(0.0, max_tab_width.max(0.0));
     TabStripLayout {
@@ -248,10 +392,16 @@ fn island_rect(slot_x: f32, tab_width: f32) -> (f32, f32, f32, f32, f32) {
 /// `window_width` is physical, as `render` receives it, while everything
 /// drawn is logical, the same conversion `tab_strip_layout` makes.
 #[inline]
-fn single_title_budget(window_width: f32, scale_factor: f32, left_margin: f32) -> f32 {
+fn single_title_budget(
+    window_width: f32,
+    scale_factor: f32,
+    left_margin: f32,
+    reserved_right: f32,
+) -> f32 {
     ((window_width / scale_factor)
         - left_margin
         - ISLAND_MARGIN_RIGHT
+        - reserved_right.max(0.0)
         - TAB_PADDING_X * 2.0)
         .max(0.0)
 }
@@ -265,8 +415,16 @@ fn single_title_x(
     scale_factor: f32,
     text_width: f32,
     left_margin: f32,
+    reserved_right: f32,
 ) -> f32 {
-    (((window_width / scale_factor) - text_width) / 2.0).max(left_margin + TAB_PADDING_X)
+    let strip_width = window_width / scale_factor;
+    // Centre on the strip, but stop short of the window buttons on the
+    // right; the left clamp wins when both cannot be satisfied.
+    let right_limit =
+        strip_width - reserved_right.max(0.0) - ISLAND_MARGIN_RIGHT - TAB_PADDING_X;
+    ((strip_width - text_width) / 2.0)
+        .min(right_limit - text_width)
+        .max(left_margin + TAB_PADDING_X)
 }
 
 #[inline]
@@ -367,6 +525,11 @@ pub struct Island {
     /// Cursor is over the active island's close button — draws the
     /// hover backdrop. Updated on every cursor move by `Screen`.
     close_hover: bool,
+    /// Draw window buttons at the right end of the strip
+    /// (`navigation.window-buttons`, Linux and Windows only).
+    window_buttons: bool,
+    /// Which window button the cursor is over, for the hover backdrop.
+    window_button_hover: Option<WindowButton>,
 }
 
 impl Island {
@@ -375,6 +538,7 @@ impl Island {
         active_text_color: [f32; 4],
         hide_if_single: bool,
         max_tab_width: f32,
+        window_buttons: bool,
     ) -> Self {
         Self {
             hide_if_single,
@@ -396,7 +560,34 @@ impl Island {
             slide_springs: FxHashMap::default(),
             last_anim_frame: Instant::now(),
             close_hover: false,
+            window_buttons,
+            window_button_hover: None,
         }
+    }
+
+    /// Logical width reserved at the right end of the strip.
+    #[inline]
+    pub fn reserved_right(&self) -> f32 {
+        window_buttons_width(self.window_buttons)
+    }
+
+    /// Window button under `x_unscaled`, if the strip draws them.
+    #[inline]
+    pub fn window_button_at(
+        &self,
+        window_width: f32,
+        scale_factor: f32,
+        x_unscaled: f32,
+    ) -> Option<WindowButton> {
+        window_button_hit(self.window_buttons, window_width, scale_factor, x_unscaled)
+    }
+
+    /// Set which window button the cursor hovers. Returns true when the
+    /// state changed (the caller redraws).
+    pub fn set_window_button_hover(&mut self, hover: Option<WindowButton>) -> bool {
+        let changed = self.window_button_hover != hover;
+        self.window_button_hover = hover;
+        changed
     }
 
     /// Set whether the cursor hovers the active island's close button.
@@ -785,8 +976,14 @@ impl Island {
         self.slide_springs
             .retain(|_, s| s.update(dt, DRAG_ANIMATION_LENGTH));
 
-        let layout =
-            tab_strip_layout(window_width, scale_factor, num_tabs, self.max_tab_width);
+        let reserved_right = self.reserved_right();
+        let layout = tab_strip_layout(
+            window_width,
+            scale_factor,
+            num_tabs,
+            self.max_tab_width,
+            reserved_right,
+        );
         let TabStripLayout {
             left_margin,
             tab_width,
@@ -840,7 +1037,12 @@ impl Island {
             let single = num_tabs == 1;
 
             let max_text_width = if single {
-                single_title_budget(window_width, scale_factor, left_margin)
+                single_title_budget(
+                    window_width,
+                    scale_factor,
+                    left_margin,
+                    reserved_right,
+                )
             } else {
                 (tab_width - TAB_PADDING_X * 2.0).max(0.0)
             };
@@ -882,7 +1084,13 @@ impl Island {
                 let ui = sugarloaf.text_mut();
                 let text_width = ui.measure(&title, &title_opts);
                 let text_x = if single {
-                    single_title_x(window_width, scale_factor, text_width, left_margin)
+                    single_title_x(
+                        window_width,
+                        scale_factor,
+                        text_width,
+                        left_margin,
+                        reserved_right,
+                    )
                 } else {
                     tab_x + (tab_width - text_width) / 2.0
                 };
@@ -1032,6 +1240,19 @@ impl Island {
             }
         }
 
+        // Window buttons sit on the strip itself, to the right of every
+        // tab slot, so a floating (dragged) tab never covers them.
+        if self.window_buttons {
+            draw_window_buttons(
+                sugarloaf,
+                window_width,
+                scale_factor,
+                &fills,
+                self.active_text_color,
+                self.window_button_hover,
+            );
+        }
+
         // Render the progress bar below the island
         self.render_progress_bar(sugarloaf, window_width, scale_factor, ISLAND_HEIGHT);
     }
@@ -1153,7 +1374,13 @@ impl Island {
             left_margin,
             tab_width,
             ..
-        } = tab_strip_layout(window_width, scale_factor, num_tabs, self.max_tab_width);
+        } = tab_strip_layout(
+            window_width,
+            scale_factor,
+            num_tabs,
+            self.max_tab_width,
+            self.reserved_right(),
+        );
         let tab_x = left_margin + picker_tab as f32 * tab_width;
 
         // Picker is rendered just below the island
@@ -1475,19 +1702,19 @@ mod tests {
         // 1600 physical at 2x is an 800pt strip, so a 100pt title starts at
         // 350, not at 750 (which would be centred on the physical width and
         // sit past the right edge).
-        let x = single_title_x(1600.0, 2.0, 100.0, 0.0);
+        let x = single_title_x(1600.0, 2.0, 100.0, 0.0, 0.0);
         assert_eq!(x, 350.0);
         assert!(x + 100.0 <= 800.0, "title must stay on screen: {x}");
 
         // At 1x the two agree, which is why this only showed up on retina.
-        assert_eq!(single_title_x(800.0, 1.0, 100.0, 0.0), 350.0);
+        assert_eq!(single_title_x(800.0, 1.0, 100.0, 0.0, 0.0), 350.0);
     }
 
     #[test]
     fn single_title_never_reaches_under_the_traffic_lights() {
         let margin = 76.0;
         // A title wider than the strip would centre at a negative x.
-        let x = single_title_x(1600.0, 2.0, 900.0, margin);
+        let x = single_title_x(1600.0, 2.0, 900.0, margin, 0.0);
         assert_eq!(x, margin + TAB_PADDING_X);
     }
 
@@ -1496,27 +1723,27 @@ mod tests {
         // 800pt strip, no left margin: full width less the right margin and
         // the padding on each side.
         assert_eq!(
-            single_title_budget(1600.0, 2.0, 0.0),
+            single_title_budget(1600.0, 2.0, 0.0, 0.0),
             800.0 - ISLAND_MARGIN_RIGHT - TAB_PADDING_X * 2.0
         );
         // The macOS left margin comes off the top of that.
         assert_eq!(
-            single_title_budget(1600.0, 2.0, 76.0),
+            single_title_budget(1600.0, 2.0, 76.0, 0.0),
             800.0 - 76.0 - ISLAND_MARGIN_RIGHT - TAB_PADDING_X * 2.0
         );
         // A window too narrow to hold any text yields no budget, not a
         // negative one that would underflow the truncation.
-        assert_eq!(single_title_budget(100.0, 2.0, 76.0), 0.0);
+        assert_eq!(single_title_budget(100.0, 2.0, 76.0, 0.0), 0.0);
     }
 
     /// A lone title gets far more room than a tab slot would give it, which
     /// is the point of dropping the island.
     #[test]
     fn single_title_budget_beats_a_tab_slot() {
-        let slot = tab_strip_layout(1600.0, 2.0, 1, 240.0).tab_width;
+        let slot = tab_strip_layout(1600.0, 2.0, 1, 240.0, 0.0).tab_width;
         let slot_budget = (slot - TAB_PADDING_X * 2.0).max(0.0);
         assert!(
-            single_title_budget(1600.0, 2.0, 0.0) > slot_budget,
+            single_title_budget(1600.0, 2.0, 0.0, 0.0) > slot_budget,
             "expected more than a slot's {slot_budget}"
         );
     }
@@ -1580,7 +1807,7 @@ mod tests {
         let inactive_color = [0.5, 0.5, 0.5, 1.0];
         let active_color = [0.9, 0.9, 0.9, 1.0];
 
-        let island = Island::new(inactive_color, active_color, true, 240.0);
+        let island = Island::new(inactive_color, active_color, true, 240.0, false);
 
         assert_eq!(island.inactive_text_color, inactive_color);
         assert_eq!(island.active_text_color, active_color);
@@ -1589,13 +1816,24 @@ mod tests {
 
     #[test]
     fn test_island_height() {
-        let island =
-            Island::new([0.8, 0.8, 0.8, 1.0], [1.0, 1.0, 1.0, 1.0], false, 240.0);
+        let island = Island::new(
+            [0.8, 0.8, 0.8, 1.0],
+            [1.0, 1.0, 1.0, 1.0],
+            false,
+            240.0,
+            false,
+        );
         assert_eq!(island.height(), ISLAND_HEIGHT);
     }
 
     fn test_island() -> Island {
-        Island::new([0.5, 0.5, 0.5, 1.0], [0.9, 0.9, 0.9, 1.0], false, 240.0)
+        Island::new(
+            [0.5, 0.5, 0.5, 1.0],
+            [0.9, 0.9, 0.9, 1.0],
+            false,
+            240.0,
+            false,
+        )
     }
 
     #[test]
@@ -1791,7 +2029,7 @@ mod tests {
         // 1000 physical px @ 2x scale → 500 logical px window. Slots
         // stay below the cap here, so the math matches the old
         // fill-the-strip layout.
-        let layout = tab_strip_layout(1000.0, 2.0, 4, 240.0);
+        let layout = tab_strip_layout(1000.0, 2.0, 4, 240.0, 0.0);
         #[cfg(target_os = "macos")]
         {
             assert_eq!(layout.left_margin, ISLAND_MARGIN_LEFT_MACOS);
@@ -1805,19 +2043,81 @@ mod tests {
             assert_eq!(layout.tabs_width, 492.0);
         }
         // Zero tabs clamps the divisor.
-        assert!(tab_strip_layout(1000.0, 2.0, 0, 240.0)
+        assert!(tab_strip_layout(1000.0, 2.0, 0, 240.0, 0.0)
             .tab_width
             .is_finite());
     }
 
     #[test]
+    fn tab_strip_layout_reserves_window_buttons() {
+        // 500 logical px strip, 4 tabs: reserving the window buttons
+        // shrinks every slot by the same share.
+        let plain = tab_strip_layout(1000.0, 2.0, 4, 240.0, 0.0);
+        let reserved = window_buttons_width(true);
+        let with_buttons = tab_strip_layout(1000.0, 2.0, 4, 240.0, reserved);
+        assert_eq!(with_buttons.tab_width, plain.tab_width - reserved / 4.0);
+        // The tab region ends before the buttons start.
+        assert!(
+            with_buttons.left_margin + with_buttons.tabs_width
+                <= window_buttons_x(1000.0, 2.0)
+        );
+        // Disabled buttons reserve nothing.
+        assert_eq!(window_buttons_width(false), 0.0);
+        // A negative reservation is treated as none.
+        assert_eq!(
+            tab_strip_layout(1000.0, 2.0, 4, 240.0, -50.0).tab_width,
+            plain.tab_width
+        );
+    }
+
+    #[test]
+    fn window_button_hit_maps_thirds_left_to_right() {
+        // 1000 physical @ 2x → 500 logical. Buttons occupy the last
+        // 3 * 36 + 4 = 112 logical px: [388, 424) [424, 460) [460, 496).
+        let x0 = window_buttons_x(1000.0, 2.0);
+        assert_eq!(x0, 500.0 - window_buttons_width(true));
+        let hit = |x| window_button_hit(true, 1000.0, 2.0, x);
+        assert_eq!(hit(x0 - 1.0), None);
+        assert_eq!(hit(x0 + 1.0), Some(WindowButton::Minimize));
+        assert_eq!(
+            hit(x0 + WINDOW_BUTTON_WIDTH + 1.0),
+            Some(WindowButton::Maximize)
+        );
+        assert_eq!(
+            hit(x0 + WINDOW_BUTTON_WIDTH * 2.0 + 1.0),
+            Some(WindowButton::Close)
+        );
+        // Past the last button (the right margin) is not a hit.
+        assert_eq!(hit(x0 + WINDOW_BUTTON_WIDTH * 3.0 + 1.0), None);
+        // Disabled buttons never hit.
+        assert_eq!(window_button_hit(false, 1000.0, 2.0, x0 + 1.0), None);
+    }
+
+    #[test]
+    fn single_title_stays_clear_of_window_buttons() {
+        // Wide title on a strip with buttons: its right edge must end
+        // before the buttons start, even though centring would overlap.
+        let reserved = window_buttons_width(true);
+        // Wider than centring allows, narrower than the budget (so the
+        // left clamp does not take over as it would for an oversized title).
+        let text_width = 300.0;
+        let x = single_title_x(1000.0, 2.0, text_width, 0.0, reserved);
+        assert!(x + text_width <= window_buttons_x(1000.0, 2.0) - TAB_PADDING_X);
+        // And the budget shrinks by the reservation.
+        assert_eq!(
+            single_title_budget(1000.0, 2.0, 0.0, reserved),
+            single_title_budget(1000.0, 2.0, 0.0, 0.0) - reserved
+        );
+    }
+
+    #[test]
     fn tab_strip_layout_caps_slot_width() {
-        let layout = tab_strip_layout(3000.0, 2.0, 2, 240.0);
+        let layout = tab_strip_layout(3000.0, 2.0, 2, 240.0, 0.0);
         assert_eq!(layout.tab_width, 240.0);
         assert_eq!(layout.tabs_width, 480.0);
 
         // The cap is configurable via navigation.max-tab-width.
-        let layout = tab_strip_layout(3000.0, 2.0, 2, 280.0);
+        let layout = tab_strip_layout(3000.0, 2.0, 2, 280.0, 0.0);
         assert_eq!(layout.tab_width, 280.0);
         assert_eq!(layout.tabs_width, 560.0);
         // The tabs region ends well before the 1500 logical px strip.
@@ -1825,7 +2125,7 @@ mod tests {
 
         // Pathologically narrow window: width clamps at 0 instead of
         // going negative.
-        let layout = tab_strip_layout(10.0, 2.0, 4, 240.0);
+        let layout = tab_strip_layout(10.0, 2.0, 4, 240.0, 0.0);
         assert_eq!(layout.tab_width, 0.0);
         assert_eq!(layout.tabs_width, 0.0);
     }

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -225,6 +225,7 @@ impl Renderer {
                 named_colors.tabs_active,
                 config.navigation.hide_if_single,
                 config.navigation.max_tab_width,
+                config.navigation.draws_window_buttons(),
             ))
         } else {
             None

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -93,6 +93,13 @@ pub struct Screen<'screen> {
     pub allow_manual_dragging: bool,
     last_chrome_press: Option<ChromePress>,
     last_close_press: Option<(std::time::Instant, f32)>,
+    /// Window button pressed on the tab strip. Consumed by the
+    /// application loop, which owns the router and event loop a close
+    /// needs (`navigation.window-buttons`).
+    pending_window_button: Option<island::WindowButton>,
+    /// Wheel travel over the tab strip, in tab steps
+    /// (`navigation.scroll-tabs`).
+    tab_scroll_accum: f32,
     pub grids: rustc_hash::FxHashMap<usize, rio_backend::sugarloaf::grid::GridRenderer>,
     pub grid_rasterizer: rio_grid::GridGlyphRasterizer,
 }
@@ -345,6 +352,8 @@ impl Screen<'_> {
             allow_manual_dragging: config.navigation.is_enabled(),
             last_chrome_press: None,
             last_close_press: None,
+            pending_window_button: None,
+            tab_scroll_accum: 0.0,
             grids: rustc_hash::FxHashMap::default(),
             grid_rasterizer: rio_grid::GridGlyphRasterizer::new(),
         })
@@ -2735,21 +2744,29 @@ impl Screen<'_> {
 
     #[inline]
     fn island_tab_layout(&self, num_tabs: usize) -> TabStripLayout {
-        let max_tab_width = self
+        let (max_tab_width, reserved_right) = self
             .renderer
             .island
             .as_ref()
-            .map(|island| island.max_tab_width)
-            .unwrap_or_else(rio_backend::config::navigation::default_max_tab_width);
+            .map(|island| (island.max_tab_width, island.reserved_right()))
+            .unwrap_or_else(|| {
+                (
+                    rio_backend::config::navigation::default_max_tab_width(),
+                    0.0,
+                )
+            });
         island::tab_strip_layout(
             self.sugarloaf.window_size().width,
             self.sugarloaf.scale_factor(),
             num_tabs,
             max_tab_width,
+            reserved_right,
         )
     }
 
-    #[cfg(target_os = "macos")]
+    /// Hand the press to the window system as a move. The button state is
+    /// released first: on Wayland (and macOS) the compositor takes over the
+    /// pointer and the matching release never reaches us.
     pub fn start_window_drag(&mut self, window: &rio_window::window::Window) {
         self.mouse.left_button_state = ElementState::Released;
         let _ = window.drag_window();
@@ -2773,10 +2790,66 @@ impl Screen<'_> {
             window_origin,
             at: std::time::Instant::now(),
         });
-        #[cfg(target_os = "macos")]
-        if self.allow_manual_dragging {
+        if self.renderer.navigation.allows_window_drag() {
             self.start_window_drag(window);
         }
+    }
+
+    /// The window button pressed by the last strip click, if any.
+    #[inline]
+    pub fn take_window_button_action(&mut self) -> Option<island::WindowButton> {
+        self.pending_window_button.take()
+    }
+
+    /// `navigation.scroll-tabs`: wheel travel over the visible strip
+    /// switches tabs. `delta` is in lines (one notch = one line); pixel
+    /// deltas are converted by the caller. Returns true when consumed.
+    pub fn scroll_tabs_over_strip(&mut self, delta_lines: f32) -> bool {
+        let num_tabs = self.context_manager.len();
+        if !self.renderer.navigation.scroll_tabs
+            || !self.renderer.navigation.island_visible(num_tabs)
+        {
+            self.tab_scroll_accum = 0.0;
+            return false;
+        }
+        let scale_factor = self.sugarloaf.scale_factor();
+        if self.mouse.y > (ISLAND_HEIGHT * scale_factor) as f64 {
+            self.tab_scroll_accum = 0.0;
+            return false;
+        }
+        if num_tabs < 2 {
+            return true;
+        }
+
+        self.tab_scroll_accum += delta_lines;
+        let mut switched = false;
+        while self.tab_scroll_accum >= 1.0 {
+            self.tab_scroll_accum -= 1.0;
+            self.switch_tab_by_wheel(false);
+            switched = true;
+        }
+        while self.tab_scroll_accum <= -1.0 {
+            self.tab_scroll_accum += 1.0;
+            self.switch_tab_by_wheel(true);
+            switched = true;
+        }
+        if switched {
+            self.mark_dirty();
+        }
+        true
+    }
+
+    fn switch_tab_by_wheel(&mut self, next: bool) {
+        self.clear_selection();
+        let old = self.context_manager.current_index();
+        if next {
+            self.context_manager.switch_to_next();
+        } else {
+            self.context_manager.switch_to_prev();
+        }
+        let new = self.context_manager.current_index();
+        self.context_manager
+            .switch_context_visibility(&mut self.sugarloaf, old, new);
     }
 
     #[inline]
@@ -2807,22 +2880,52 @@ impl Screen<'_> {
     pub fn update_close_button_hover(&mut self, mouse_x: f64, mouse_y: f64) -> bool {
         let num_tabs = self.context_manager.len();
         let scale_factor = self.sugarloaf.scale_factor();
+        let island_visible = self.renderer.navigation.island_visible(num_tabs);
+        let in_band = mouse_y <= (ISLAND_HEIGHT * scale_factor) as f64;
+        let x_unscaled = mouse_x as f32 / scale_factor;
 
         let hovering = num_tabs > 1
-            && self.renderer.navigation.island_visible(num_tabs)
-            && mouse_y <= (ISLAND_HEIGHT * scale_factor) as f64
+            && island_visible
+            && in_band
             && island::close_button_hit(
                 &self.island_tab_layout(num_tabs),
                 self.context_manager.current_index(),
-                mouse_x as f32 / scale_factor,
+                x_unscaled,
             );
 
-        self.apply_close_hover(hovering)
+        let window_button = if island_visible && in_band {
+            let window_width = self.sugarloaf.window_size().width;
+            self.renderer.island.as_ref().and_then(|island| {
+                island.window_button_at(window_width, scale_factor, x_unscaled)
+            })
+        } else {
+            None
+        };
+
+        // Evaluate both: `||` would skip the second update once the first
+        // reports a change.
+        let close_changed = self.apply_close_hover(hovering);
+        let button_changed = self.apply_window_button_hover(window_button);
+        close_changed || button_changed
+    }
+
+    fn apply_window_button_hover(&mut self, hover: Option<island::WindowButton>) -> bool {
+        let changed = self
+            .renderer
+            .island
+            .as_mut()
+            .is_some_and(|island| island.set_window_button_hover(hover));
+        if changed {
+            self.mark_dirty();
+        }
+        changed
     }
 
     #[inline]
     pub fn clear_close_button_hover(&mut self) -> bool {
-        self.apply_close_hover(false)
+        let close_changed = self.apply_close_hover(false);
+        let button_changed = self.apply_window_button_hover(None);
+        close_changed || button_changed
     }
 
     pub fn handle_island_click(
@@ -2905,6 +3008,18 @@ impl Screen<'_> {
             }
 
             return false;
+        }
+
+        // Window buttons come before the tab slots: they live past the
+        // last slot, where a press would otherwise start a window drag.
+        if let Some(button) = self.renderer.island.as_ref().and_then(|island| {
+            island.window_button_at(window_width, scale_factor, mouse_x_unscaled)
+        }) {
+            if !is_right_click {
+                self.stop_hint_mode_if_active();
+                self.pending_window_button = Some(button);
+            }
+            return true;
         }
 
         let layout = self.island_tab_layout(num_tabs);

--- a/rio-backend/src/config/navigation.rs
+++ b/rio-backend/src/config/navigation.rs
@@ -178,6 +178,20 @@ pub struct Navigation {
     /// when few are open. Clamped to `[80.0, 280.0]` at load time.
     #[serde(default = "default_max_tab_width", rename = "max-tab-width")]
     pub max_tab_width: f32,
+    /// Draw minimize / maximize / close buttons at the right end of the
+    /// tab strip. Intended for `window.decorations = "Disabled"` on Linux
+    /// and Windows, where the strip then acts as the window's title bar.
+    /// Ignored on macOS, which keeps the native traffic lights.
+    #[serde(default = "bool::default", rename = "window-buttons")]
+    pub window_buttons: bool,
+    /// Left-drag on an empty part of the tab strip moves the window
+    /// (Linux and Windows). macOS always allows this, so the option is
+    /// ignored there.
+    #[serde(default = "bool::default", rename = "drag-window")]
+    pub drag_window: bool,
+    /// Mouse wheel over the tab strip switches to the previous / next tab.
+    #[serde(default = "bool::default", rename = "scroll-tabs")]
+    pub scroll_tabs: bool,
 }
 
 impl Default for Navigation {
@@ -194,6 +208,9 @@ impl Default for Navigation {
             unfocused_split_fill: None,
             open_config_with_split: true,
             max_tab_width: default_max_tab_width(),
+            window_buttons: false,
+            drag_window: false,
+            scroll_tabs: false,
         }
     }
 }
@@ -245,6 +262,20 @@ impl Navigation {
         } else {
             self.island_visible(num_tabs)
         }
+    }
+
+    /// Whether the tab strip draws its own window buttons. Never on
+    /// macOS: the native traffic lights already occupy the strip.
+    #[inline]
+    pub fn draws_window_buttons(&self) -> bool {
+        !cfg!(target_os = "macos") && self.is_enabled() && self.window_buttons
+    }
+
+    /// Whether a left-drag on empty strip area may move the window.
+    /// Always on macOS (full-size content view); opt-in elsewhere.
+    #[inline]
+    pub fn allows_window_drag(&self) -> bool {
+        self.is_enabled() && (cfg!(target_os = "macos") || self.drag_window)
     }
 }
 


### PR DESCRIPTION

Closes #1916

## What

Under `window.decorations = "Disabled"` the rio-rendered tab strip is the only chrome a Linux or Windows window has, but outside macOS it offered none of a title bar's controls. This adds three opt-in `[navigation]` keys:

```toml
[window]
decorations = "Disabled"

[navigation]
window-buttons = true   # ⎯ ☐ ✕ at the right end of the strip
drag-window = true      # left-drag on empty strip area moves the window
scroll-tabs = true      # mouse wheel over the strip switches tabs
```

All three default to `false`. macOS ignores `window-buttons` (the traffic lights already occupy the strip) and keeps allowing the drag, exactly as before.

<img width="1386" height="894" alt="hero" src="https://github.com/user-attachments/assets/57330022-2d7f-4e05-a64a-4cee56c08a5d" />

## How

**`window-buttons`** (`renderer/island.rs`)
- New `WindowButton` enum and geometry helpers (`window_buttons_width`, `window_button_hit`). Buttons are 36 logical px each, anchored to the right edge — the same anchoring the tab close × uses.
- `tab_strip_layout` gains a `reserved_right` argument; slots and the lone-tab title budget / centring subtract it, so tabs shrink and a floating (dragged) tab never covers the buttons.
- Drawn with `sugarloaf.line` / `rounded_rect` like the existing close ×. Hover backdrop comes from `island_fills` so it adapts to light and dark backgrounds; close hovers red with a white glyph.
- Click routing (`screen/mod.rs::handle_island_click`): the button hit test runs before the tab-slot logic, because the buttons live past the last slot where a press would otherwise start a window drag. The pressed button is stored as `pending_window_button` and consumed in `application.rs`, which owns the router / event loop a close needs. Close follows the `CloseRequested` contract: `confirm_quit()` when `confirm-before-quit` is set, otherwise remove the route and exit once none remain.
- Hover is tracked next to the close-× hover in `update_close_button_hover` (both are evaluated so neither update is skipped).

**`drag-window`** (`screen/mod.rs`)
- `start_window_drag` loses its macOS cfg; `on_chrome_press` calls it when `navigation.allows_window_drag()` — always on macOS, opt-in elsewhere. `drag_window()` is winit's `xdg_toplevel.move` / `_NET_WM_MOVERESIZE` / `WM_NCLBUTTONDOWN`, so no platform code is added.
- Double-click → toggle maximize was already cross-platform and is unchanged.

**`scroll-tabs`** (`application.rs`, `screen/mod.rs`)
- `MouseWheel` over the visible strip goes to `Screen::scroll_tabs_over_strip` before terminal scrolling. Line deltas switch per notch; pixel deltas (touchpads) accumulate, one tab per `WHEEL_PX_PER_TAB` (40 logical px). Switching reuses the same `switch_to_next/prev` + `switch_context_visibility` sequence as the palette actions.

**Config** (`rio-backend/src/config/navigation.rs`)
- Three `bool` fields with serde defaults; `draws_window_buttons()` / `allows_window_drag()` encode the platform rules in one place.

## Tests

- `tab_strip_layout_reserves_window_buttons` — slots shrink by the reserved width, tab region ends before the buttons, negative reservation is ignored.
- `window_button_hit_maps_thirds_left_to_right` — hit test per button, right margin and disabled state.
- `single_title_stays_clear_of_window_buttons` — lone-tab title never runs under the buttons; budget shrinks by the reservation.
- Existing layout / title tests updated for the new argument.

Locally: `cargo fmt -- --check`, `cargo clippy --all-targets --all-features` (no warnings in touched files), `cargo test --features wgpu` (all green).

## Tested on

- Linux · Wayland (GNOME 50, Vulkan backend): buttons, hover, minimize / maximize / close, drag, double-click maximize, wheel switching, tab drag-reorder and close × unaffected, single-tab title clear of the buttons.
- Linux · X11 (XWayland): same as above.
- Windows: builds in CI (`msys2-build-test`, `windows-latest`); `drag_window()` / `set_minimized` / `set_maximized` are winit's existing Windows paths. Not hand-tested — happy to adjust if someone can try it.
- macOS: behaviour unchanged (`window-buttons` is a no-op, drag stays always-on); verified by reading the cfg paths, no hardware to test.

## Docs

Companion PR to rioterm.com: raphamorim/rioterm.com#3


https://github.com/user-attachments/assets/24a13019-b479-445a-815d-b79215c015b4

<img width="1386" height="894" alt="single-tab" src="https://github.com/user-attachments/assets/95ae5ee0-b424-4d33-8ee0-ab891a53074f" />

<img width="2792" height="912" alt="before-after" src="https://github.com/user-attachments/assets/426dcbd9-e71a-40fe-9bb4-5ea1e1d0ddf5" />
