### PR TITLE
fix: render IME preedit text inline instead of only in the candidate popup

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -2035,13 +2035,17 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         if route.window.screen.context_manager.current().ime.preedit()
                             != preedit.as_ref()
                         {
-                            route
-                                .window
-                                .screen
-                                .context_manager
-                                .current_mut()
-                                .ime
-                                .set_preedit(preedit);
+                            let ctx = route.window.screen.context_manager.current_mut();
+                            ctx.ime.set_preedit(preedit);
+                            // Preedit doesn't touch terminal cells, but it
+                            // does change what gets drawn (the composed
+                            // text overlay + cursor style) — without this,
+                            // `Renderer::run`'s per-context dirty gate
+                            // skips the panel entirely and the composing
+                            // text never reaches the screen. Same
+                            // "UI overlay changed" case as the command
+                            // palette / search bar (see `set_dirty` doc).
+                            ctx.renderable_content.pending_update.set_dirty();
                             route.request_redraw();
                         }
                     }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -4226,34 +4226,36 @@ impl Screen<'_> {
                 // cells, so it never generates PTY/UI damage and the
                 // gate above would otherwise never pick the cursor
                 // row up. Force it in directly: mark that row dirty
-                // while composing so `overlay_preedit_text` runs, and
-                // once more right after composing ends without a
-                // commit (e.g. Escape cancels it) so the overlay gets
-                // erased and the row falls back to its real terminal
-                // content.
+                // while composing so `overlay_preedit_text` runs.
                 let prev_preedit_row = preedit_rows.get(route_id).copied();
-                let force_preedit_row = if p.preedit_text.is_some() {
-                    preedit_rows.insert(*route_id, p.cursor_row);
-                    Some(p.cursor_row)
+                let current_preedit_row =
+                    p.preedit_text.is_some().then_some(p.cursor_row);
+                if let Some(row) = current_preedit_row {
+                    preedit_rows.insert(*route_id, row);
                 } else {
                     preedit_rows.remove(route_id);
-                    prev_preedit_row
-                };
-                let rows_to_rebuild = match (rows_to_rebuild, force_preedit_row) {
-                    (RowsToRebuild::None, Some(row)) => {
-                        if let Some(r) = p.visible_rows.get_mut(row as usize) {
-                            r.dirty = true;
-                        }
-                        RowsToRebuild::Dirty
+                }
+                // The row that carried last frame's overlay but isn't
+                // the current one — composing ended without a commit
+                // (e.g. Escape), or the cursor moved to a different
+                // row mid-composition. Force it in too, once, so the
+                // stale overlay left over from last frame's
+                // `overlay_preedit_text` doesn't linger on screen.
+                let stale_preedit_row =
+                    prev_preedit_row.filter(|&prev| Some(prev) != current_preedit_row);
+
+                let mut rows_to_rebuild = rows_to_rebuild;
+                for row in [current_preedit_row, stale_preedit_row]
+                    .into_iter()
+                    .flatten()
+                {
+                    if let Some(r) = p.visible_rows.get_mut(row as usize) {
+                        r.dirty = true;
                     }
-                    (mode, Some(row)) => {
-                        if let Some(r) = p.visible_rows.get_mut(row as usize) {
-                            r.dirty = true;
-                        }
-                        mode
+                    if matches!(rows_to_rebuild, RowsToRebuild::None) {
+                        rows_to_rebuild = RowsToRebuild::Dirty;
                     }
-                    (mode, None) => mode,
-                };
+                }
 
                 let cols = p.cols as usize;
                 let mut bg_scratch: Vec<rio_backend::sugarloaf::grid::CellBg> =

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -95,6 +95,15 @@ pub struct Screen<'screen> {
     last_close_press: Option<(std::time::Instant, f32)>,
     pub grids: rustc_hash::FxHashMap<usize, rio_backend::sugarloaf::grid::GridRenderer>,
     pub grid_rasterizer: rio_grid::GridGlyphRasterizer,
+    /// Per-route cursor row that currently carries a spliced-in IME
+    /// preedit overlay (see `overlay_preedit_text`). An IME-only
+    /// update never touches terminal damage, so the normal
+    /// `RowsToRebuild` gate (driven by PTY/UI damage) wouldn't pick
+    /// the row up on its own; this lets the render loop force that
+    /// one row through even on an otherwise-Noop frame, both while
+    /// composing and once more to erase the overlay when composing
+    /// ends without a commit (e.g. Escape).
+    preedit_row: rustc_hash::FxHashMap<usize, u16>,
 }
 
 pub struct ChromePress {
@@ -347,6 +356,7 @@ impl Screen<'_> {
             last_close_press: None,
             grids: rustc_hash::FxHashMap::default(),
             grid_rasterizer: rio_grid::GridGlyphRasterizer::new(),
+            preedit_row: rustc_hash::FxHashMap::default(),
         })
     }
 
@@ -3965,6 +3975,12 @@ impl Screen<'_> {
                 /// configured shape so the user can tell IME is
                 /// taking input.
                 cursor_preedit: bool,
+                /// The IME composition string itself (e.g. the pinyin
+                /// typed before a candidate is selected), spliced into
+                /// the cursor's row so composing input is actually
+                /// visible in the grid rather than only in the IME's
+                /// own candidate popup. `None` when not composing.
+                preedit_text: Option<String>,
                 /// Resolved cursor color: OSC 12 wins, then config /
                 /// theme `cursor`.
                 /// `state.colors.cursor → config.cursor_color`
@@ -4096,6 +4112,11 @@ impl Screen<'_> {
                 let cursor_blink_visible =
                     !cursor_blinking || ctx.renderable_content.is_blinking_cursor_visible;
                 let cursor_preedit = ctx.ime.preedit().is_some();
+                let preedit_text = if is_active {
+                    ctx.ime.preedit().map(|p| p.text.clone())
+                } else {
+                    None
+                };
                 // OSC 12 wins; otherwise fall back to the named-color
                 // theme value. `Renderer::color`'s fallback (the
                 // indexed-color List) is not populated for the Cursor
@@ -4123,6 +4144,7 @@ impl Screen<'_> {
                     cursor_blinking,
                     cursor_blink_visible,
                     cursor_preedit,
+                    preedit_text,
                     cursor_color,
                     is_active,
                     damage,
@@ -4157,6 +4179,7 @@ impl Screen<'_> {
             )> = Vec::with_capacity(panels.len());
 
             let rasterizer = &mut self.grid_rasterizer;
+            let preedit_rows = &mut self.preedit_row;
             let renderer_ref = &self.renderer;
             for (route_id, grid) in self.grids.iter_mut() {
                 let Some(p) = panels.iter_mut().find(|p| p.route_id == *route_id) else {
@@ -4196,6 +4219,40 @@ impl Screen<'_> {
                         rio_backend::event::TerminalDamage::CursorOnly
                         | rio_backend::event::TerminalDamage::Noop => RowsToRebuild::None,
                     }
+                };
+
+                // IME preedit (the pinyin/romaji typed before a
+                // candidate is committed) never touches terminal
+                // cells, so it never generates PTY/UI damage and the
+                // gate above would otherwise never pick the cursor
+                // row up. Force it in directly: mark that row dirty
+                // while composing so `overlay_preedit_text` runs, and
+                // once more right after composing ends without a
+                // commit (e.g. Escape cancels it) so the overlay gets
+                // erased and the row falls back to its real terminal
+                // content.
+                let prev_preedit_row = preedit_rows.get(route_id).copied();
+                let force_preedit_row = if p.preedit_text.is_some() {
+                    preedit_rows.insert(*route_id, p.cursor_row);
+                    Some(p.cursor_row)
+                } else {
+                    preedit_rows.remove(route_id);
+                    prev_preedit_row
+                };
+                let rows_to_rebuild = match (rows_to_rebuild, force_preedit_row) {
+                    (RowsToRebuild::None, Some(row)) => {
+                        if let Some(r) = p.visible_rows.get_mut(row as usize) {
+                            r.dirty = true;
+                        }
+                        RowsToRebuild::Dirty
+                    }
+                    (mode, Some(row)) => {
+                        if let Some(r) = p.visible_rows.get_mut(row as usize) {
+                            r.dirty = true;
+                        }
+                        mode
+                    }
+                    (mode, None) => mode,
                 };
 
                 let cols = p.cols as usize;
@@ -4281,6 +4338,27 @@ impl Screen<'_> {
                                 }
                             }
                             None => (row, row_styles),
+                        };
+                        let preedit_row;
+                        let preedit_styles;
+                        let (row, row_styles) = match p.preedit_text.as_deref() {
+                            Some(text) if (y as u16) == p.cursor_row => {
+                                match rio_grid::overlay_preedit_text(
+                                    row,
+                                    row_styles,
+                                    text,
+                                    p.cursor_col,
+                                    &mut hint_scratch,
+                                ) {
+                                    Some((r, styles)) => {
+                                        preedit_row = r;
+                                        preedit_styles = styles;
+                                        (&preedit_row, preedit_styles.as_slice())
+                                    }
+                                    None => (row, row_styles),
+                                }
+                            }
+                            _ => (row, row_styles),
                         };
                         rio_grid::build_row_bg(
                             row,

--- a/librio/include/librio.h
+++ b/librio/include/librio.h
@@ -64,6 +64,13 @@ typedef size_t rio_surface_id_t;
 #define RIO_SELECTION_LINE 2u
 #define RIO_SELECTION_BLOCK 3u
 
+/* rio_render_state_cursor_shape: DECSCUSR shape, or HIDDEN when the program
+   hid the cursor (DECTCEM) or the view is scrolled into history. */
+#define RIO_CURSOR_BLOCK 0u
+#define RIO_CURSOR_UNDERLINE 1u
+#define RIO_CURSOR_BEAM 2u
+#define RIO_CURSOR_HIDDEN 3u
+
 #define RIO_MOD_SHIFT (1u << 0)
 #define RIO_MOD_CTRL (1u << 1)
 #define RIO_MOD_ALT (1u << 2)
@@ -203,6 +210,10 @@ rio_surface_t *rio_surface_new(rio_engine_t *engine,
                                const rio_surface_config_s *config);
 void rio_surface_free(rio_surface_t *surface);
 rio_surface_id_t rio_surface_id(const rio_surface_t *surface);
+/* Pid of the spawned program. It is a session leader, so killpg() on it
+ * reaches everything the shell started; rio_surface_free only hangs up the
+ * pty and signals this pid. 0 when the surface has no PTY. */
+uint32_t rio_surface_child_pid(const rio_surface_t *surface);
 
 /* Input entry points are callable from any thread. */
 void rio_surface_text(rio_surface_t *surface, const char *bytes, size_t len);
@@ -312,6 +323,8 @@ size_t rio_cluster_width(const uint32_t *codepoints, size_t len,
 rio_cell_s rio_render_state_cell(const rio_render_state_t *state, uint16_t line,
                                  uint16_t column);
 rio_cursor_s rio_render_state_cursor(const rio_render_state_t *state);
+/* RIO_CURSOR_*; see the defines. */
+uint8_t rio_render_state_cursor_shape(const rio_render_state_t *state);
 
 /* This frame's dynamic (OSC 10/11/12) default colors. `which`: 0 =
  * foreground, 1 = background, 2 = cursor. Writes the resolved RGB into

--- a/librio/src/capi.rs
+++ b/librio/src/capi.rs
@@ -58,6 +58,11 @@ pub const RIO_SELECTION_WORD: u8 = 1;
 pub const RIO_SELECTION_LINE: u8 = 2;
 pub const RIO_SELECTION_BLOCK: u8 = 3;
 
+pub const RIO_CURSOR_BLOCK: u8 = 0;
+pub const RIO_CURSOR_UNDERLINE: u8 = 1;
+pub const RIO_CURSOR_BEAM: u8 = 2;
+pub const RIO_CURSOR_HIDDEN: u8 = 3;
+
 #[repr(C)]
 pub struct rio_action_s {
     pub tag: u32,
@@ -588,6 +593,25 @@ pub unsafe extern "C" fn rio_surface_id(surface: *const Surface) -> usize {
             return 0;
         }
         unsafe { &*surface }.id()
+    }))
+    .unwrap_or(0)
+}
+
+/// Pid of the spawned program (a session leader), 0 without a PTY.
+#[no_mangle]
+pub unsafe extern "C" fn rio_surface_child_pid(surface: *const Surface) -> u32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        if surface.is_null() {
+            return 0;
+        }
+        #[cfg(feature = "pty")]
+        {
+            unsafe { &*surface }.child_pid()
+        }
+        #[cfg(not(feature = "pty"))]
+        {
+            0
+        }
     }))
     .unwrap_or(0)
 }
@@ -1465,6 +1489,33 @@ pub unsafe extern "C" fn rio_render_state_cursor(
         }
     }))
     .unwrap_or(rio_cursor_s { line: 0, column: 0 })
+}
+
+/// The cursor's visual shape for this frame, as RIO_CURSOR_*: the program's
+/// DECSCUSR choice (block / underline / beam), or RIO_CURSOR_HIDDEN when it
+/// hid the cursor (DECTCEM) or the view is scrolled into history. Hosts that
+/// paint the cursor themselves read this next to `rio_render_state_cursor`.
+#[no_mangle]
+pub unsafe extern "C" fn rio_render_state_cursor_shape(
+    state: *const RenderState,
+) -> u8 {
+    catch_unwind(AssertUnwindSafe(|| {
+        if state.is_null() {
+            return RIO_CURSOR_HIDDEN;
+        }
+        let state = unsafe { &*state };
+        if !state.cursor_visible() {
+            return RIO_CURSOR_HIDDEN;
+        }
+        use rio_vt::ansi::CursorShape;
+        match state.cursor_shape() {
+            CursorShape::Block => RIO_CURSOR_BLOCK,
+            CursorShape::Underline => RIO_CURSOR_UNDERLINE,
+            CursorShape::Beam => RIO_CURSOR_BEAM,
+            CursorShape::Hidden => RIO_CURSOR_HIDDEN,
+        }
+    }))
+    .unwrap_or(RIO_CURSOR_HIDDEN)
 }
 
 /// This frame's dynamic (OSC 10/11/12) default colors. `which`:

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -1105,6 +1105,15 @@ impl Surface {
         Some(matches)
     }
 
+    /// The pid of the program this surface spawned (the shell, or the
+    /// configured `shell` program). It is a session leader, so a host that
+    /// must take the whole process tree down on teardown can `killpg` it:
+    /// dropping the surface only hangs up the pty and signals this pid.
+    #[cfg(feature = "pty")]
+    pub fn child_pid(&self) -> u32 {
+        self.shell_pid
+    }
+
     /// The foreground process's name (the program the user is running
     /// right now: `claude`, `vim`, or the shell itself), from the kernel.
     /// Hosts use it to tell what a pane is running without any shell

--- a/rio-grid/src/lib.rs
+++ b/rio-grid/src/lib.rs
@@ -155,12 +155,18 @@ fn cell_in_row_sel(row_sel: Option<RowSelection>, col: u16) -> bool {
 /// `HyperlinkHover` is rio-specific: same row-interval shape but the
 /// only visual is a forced underline (no bg/fg color change), used for
 /// the OSC 8 / regex-hint-on-hover affordance.
+///
+/// `Preedit` is the IME composition span (e.g. the romaji/pinyin typed
+/// before a candidate is committed). Same forced-underline-only
+/// treatment as `HyperlinkHover` — it marks in-progress input without
+/// recoloring the cell.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HintTag {
     Match,
     Focused,
     HyperlinkHover,
     Label,
+    Preedit,
 }
 
 /// Per-row hint interval, closed on both ends. Several `RowHint`s may
@@ -343,12 +349,77 @@ pub fn overlay_hint_labels(
     out
 }
 
+/// Style id stamped on overlaid IME preedit cells. Distinct from
+/// `HINT_LABEL_STYLE_ID` (also outside the interning range) so a
+/// preedit run never gets shaped together with a hint-label run, and
+/// so `build_row_fg`'s run-break-on-style-id-change always splits at
+/// the preedit boundary even when the surrounding text happens to
+/// share the default style.
+const PREEDIT_STYLE_ID: u16 = u16::MAX - 1;
+
+/// Splice the IME composition string into the cursor's row so it is
+/// actually visible while composing (e.g. the pinyin typed before a
+/// candidate is selected), instead of only showing up in the IME's own
+/// candidate popup. Mirrors `overlay_hint_labels`: cells are
+/// overwritten in a cloned row/style buffer, and a `RowHint` marks the
+/// span so `emit_underlines` draws a plain underline under it (see
+/// `HintTag::Preedit`).
+///
+/// One column per `char` — correct for the common case (romaji /
+/// pinyin composition is ASCII) and good enough for a visible-but-not
+/// pixel-perfect indicator for wide preedit text; text run past the
+/// end of the row is clipped rather than wrapped.
+pub fn overlay_preedit_text(
+    row: &Row<Square>,
+    row_styles: &[Style],
+    text: &str,
+    start_col: u16,
+    row_hints: &mut Vec<RowHint>,
+) -> Option<(Row<Square>, Vec<Style>)> {
+    let width = row.len();
+    let mut col = start_col as usize;
+    if text.is_empty() || col >= width {
+        return None;
+    }
+
+    let mut out: Option<(Row<Square>, Vec<Style>)> = None;
+    let start_col = col;
+    for ch in text.chars() {
+        if col >= width {
+            break;
+        }
+        let (target, styles) = out.get_or_insert_with(|| {
+            let mut styles = row_styles.to_vec();
+            styles.resize(width, Style::default());
+            (row.clone(), styles)
+        });
+        let mut sq = Square::from_char(ch);
+        sq.set_style_id(PREEDIT_STYLE_ID);
+        target[Column(col)] = sq;
+        styles[col] = Style::default();
+        col += 1;
+    }
+
+    if out.is_some() {
+        row_hints.insert(
+            0,
+            RowHint {
+                lo: start_col as u16,
+                hi: (col - 1) as u16,
+                tag: HintTag::Preedit,
+            },
+        );
+    }
+    out
+}
+
 #[inline]
 fn cell_in_row_hints(row_hints: &[RowHint], col: u16) -> Option<HintTag> {
-    // Skip HyperlinkHover for the color paths — it only contributes
-    // an underline (handled separately in `emit_underlines`).
+    // Skip HyperlinkHover/Preedit for the color paths — they only
+    // contribute an underline (handled separately in
+    // `emit_underlines`).
     for rh in row_hints {
-        if rh.tag == HintTag::HyperlinkHover {
+        if matches!(rh.tag, HintTag::HyperlinkHover | HintTag::Preedit) {
             continue;
         }
         if col >= rh.lo && col <= rh.hi {
@@ -359,12 +430,15 @@ fn cell_in_row_hints(row_hints: &[RowHint], col: u16) -> Option<HintTag> {
 }
 
 /// Whether a cell should receive a forced underline from a hovered
-/// hyperlink / hint, regardless of its own SGR style flags.
+/// hyperlink / hint / IME preedit span, regardless of its own SGR
+/// style flags.
 #[inline]
 fn cell_in_hover_underline(row_hints: &[RowHint], col: u16) -> bool {
-    row_hints
-        .iter()
-        .any(|rh| rh.tag == HintTag::HyperlinkHover && col >= rh.lo && col <= rh.hi)
+    row_hints.iter().any(|rh| {
+        matches!(rh.tag, HintTag::HyperlinkHover | HintTag::Preedit)
+            && col >= rh.lo
+            && col <= rh.hi
+    })
 }
 
 /// Foreground for a hint-matched cell. Mirrors `cell_fg_selected` but
@@ -381,9 +455,10 @@ fn cell_fg_hinted<P: GridPalette>(tag: HintTag, palette: &P) -> [u8; 4] {
             normalized_to_u8(palette.named_colors().search_match_foreground)
         }
         HintTag::Label => normalized_to_u8(palette.named_colors().hint_foreground),
-        // Hover doesn't change fg color; defensive — `cell_in_row_hints`
-        // already filters this tag out, so this arm shouldn't fire.
-        HintTag::HyperlinkHover => [0, 0, 0, 0],
+        // Hover/Preedit don't change fg color; defensive —
+        // `cell_in_row_hints` already filters these tags out, so
+        // these arms shouldn't fire.
+        HintTag::HyperlinkHover | HintTag::Preedit => [0, 0, 0, 0],
     }
 }
 
@@ -1119,7 +1194,9 @@ pub fn build_row_bg<P: GridPalette>(
     // strip the per-cell `cell_in_row_sel` / `cell_in_row_hints`
     // checks and just walk cells.
     let has_sel = row_sel.is_some();
-    let has_color_hints = row_hints.iter().any(|rh| rh.tag != HintTag::HyperlinkHover);
+    let has_color_hints = row_hints
+        .iter()
+        .any(|rh| !matches!(rh.tag, HintTag::HyperlinkHover | HintTag::Preedit));
     if !has_sel && !has_color_hints {
         bg_scratch.reserve(cols);
         for x in 0..cols {
@@ -1168,10 +1245,12 @@ pub fn build_row_bg<P: GridPalette>(
                     HintTag::Match => match_bg
                         .unwrap_or_else(|| cell_bg(sq, style, palette, term_colors)),
                     HintTag::Label => cell_bg(sq, style, palette, term_colors),
-                    // `cell_in_row_hints` filters HyperlinkHover out, but
-                    // make the match exhaustive so a future caller can't
-                    // accidentally hit a panic.
-                    HintTag::HyperlinkHover => cell_bg(sq, style, palette, term_colors),
+                    // `cell_in_row_hints` filters HyperlinkHover/Preedit
+                    // out, but make the match exhaustive so a future
+                    // caller can't accidentally hit a panic.
+                    HintTag::HyperlinkHover | HintTag::Preedit => {
+                        cell_bg(sq, style, palette, term_colors)
+                    }
                 }
             } else {
                 cell_bg(sq, style, palette, term_colors)
@@ -1751,7 +1830,9 @@ pub fn build_row_fg<P: GridPalette>(
     // `cell_in_row_sel` + `cell_in_row_hints` calls per glyph when
     // the row has no selection / no color-changing hints.
     let has_sel = row_sel.is_some();
-    let has_color_hints = row_hints.iter().any(|rh| rh.tag != HintTag::HyperlinkHover);
+    let has_color_hints = row_hints
+        .iter()
+        .any(|rh| !matches!(rh.tag, HintTag::HyperlinkHover | HintTag::Preedit));
     let needs_per_cell_check = has_sel || has_color_hints;
     // Consulted in the per-cell sprite hook and the run-extension break.
     let use_drawable_chars = palette.use_drawable_chars();

--- a/rio-grid/src/lib.rs
+++ b/rio-grid/src/lib.rs
@@ -388,15 +388,21 @@ pub fn overlay_preedit_text(
         if col >= width {
             break;
         }
-        let (target, styles) = out.get_or_insert_with(|| {
-            let mut styles = row_styles.to_vec();
-            styles.resize(width, Style::default());
-            (row.clone(), styles)
-        });
+        let target = &mut out
+            .get_or_insert_with(|| {
+                let mut styles = row_styles.to_vec();
+                styles.resize(width, Style::default());
+                (row.clone(), styles)
+            })
+            .0;
         let mut sq = Square::from_char(ch);
         sq.set_style_id(PREEDIT_STYLE_ID);
         target[Column(col)] = sq;
-        styles[col] = Style::default();
+        // The per-cell style (`out.1`, cloned from `row_styles` above)
+        // is left untouched — resetting it would recolor the cell
+        // (e.g. composing over colored prompt text) even though
+        // `HintTag::Preedit` is meant to be underline-only,
+        // same as `HyperlinkHover`.
         col += 1;
     }
 


### PR DESCRIPTION
## Summary

The composing string (e.g. the pinyin typed before a candidate is chosen) never reached the terminal grid — typing was effectively blind aside from the OS candidate popup. This is cross-platform, not Windows-specific: see #1883 (Wayland), which also has a comment confirming the same symptom on macOS.

Three independent things were blocking this, all needed together (verified each is load-bearing by testing with one removed at a time):

- `Renderer::run` only stashed the first preedit char into an unused cursor field; nothing ever painted the actual composing text. Added `overlay_preedit_text` (mirrors the existing `overlay_hint_labels` mechanism) to splice the preedit string into the cursor's row, and a `HintTag::Preedit` that reuses the `HyperlinkHover` forced-underline treatment so it's visually marked without recoloring the cell.
- `Ime::Preedit` updates never marked the panel dirty, so the render pipeline's per-context damage gate skipped the panel outright on an IME-only frame — same category as command-palette/search-bar input, which already has a documented `set_dirty()` escape hatch for exactly this. Without this, the overlay only updates on the very first keystroke of a composition and then visibly freezes (confirmed by testing with it removed).
- IME composition generates no terminal damage, so even with the panel dirty, the row-rebuild decision (driven by PTY/UI damage) never selected the cursor's row. Track the last row that carried a preedit overlay per route and force it into the rebuild set, both while composing and once more after composing ends without a commit (e.g. Escape), so the overlay is cleaned up correctly.

## Test plan

Verified end-to-end on Windows 11 with Microsoft Pinyin (built release binary, drove it with real IME input, screenshotted each state):
- [x] Composing text ("ni'hao") now renders live at the cursor, tracking every keystroke, not just the first
- [x] Selecting a candidate commits normally, no leftover overlay artifacts
- [x] Escape cancels the composition cleanly, overlay is erased and the row reverts to real terminal content
- [x] Also checked with cursor blinking disabled, to rule out the blink timer masking a missing redraw
- [x] `cargo check --workspace`, `cargo clippy -p rio-grid -p rioterm --release`, `cargo fmt --check` all clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmiYRs6weCxNBesjhEM3QQ