### PR TITLE
Surface terminal bells on tabs, with a font-free indicator

### DIFF
--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -581,7 +581,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                 self.config = config;
                 self.title_tracks_size = title_tracks_size(&self.config);
-                self.router.update_titles();
 
                 // Dropping the old manager unregisters its hotkeys, so
                 // ToggleQuake binding edits apply without restarting.
@@ -630,6 +629,8 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                     route.request_redraw();
                 }
+
+                self.router.update_titles();
             }
             RioEventType::Rio(RioEvent::Exit | RioEvent::Quit) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
@@ -2205,6 +2206,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 route.window.screen.resize(new_size);
                 if self.title_tracks_size {
                     let only_current = route.window.screen.renderer.island.is_none();
+                    route.window.screen.context_manager.mark_all_titles_dirty();
                     route
                         .window
                         .screen

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -823,9 +823,21 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     );
                 }
             }
-            RioEventType::Rio(RioEvent::Title(title)) => {
+            RioEventType::Rio(RioEvent::Title(route_id, title)) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     route.set_window_title(&title);
+                    // The tab strip is window chrome: a bare redraw request
+                    // is dropped by the `any_panel_dirty` present gate, so
+                    // the new title needs the frame marked dirty to appear
+                    // before the terminal next changes on its own.
+                    if route
+                        .window
+                        .screen
+                        .context_manager
+                        .update_title_for_route(route_id)
+                    {
+                        route.request_overlay_redraw();
+                    }
                 }
             }
             RioEventType::Rio(RioEvent::TitleWithSubtitle(title, subtitle)) => {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -741,7 +741,11 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     if let Some(island) = &mut route.window.screen.renderer.island {
                         island.set_progress_report(report);
-                        route.request_redraw();
+                        // Chrome: a bare redraw is dropped by the
+                        // present gate when no terminal cells changed
+                        // (a determinate progress-value change is
+                        // exactly that).
+                        route.request_overlay_redraw();
                     }
                 }
             }
@@ -759,11 +763,13 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                 if self.config.bell.tab_indicator {
                     if let Some(route) = self.router.routes.get_mut(&window_id) {
-                        if route.window.screen.context_manager.ring_bell(route_id) {
-                            // The mark is window chrome, not terminal cells:
-                            // a bare redraw request is dropped by the
-                            // `any_panel_dirty` present gate, so the frame
-                            // has to be marked dirty for it to reach screen.
+                        let focused = route.window.is_focused;
+                        if route
+                            .window
+                            .screen
+                            .context_manager
+                            .ring_bell(route_id, focused)
+                        {
                             route.request_overlay_redraw();
                         }
                     }
@@ -824,19 +830,42 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::Title(route_id, title)) => {
+                // `title` is the raw OSC string; only RENDERED titles
+                // reach the OS titlebar or the strip, so it is unused.
+                let _ = title;
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
-                    route.set_window_title(&title);
-                    // The tab strip is window chrome: a bare redraw request
-                    // is dropped by the `any_panel_dirty` present gate, so
-                    // the new title needs the frame marked dirty to appear
-                    // before the terminal next changes on its own.
-                    if route
+                    let changed = route
                         .window
                         .screen
                         .context_manager
-                        .update_title_for_route(route_id)
+                        .update_title_for_route(route_id);
+                    // Chrome repaints only for the pane its tab displays:
+                    // a hidden split's title is recomputed above but shows
+                    // nothing until the split surfaces.
+                    if changed
+                        && route
+                            .window
+                            .screen
+                            .context_manager
+                            .is_displayed_pane(route_id)
                     {
                         route.request_overlay_redraw();
+                    }
+                    // The native titlebar follows the FOCUSED tab's pane
+                    // only (it used to be rewritten by every tab, last
+                    // writer winning, flashing raw OSC text until the
+                    // next poll).
+                    if route.window.screen.context_manager.current().route_id == route_id
+                    {
+                        let rendered = route
+                            .window
+                            .screen
+                            .context_manager
+                            .current()
+                            .title
+                            .content
+                            .clone();
+                        route.set_window_title(&rendered);
                     }
                 }
             }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -32,6 +32,10 @@ use std::time::{Duration, Instant};
 
 pub struct Application<'a> {
     config: rio_backend::config::Config,
+    /// The title template references data no PTY event announces, so
+    /// renders opportunistically refresh titles (see
+    /// `context::title::needs_title_refresh`).
+    title_on_demand: bool,
     event_proxy: EventProxy,
     router: Router<'a>,
     scheduler: Scheduler,
@@ -75,6 +79,7 @@ impl Application<'_> {
         rio_notifier::request_authorization();
 
         Application {
+            title_on_demand: crate::context::title::needs_title_refresh(&config),
             config,
             event_proxy,
             router,
@@ -159,26 +164,51 @@ impl Application<'_> {
 }
 
 impl Application<'_> {
-    /// Schedule or cancel the 2s title poll to match the config. The
-    /// poll exists only for data no PTY event announces (`{{program}}`,
-    /// paths, sizes); a `{{ title }}`-only template runs NO title
-    /// timer at all, so titles stay purely event-driven by default.
-    fn reconcile_title_poll(&mut self) {
-        let timer_id = TimerId::new(Topic::UpdateTitles, 0);
-        if crate::context::title::needs_title_poll(&self.config) {
-            if !self.scheduler.scheduled(timer_id) {
-                self.scheduler.schedule(
-                    EventPayload::new(
-                        RioEventType::Rio(RioEvent::UpdateTitles),
-                        unsafe { rio_window::window::WindowId::dummy().into() },
-                    ),
-                    Duration::from_secs(2),
-                    true,
-                    timer_id,
-                );
+    /// Recompute whether renders must refresh title data and drop any
+    /// pending trailing shot when they must not. There is NO standing
+    /// title timer: refreshes ride renders behind a rate limit, plus
+    /// one trailing shot, so an idle terminal never wakes for titles.
+    fn reconcile_title_refresh(&mut self) {
+        self.title_on_demand = crate::context::title::needs_title_refresh(&self.config);
+        if !self.title_on_demand {
+            self.scheduler
+                .unschedule(TimerId::new(Topic::UpdateTitles, 0));
+        }
+    }
+
+    /// Render-time title refresh: run it when the rate limit allows,
+    /// otherwise arm ONE trailing shot at the limit's expiry so the
+    /// change that triggered this render still lands once the pane
+    /// goes idle. While output streams this settles into one refresh
+    /// per interval (what the old repeating poll did); with no
+    /// activity there are no renders, so no title work at all.
+    fn refresh_titles_for_render(&mut self, window_id: rio_backend::event::WindowId) {
+        let Some(route) = self.router.routes.get_mut(&window_id) else {
+            return;
+        };
+        let only_current = route.window.screen.renderer.island.is_none();
+        match route.window.screen.context_manager.title_refresh_due() {
+            None => {
+                route
+                    .window
+                    .screen
+                    .context_manager
+                    .update_titles(only_current);
             }
-        } else {
-            self.scheduler.unschedule(timer_id);
+            Some(remaining) => {
+                let timer_id = TimerId::new(Topic::UpdateTitles, 0);
+                if !self.scheduler.scheduled(timer_id) {
+                    self.scheduler.schedule(
+                        EventPayload::new(
+                            RioEventType::Rio(RioEvent::UpdateTitles),
+                            unsafe { rio_window::window::WindowId::dummy().into() },
+                        ),
+                        remaining,
+                        false,
+                        timer_id,
+                    );
+                }
+            }
         }
     }
 
@@ -359,7 +389,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             self.setup_quake_hotkey();
         }
 
-        self.reconcile_title_poll();
+        self.reconcile_title_refresh();
 
         tracing::info!("Initialisation complete");
     }
@@ -593,7 +623,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 };
 
                 self.config = config;
-                self.reconcile_title_poll();
+                self.reconcile_title_refresh();
 
                 // Dropping the old manager unregisters its hotkeys, so
                 // ToggleQuake binding edits apply without restarting.
@@ -847,7 +877,20 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         .window
                         .screen
                         .context_manager
-                        .on_title_change(route_id, &title)
+                        .on_title_change(route_id, Some(&title))
+                    {
+                        route.request_overlay_redraw();
+                    }
+                    route.sync_window_title();
+                }
+            }
+            RioEventType::Rio(RioEvent::CurrentDirectoryChanged(route_id)) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    if route
+                        .window
+                        .screen
+                        .context_manager
+                        .on_title_change(route_id, None)
                     {
                         route.request_overlay_redraw();
                     }
@@ -2222,6 +2265,12 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             }
 
             WindowEvent::RedrawRequested => {
+                if self.title_on_demand && matches!(route.path, RoutePath::Terminal) {
+                    self.refresh_titles_for_render(window_id);
+                }
+                let Some(route) = self.router.routes.get_mut(&window_id) else {
+                    return;
+                };
                 route.begin_render();
 
                 match route.path {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -32,10 +32,10 @@ use std::time::{Duration, Instant};
 
 pub struct Application<'a> {
     config: rio_backend::config::Config,
-    /// The title template references data no PTY event announces, so
-    /// renders opportunistically refresh titles (see
-    /// `context::title::needs_title_refresh`).
-    title_on_demand: bool,
+    /// The title template shows `{{columns}}`/`{{lines}}`, so a resize
+    /// must re-render titles (the only title data with no PTY event;
+    /// everything else arrives via OSC 0/2 and OSC 7).
+    title_tracks_size: bool,
     event_proxy: EventProxy,
     router: Router<'a>,
     scheduler: Scheduler,
@@ -79,7 +79,7 @@ impl Application<'_> {
         rio_notifier::request_authorization();
 
         Application {
-            title_on_demand: crate::context::title::needs_title_refresh(&config),
+            title_tracks_size: title_tracks_size(&config),
             config,
             event_proxy,
             router,
@@ -163,55 +163,14 @@ impl Application<'_> {
     }
 }
 
+/// Whether the title template renders the pane size, the one title
+/// input with no PTY event attached (resizes are locally known).
+fn title_tracks_size(config: &rio_backend::config::Config) -> bool {
+    let template = config.title.content.to_lowercase();
+    template.contains("columns") || template.contains("lines")
+}
+
 impl Application<'_> {
-    /// Recompute whether renders must refresh title data and drop any
-    /// pending trailing shot when they must not. There is NO standing
-    /// title timer: refreshes ride renders behind a rate limit, plus
-    /// one trailing shot, so an idle terminal never wakes for titles.
-    fn reconcile_title_refresh(&mut self) {
-        self.title_on_demand = crate::context::title::needs_title_refresh(&self.config);
-        if !self.title_on_demand {
-            self.scheduler
-                .unschedule(TimerId::new(Topic::UpdateTitles, 0));
-        }
-    }
-
-    /// Render-time title refresh: run it when the rate limit allows,
-    /// otherwise arm ONE trailing shot at the limit's expiry so the
-    /// change that triggered this render still lands once the pane
-    /// goes idle. While output streams this settles into one refresh
-    /// per interval (what the old repeating poll did); with no
-    /// activity there are no renders, so no title work at all.
-    fn refresh_titles_for_render(&mut self, window_id: rio_backend::event::WindowId) {
-        let Some(route) = self.router.routes.get_mut(&window_id) else {
-            return;
-        };
-        let only_current = route.window.screen.renderer.island.is_none();
-        match route.window.screen.context_manager.title_refresh_due() {
-            None => {
-                route
-                    .window
-                    .screen
-                    .context_manager
-                    .update_titles(only_current);
-            }
-            Some(remaining) => {
-                let timer_id = TimerId::new(Topic::UpdateTitles, 0);
-                if !self.scheduler.scheduled(timer_id) {
-                    self.scheduler.schedule(
-                        EventPayload::new(
-                            RioEventType::Rio(RioEvent::UpdateTitles),
-                            unsafe { rio_window::window::WindowId::dummy().into() },
-                        ),
-                        remaining,
-                        false,
-                        timer_id,
-                    );
-                }
-            }
-        }
-    }
-
     /// Register a system-wide hotkey for every `ToggleQuake` binding
     /// in the config, so the quake window opens while Rio is
     /// unfocused. No-op when quake is not bound; pure Wayland has no
@@ -388,8 +347,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
         if cause == StartCause::Init {
             self.setup_quake_hotkey();
         }
-
-        self.reconcile_title_refresh();
 
         tracing::info!("Initialisation complete");
     }
@@ -623,7 +580,8 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 };
 
                 self.config = config;
-                self.reconcile_title_refresh();
+                self.title_tracks_size = title_tracks_size(&self.config);
+                self.router.update_titles();
 
                 // Dropping the old manager unregisters its hotkeys, so
                 // ToggleQuake binding edits apply without restarting.
@@ -907,9 +865,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     route.set_window_title(&title);
                     route.set_window_subtitle(&subtitle);
                 }
-            }
-            RioEventType::Rio(RioEvent::UpdateTitles) => {
-                self.router.update_titles();
             }
             RioEventType::Rio(RioEvent::MouseCursorDirty) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
@@ -2248,6 +2203,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
 
                 route.window.screen.resize(new_size);
+                if self.title_tracks_size {
+                    let only_current = route.window.screen.renderer.island.is_none();
+                    route
+                        .window
+                        .screen
+                        .context_manager
+                        .update_titles(only_current);
+                }
                 route.request_redraw();
             }
 
@@ -2265,12 +2228,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             }
 
             WindowEvent::RedrawRequested => {
-                if self.title_on_demand && matches!(route.path, RoutePath::Terminal) {
-                    self.refresh_titles_for_render(window_id);
-                }
-                let Some(route) = self.router.routes.get_mut(&window_id) else {
-                    return;
-                };
                 route.begin_render();
 
                 match route.path {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -751,10 +751,22 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     route.request_redraw();
                 }
             }
-            RioEventType::Rio(RioEvent::Bell) => {
+            RioEventType::Rio(RioEvent::Bell(route_id)) => {
                 // Handle audio bell
                 if self.config.bell.audio {
                     self.handle_audio_bell();
+                }
+
+                if self.config.bell.tab_indicator {
+                    if let Some(route) = self.router.routes.get_mut(&window_id) {
+                        if route.window.screen.context_manager.ring_bell(route_id) {
+                            // The mark is window chrome, not terminal cells:
+                            // a bare redraw request is dropped by the
+                            // `any_panel_dirty` present gate, so the frame
+                            // has to be marked dirty for it to reach screen.
+                            route.request_overlay_redraw();
+                        }
+                    }
                 }
             }
             RioEventType::Rio(RioEvent::DesktopNotification { title, body }) => {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -159,6 +159,30 @@ impl Application<'_> {
 }
 
 impl Application<'_> {
+    /// Schedule or cancel the 2s title poll to match the config. The
+    /// poll exists only for data no PTY event announces (`{{program}}`,
+    /// paths, sizes, color automation); a `{{ title }}`-only template
+    /// with color automation off runs NO title timer at all, matching
+    /// how ghostty and kitty never poll for titles.
+    fn reconcile_title_poll(&mut self) {
+        let timer_id = TimerId::new(Topic::UpdateTitles, 0);
+        if crate::context::title::needs_title_poll(&self.config) {
+            if !self.scheduler.scheduled(timer_id) {
+                self.scheduler.schedule(
+                    EventPayload::new(
+                        RioEventType::Rio(RioEvent::UpdateTitles),
+                        unsafe { rio_window::window::WindowId::dummy().into() },
+                    ),
+                    Duration::from_secs(2),
+                    true,
+                    timer_id,
+                );
+            }
+        } else {
+            self.scheduler.unschedule(timer_id);
+        }
+    }
+
     /// Register a system-wide hotkey for every `ToggleQuake` binding
     /// in the config, so the quake window opens while Rio is
     /// unfocused. No-op when quake is not bound; pure Wayland has no
@@ -336,18 +360,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             self.setup_quake_hotkey();
         }
 
-        // Schedule title updates every 2s
-        let timer_id = TimerId::new(Topic::UpdateTitles, 0);
-        if !self.scheduler.scheduled(timer_id) {
-            self.scheduler.schedule(
-                EventPayload::new(RioEventType::Rio(RioEvent::UpdateTitles), unsafe {
-                    rio_window::window::WindowId::dummy().into()
-                }),
-                Duration::from_secs(2),
-                true,
-                timer_id,
-            );
-        }
+        self.reconcile_title_poll();
 
         tracing::info!("Initialisation complete");
     }
@@ -360,6 +373,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     // Skip rendering for unfocused windows if configured
                     if self.config.renderer.disable_unfocused_render
                         && !route.window.is_focused
+                        && route.window.focus_seen
                     {
                         return;
                     }
@@ -386,6 +400,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         // Skip rendering for unfocused windows if configured
                         if self.config.renderer.disable_unfocused_render
                             && !route.window.is_focused
+                            && route.window.focus_seen
                         {
                             if route.window.screen.renderer.scrollbar.needs_redraw() {
                                 route.request_redraw();
@@ -444,6 +459,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     if let Some(route) = self.router.routes.get_mut(&window_id) {
                         if self.config.renderer.disable_unfocused_render
                             && !route.window.is_focused
+                            && route.window.focus_seen
                         {
                             return;
                         }
@@ -578,6 +594,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 };
 
                 self.config = config;
+                self.reconcile_title_poll();
 
                 // Dropping the old manager unregisters its hotkeys, so
                 // ToggleQuake binding edits apply without restarting.
@@ -827,7 +844,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
             }
             RioEventType::Rio(RioEvent::Title(route_id, _)) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
-                    let (content_changed, displayed_changed) = route
+                    let displayed_changed = route
                         .window
                         .screen
                         .context_manager
@@ -841,25 +858,12 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     {
                         route.request_overlay_redraw();
                     }
-                    if content_changed
-                        && route.window.screen.context_manager.current().route_id
-                            == route_id
-                    {
-                        let rendered = route
-                            .window
-                            .screen
-                            .context_manager
-                            .current()
-                            .title
-                            .content
-                            .clone();
-                        route.set_window_title(&rendered);
-                    }
+                    route.sync_window_title();
                 }
             }
-            RioEventType::Rio(RioEvent::WindowTitle(title)) => {
+            RioEventType::Rio(RioEvent::SyncWindowTitle) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
-                    route.set_window_title(&title);
+                    route.sync_window_title();
                 }
             }
             RioEventType::Rio(RioEvent::TitleWithSubtitle(title, subtitle)) => {
@@ -2137,6 +2141,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                 let focus_changed = route.window.is_focused != focused;
                 route.window.is_focused = focused;
+                route.window.focus_seen = true;
 
                 // Focus is a cheap checkpoint to catch backing-scale changes
                 // whose ScaleFactorChanged never arrived (sleep/wake display

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -161,9 +161,8 @@ impl Application<'_> {
 impl Application<'_> {
     /// Schedule or cancel the 2s title poll to match the config. The
     /// poll exists only for data no PTY event announces (`{{program}}`,
-    /// paths, sizes, color automation); a `{{ title }}`-only template
-    /// with color automation off runs NO title timer at all, matching
-    /// how ghostty and kitty never poll for titles.
+    /// paths, sizes); a `{{ title }}`-only template runs NO title
+    /// timer at all, so titles stay purely event-driven by default.
     fn reconcile_title_poll(&mut self) {
         let timer_id = TimerId::new(Topic::UpdateTitles, 0);
         if crate::context::title::needs_title_poll(&self.config) {
@@ -842,19 +841,13 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     );
                 }
             }
-            RioEventType::Rio(RioEvent::Title(route_id, _)) => {
+            RioEventType::Rio(RioEvent::Title(route_id, title)) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
-                    let displayed_changed = route
+                    if route
                         .window
                         .screen
                         .context_manager
-                        .update_title_for_route(route_id);
-                    if displayed_changed
-                        && route
-                            .window
-                            .screen
-                            .context_manager
-                            .is_displayed_pane(route_id)
+                        .on_title_change(route_id, &title)
                     {
                         route.request_overlay_redraw();
                     }

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -741,10 +741,6 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
                     if let Some(island) = &mut route.window.screen.renderer.island {
                         island.set_progress_report(report);
-                        // Chrome: a bare redraw is dropped by the
-                        // present gate when no terminal cells changed
-                        // (a determinate progress-value change is
-                        // exactly that).
                         route.request_overlay_redraw();
                     }
                 }
@@ -829,20 +825,14 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     );
                 }
             }
-            RioEventType::Rio(RioEvent::Title(route_id, title)) => {
-                // `title` is the raw OSC string; only RENDERED titles
-                // reach the OS titlebar or the strip, so it is unused.
-                let _ = title;
+            RioEventType::Rio(RioEvent::Title(route_id, _)) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
-                    let changed = route
+                    let (content_changed, displayed_changed) = route
                         .window
                         .screen
                         .context_manager
                         .update_title_for_route(route_id);
-                    // Chrome repaints only for the pane its tab displays:
-                    // a hidden split's title is recomputed above but shows
-                    // nothing until the split surfaces.
-                    if changed
+                    if displayed_changed
                         && route
                             .window
                             .screen
@@ -851,11 +841,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     {
                         route.request_overlay_redraw();
                     }
-                    // The native titlebar follows the FOCUSED tab's pane
-                    // only (it used to be rewritten by every tab, last
-                    // writer winning, flashing raw OSC text until the
-                    // next poll).
-                    if route.window.screen.context_manager.current().route_id == route_id
+                    if content_changed
+                        && route.window.screen.context_manager.current().route_id
+                            == route_id
                     {
                         let rendered = route
                             .window
@@ -867,6 +855,11 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             .clone();
                         route.set_window_title(&rendered);
                     }
+                }
+            }
+            RioEventType::Rio(RioEvent::WindowTitle(title)) => {
+                if let Some(route) = self.router.routes.get_mut(&window_id) {
+                    route.set_window_title(&title);
                 }
             }
             RioEventType::Rio(RioEvent::TitleWithSubtitle(title, subtitle)) => {

--- a/frontends/rioterm/src/application.rs
+++ b/frontends/rioterm/src/application.rs
@@ -163,6 +163,30 @@ impl Application<'_> {
     }
 }
 
+impl Application<'_> {
+    /// One pane's title data changed (OSC 0/2 title carried in
+    /// `raw_title`, OSC 7 directory as `None`): re-render, repaint the
+    /// strip when the displayed text changed, and poke the titlebar.
+    fn handle_title_change(
+        &mut self,
+        window_id: rio_backend::event::WindowId,
+        route_id: usize,
+        raw_title: Option<&str>,
+    ) {
+        if let Some(route) = self.router.routes.get_mut(&window_id) {
+            if route
+                .window
+                .screen
+                .context_manager
+                .on_title_change(route_id, raw_title)
+            {
+                route.request_overlay_redraw();
+            }
+            route.sync_window_title();
+        }
+    }
+}
+
 /// Whether the title template renders the pane size, the one title
 /// input with no PTY event attached (resizes are locally known).
 fn title_tracks_size(config: &rio_backend::config::Config) -> bool {
@@ -619,6 +643,9 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                         &self.router.font_library,
                         has_font_updates,
                     );
+                    if !self.config.bell.tab_indicator {
+                        route.window.screen.context_manager.clear_all_bells();
+                    }
                     route.window.configure_window(&self.config);
 
                     if let Some(error) = &config_error {
@@ -709,6 +736,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                             event_loop.exit();
                         }
                     } else {
+                        route.window.screen.refresh_titles();
                         let size = route.window.screen.context_manager.len();
                         route.window.screen.resize_top_or_bottom_line(size);
                     }
@@ -831,30 +859,10 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                 }
             }
             RioEventType::Rio(RioEvent::Title(route_id, title)) => {
-                if let Some(route) = self.router.routes.get_mut(&window_id) {
-                    if route
-                        .window
-                        .screen
-                        .context_manager
-                        .on_title_change(route_id, Some(&title))
-                    {
-                        route.request_overlay_redraw();
-                    }
-                    route.sync_window_title();
-                }
+                self.handle_title_change(window_id, route_id, Some(&title));
             }
             RioEventType::Rio(RioEvent::CurrentDirectoryChanged(route_id)) => {
-                if let Some(route) = self.router.routes.get_mut(&window_id) {
-                    if route
-                        .window
-                        .screen
-                        .context_manager
-                        .on_title_change(route_id, None)
-                    {
-                        route.request_overlay_redraw();
-                    }
-                    route.sync_window_title();
-                }
+                self.handle_title_change(window_id, route_id, None);
             }
             RioEventType::Rio(RioEvent::SyncWindowTitle) => {
                 if let Some(route) = self.router.routes.get_mut(&window_id) {
@@ -894,7 +902,11 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     routes, clipboard, ..
                 } = &mut self.router;
                 if let Some(route) = routes.get_mut(&window_id) {
-                    if route.window.is_focused {
+                    // `!focus_seen` mirrors the render gates: a window
+                    // that never received a focus event yet (created in
+                    // the background) must not have OSC 52 silently
+                    // dropped by an is_focused that never initialized.
+                    if route.window.is_focused || !route.window.focus_seen {
                         let text = format(clipboard.get(clipboard_type).as_str());
                         // Route the paste back to the panel that asked for it
                         // (OSC 52 reply), not whichever panel happens to be
@@ -915,7 +927,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
                     routes, clipboard, ..
                 } = &mut self.router;
                 if let Some(route) = routes.get_mut(&window_id) {
-                    if route.window.is_focused {
+                    if route.window.is_focused || !route.window.focus_seen {
                         clipboard.set(clipboard_type, content);
                     }
                 }
@@ -2205,13 +2217,7 @@ impl ApplicationHandler<EventPayload> for Application<'_> {
 
                 route.window.screen.resize(new_size);
                 if self.title_tracks_size {
-                    let only_current = route.window.screen.renderer.island.is_none();
-                    route.window.screen.context_manager.mark_all_titles_dirty();
-                    route
-                        .window
-                        .screen
-                        .context_manager
-                        .update_titles(only_current);
+                    route.window.screen.refresh_titles();
                 }
                 route.request_redraw();
             }

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -880,17 +880,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         Self::refresh_item_title(&template, context, raw_title)
     }
 
-    /// Re-render tab titles from local state: a config reload can
-    /// change the template, and a resize changes `{{columns}}`/
-    /// `{{lines}}`. OSC title and OSC 7 changes arrive via
-    /// `on_title_change` instead; nothing calls this on a timer. The
-    /// chrome repaint rides the returned flag, and one unconditional
-    /// titlebar poke per run makes the native title CONVERGE on the
-    /// displayed text (the poke is payload-less and deduped at the
-    /// sink, so a run that changed nothing costs one no-op event).
-    /// `only_current` restricts the walk to the displayed tab: with
-    /// the tab strip absent (navigation disabled) background tabs'
-    /// titles render nowhere, so refreshing them buys nothing.
     /// Mark every pane's title stale. For changes that affect panes no
     /// walk re-renders (a resize changing `{{columns}}`, a config
     /// reload changing the template), hidden splits and unwalked tabs
@@ -903,6 +892,17 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
+    /// Re-render tab titles from local state: a config reload can
+    /// change the template, and a resize changes `{{columns}}`/
+    /// `{{lines}}`. OSC title and OSC 7 changes arrive via
+    /// `on_title_change` instead; nothing calls this on a timer. The
+    /// chrome repaint rides the returned flag, and one unconditional
+    /// titlebar poke per run makes the native title CONVERGE on the
+    /// displayed text (the poke is payload-less and deduped at the
+    /// sink, so a run that changed nothing costs one no-op event).
+    /// `only_current` restricts the walk to the displayed tab: with
+    /// the tab strip absent (navigation disabled) background tabs'
+    /// titles render nowhere, so refreshing them buys nothing.
     pub fn update_titles(&mut self, only_current: bool) -> bool {
         let template = self.config.title.content.clone();
         let mut repaint = false;

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -753,6 +753,41 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
+    /// A pane rang the bell. Flags its tab so the strip can surface it;
+    /// the focused tab is skipped since the user is already looking at it.
+    /// The ringing pane can live in any tab (background split of a
+    /// background tab included), so every tab is searched.
+    #[inline]
+    pub fn ring_bell(&mut self, route_id: usize) -> bool {
+        let Some(tab_index) = self
+            .contexts
+            .iter_mut()
+            .position(|grid| grid.get_by_route_id(route_id).is_some())
+        else {
+            return false;
+        };
+
+        if tab_index == self.current_index {
+            return false;
+        }
+
+        self.contexts[tab_index].bell = true;
+        true
+    }
+
+    #[inline]
+    pub fn bell(&self, index: usize) -> bool {
+        self.contexts.get(index).is_some_and(|grid| grid.bell)
+    }
+
+    /// Clears the focused tab's bell flag. Called every frame so the mark
+    /// drops the moment the tab is shown, whatever brought it to the front.
+    #[inline]
+    pub fn clear_current_bell(&mut self) -> bool {
+        let grid = &mut self.contexts[self.current_index];
+        std::mem::replace(&mut grid.bell, false)
+    }
+
     #[inline]
     pub fn resize_all_grids(
         &mut self,
@@ -1354,6 +1389,35 @@ pub mod test {
 
         context_manager.set_current(8);
         assert_eq!(context_manager.current_index, 3);
+    }
+
+    #[test]
+    fn bell_marks_background_tabs_only_and_clears_on_focus() {
+        let mut cm =
+            ContextManager::start_with_capacity(5, VoidListener {}, WindowId::from(0))
+                .unwrap();
+        cm.add_context(true, 0);
+        cm.add_context(true, 0);
+        cm.set_current(0);
+
+        let background_route = cm.contexts[2].current().route_id;
+        let focused_route = cm.contexts[0].current().route_id;
+
+        assert!(cm.ring_bell(background_route));
+        assert!(cm.bell(2));
+
+        // The focused tab is never marked: the user is looking at it.
+        assert!(!cm.ring_bell(focused_route));
+        assert!(!cm.bell(0));
+
+        // Unknown routes (already-closed panes) are a no-op.
+        assert!(!cm.ring_bell(usize::MAX));
+
+        // Focusing the tab drops the mark on the next rendered frame.
+        cm.set_current(2);
+        assert!(cm.bell(2));
+        assert!(cm.clear_current_bell());
+        assert!(!cm.bell(2));
     }
 
     fn set_tab_title(cm: &mut ContextManager<VoidListener>, index: usize, content: &str) {

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -56,6 +56,9 @@ pub struct Context<T: EventListener> {
     pub rich_text_id: usize,
     pub dimension: ContextDimension,
     pub title: ContextTitle,
+    /// An OSC title change arrived while this pane was hidden: the
+    /// render was skipped and must run when the pane surfaces.
+    pub title_dirty: bool,
     _io_thread: Option<JoinHandle<(Machine<teletypewriter::Pty, T>, performer::State)>>,
 }
 
@@ -113,7 +116,6 @@ pub struct ContextManagerConfig {
     pub spawn_performer: bool,
     pub cwd: bool,
     pub is_native: bool,
-    pub should_update_title_extra: bool,
     pub split_color: [f32; 4],
     pub split_active_color: [f32; 4],
     pub panel: rio_backend::config::layout::Panel,
@@ -167,6 +169,7 @@ pub fn create_dead_context<T: rio_backend::event::EventListener>(
         rich_text_id,
         dimension,
         title: ContextTitle::default(),
+        title_dirty: false,
         _io_thread: None,
     }
 }
@@ -340,6 +343,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             renderable_content: RenderableContent::new(cursor_state.0.clone()),
             dimension,
             title: ContextTitle::default(),
+            title_dirty: false,
             _io_thread: io_thread,
         })
     }
@@ -757,16 +761,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             .position(|grid| grid.get_by_route_id(route_id).is_some())
     }
 
-    /// Whether `route_id` is the pane its tab currently displays: the
-    /// pane whose title the tab strip shows for that tab. Chrome only
-    /// repaints for these; a hidden split's state changes display
-    /// nothing until it surfaces.
-    #[inline]
-    pub fn is_displayed_pane(&mut self, route_id: usize) -> bool {
-        self.tab_index_for_route(route_id)
-            .is_some_and(|index| self.contexts[index].current().route_id == route_id)
-    }
-
     /// A pane rang the bell. Flags its tab so the strip can surface it.
     /// The current tab is skipped only while the window has focus: the
     /// user is already looking at it then, but a ring in the visible
@@ -812,29 +806,23 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
-    /// Re-render one pane's title. The extra tracks the running
-    /// program, which changes without any title event, so it refreshes
-    /// even when the rendered content is unchanged; the fetched program
-    /// is reused for the template render, so a refresh runs the process
-    /// inspection at most once. Returns whether the DISPLAYED text
-    /// changed: the strip shows the content, falling back to the
-    /// program only when the content is empty, so extra-only churn
-    /// repaints nothing.
+    /// Re-render one pane's title. The extra (foreground program) is
+    /// fetched exactly when its one consumer needs it: the strip falls
+    /// back to the program only for an EMPTY rendered content, so a
+    /// pane with any content pays no process inspection at all (the
+    /// old coupling keyed this on `navigation.color_automation`, which
+    /// nothing consumes). Returns whether the displayed text changed.
     fn refresh_item_title(
         template: &str,
-        should_update_title_extra: bool,
         context: &mut Context<T>,
+        prefetched_title: Option<&str>,
     ) -> bool {
-        let extra = if should_update_title_extra {
+        let content = update_title(template, context, prefetched_title);
+        let extra = if content.is_empty() {
             create_title_extra_from_context(context)
         } else {
             None
         };
-        let content = update_title(
-            template,
-            context,
-            extra.as_ref().map(|e| e.program.as_str()),
-        );
         let content_changed = content != context.title.content;
         let extra_changed = extra != context.title.extra;
         if !content_changed && !extra_changed {
@@ -845,36 +833,53 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         displayed_changed
     }
 
-    /// Recompute the tab title for a single pane, used when its terminal
-    /// title changed (OSC 0/2). The poll below only paces the variables
-    /// that have no event to hang off (`{{program}}`, paths), so waiting
-    /// on it made a title the PTY already told us about show up seconds
-    /// late. Returns whether the displayed text changed.
-    pub fn update_title_for_route(&mut self, route_id: usize) -> bool {
-        let template = self.config.title.content.clone();
-        let should_update_title_extra = self.config.should_update_title_extra;
-        let Some(item) = self.get_by_route_id(route_id) else {
+    /// A pane's OSC 0/2 title changed. A DISPLAYED pane (its tab's
+    /// current) re-renders immediately with the event's own title
+    /// string, so the common `{{ title }}` render never locks the
+    /// terminal; a hidden pane is only marked dirty (one flag write,
+    /// no locks, no render) and renders when it surfaces, so a
+    /// background split streaming titles costs nothing visible. One
+    /// route scan serves every decision. Returns whether the strip
+    /// must repaint.
+    pub fn on_title_change(&mut self, route_id: usize, raw_title: &str) -> bool {
+        let Some(tab_index) = self.tab_index_for_route(route_id) else {
             return false;
         };
-        Self::refresh_item_title(&template, should_update_title_extra, item.context_mut())
+        if self.contexts[tab_index].current().route_id != route_id {
+            if let Some(item) = self.contexts[tab_index].get_by_route_id(route_id) {
+                item.context_mut().title_dirty = true;
+            }
+            return false;
+        }
+        let template = self.config.title.content.clone();
+        let context = self.contexts[tab_index].current_mut();
+        context.title_dirty = false;
+        Self::refresh_item_title(&template, context, Some(raw_title))
     }
 
     /// Recompute every tab's title on the poll tick. This is what picks up
     /// the variables no PTY event announces (`{{program}}`, paths); OSC
-    /// title changes arrive immediately via `update_title_for_route`.
+    /// title changes arrive immediately via `on_title_change`.
     /// The titles are committed HERE; the chrome repaint rides the
     /// returned flag, and one unconditional titlebar poke per tick
     /// makes the native title CONVERGE on the displayed text (the poke
     /// is payload-less and deduped at the sink, so a tick that changed
     /// nothing costs one no-op event).
-    pub fn update_titles(&mut self) -> bool {
+    /// `only_current` restricts the walk to the displayed tab: with the
+    /// tab strip absent (navigation disabled) background tabs' titles
+    /// render nowhere, so polling them buys nothing.
+    pub fn update_titles(&mut self, only_current: bool) -> bool {
         let template = self.config.title.content.clone();
-        let should_update_title_extra = self.config.should_update_title_extra;
         let mut repaint = false;
-        for index in 0..self.contexts.len() {
+        let range = if only_current {
+            self.current_index..self.current_index + 1
+        } else {
+            0..self.contexts.len()
+        };
+        for index in range {
             let context = self.contexts[index].current_mut();
-            repaint |=
-                Self::refresh_item_title(&template, should_update_title_extra, context);
+            context.title_dirty = false;
+            repaint |= Self::refresh_item_title(&template, context, None);
         }
         self.sync_window_title();
         repaint
@@ -921,6 +926,12 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     /// can never be left showing a pane that is not on screen.
     fn sync_current_route(&mut self) {
         self.current_route = self.current().route_id;
+        if self.current().title_dirty {
+            let template = self.config.title.content.clone();
+            let context = self.contexts[self.current_index].current_mut();
+            context.title_dirty = false;
+            Self::refresh_item_title(&template, context, None);
+        }
         self.sync_window_title();
     }
 
@@ -1212,7 +1223,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             is_native: config.navigation.is_native(),
             // When navigation is collapsed and does not contain any color rule
             // does not make sense fetch for foreground process names
-            should_update_title_extra: !config.navigation.color_automation.is_empty(),
             split_color: config.colors.split,
             split_active_color: config.colors.split_active,
             panel: config.panel,

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -26,7 +26,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 // Global atomic counter for generating unique route IDs
 static ROUTE_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
@@ -127,6 +127,11 @@ pub struct ContextManagerConfig {
 
 const DEFAULT_CONTEXT_CAPACITY: usize = 28;
 
+/// Floor between two render-time title refreshes: process inspection
+/// stays rate-limited (the point of the old 2s poll) without any
+/// standing timer waking an idle terminal.
+pub const TITLE_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+
 pub struct ContextManager<T: EventListener> {
     contexts: SmallVec<[ContextGrid<T>; DEFAULT_CONTEXT_CAPACITY]>,
     current_index: usize,
@@ -135,6 +140,7 @@ pub struct ContextManager<T: EventListener> {
     capacity: usize,
     event_proxy: T,
     window_id: WindowId,
+    last_title_refresh: Instant,
     pub config: ContextManagerConfig,
 }
 
@@ -421,6 +427,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             capacity: DEFAULT_CONTEXT_CAPACITY,
             event_proxy,
             window_id,
+            last_title_refresh: Instant::now(),
             config: ctx_config,
         })
     }
@@ -458,6 +465,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             capacity,
             event_proxy,
             window_id,
+            last_title_refresh: Instant::now(),
             config,
         })
     }
@@ -833,15 +841,16 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         displayed_changed
     }
 
-    /// A pane's OSC 0/2 title changed. A DISPLAYED pane (its tab's
-    /// current) re-renders immediately with the event's own title
-    /// string, so the common `{{ title }}` render never locks the
-    /// terminal; a hidden pane is only marked dirty (one flag write,
-    /// no locks, no render) and renders when it surfaces, so a
-    /// background split streaming titles costs nothing visible. One
-    /// route scan serves every decision. Returns whether the strip
-    /// must repaint.
-    pub fn on_title_change(&mut self, route_id: usize, raw_title: &str) -> bool {
+    /// A pane's title data changed: an OSC 0/2 title (carried in
+    /// `raw_title`, so the common `{{ title }}` render never locks the
+    /// terminal) or an OSC 7 working directory (`raw_title` None: the
+    /// render re-reads the stored directory). A DISPLAYED pane (its
+    /// tab's current) re-renders immediately; a hidden pane is only
+    /// marked dirty (one flag write, no locks, no render) and renders
+    /// when it surfaces, so a background split streaming titles costs
+    /// nothing visible. One route scan serves every decision. Returns
+    /// whether the strip must repaint.
+    pub fn on_title_change(&mut self, route_id: usize, raw_title: Option<&str>) -> bool {
         let Some(tab_index) = self.tab_index_for_route(route_id) else {
             return false;
         };
@@ -854,21 +863,31 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         let template = self.config.title.content.clone();
         let context = self.contexts[tab_index].current_mut();
         context.title_dirty = false;
-        Self::refresh_item_title(&template, context, Some(raw_title))
+        Self::refresh_item_title(&template, context, raw_title)
     }
 
-    /// Recompute every tab's title on the poll tick. This is what picks up
-    /// the variables no PTY event announces (`{{program}}`, paths); OSC
-    /// title changes arrive immediately via `on_title_change`.
-    /// The titles are committed HERE; the chrome repaint rides the
-    /// returned flag, and one unconditional titlebar poke per tick
-    /// makes the native title CONVERGE on the displayed text (the poke
-    /// is payload-less and deduped at the sink, so a tick that changed
-    /// nothing costs one no-op event).
-    /// `only_current` restricts the walk to the displayed tab: with the
-    /// tab strip absent (navigation disabled) background tabs' titles
-    /// render nowhere, so polling them buys nothing.
+    /// Time left before the render-time refresh may run again: `None`
+    /// means due now. The caller schedules a single trailing shot for
+    /// the `Some` case so the last change before an idle period still
+    /// lands (a pure floor would hold it stale until the next render).
+    pub fn title_refresh_due(&self) -> Option<Duration> {
+        TITLE_REFRESH_INTERVAL.checked_sub(self.last_title_refresh.elapsed())
+    }
+
+    /// Recompute tab titles for the variables no PTY event announces
+    /// (`{{program}}`, path fallbacks); OSC title and OSC 7 changes
+    /// arrive immediately via `on_title_change`. Runs opportunistically
+    /// at render time behind `title_refresh_due` (plus one trailing
+    /// shot), never on a standing timer, so an idle terminal does zero
+    /// title work. The chrome repaint rides the returned flag, and one
+    /// unconditional titlebar poke per run makes the native title
+    /// CONVERGE on the displayed text (the poke is payload-less and
+    /// deduped at the sink, so a run that changed nothing costs one
+    /// no-op event). `only_current` restricts the walk to the displayed
+    /// tab: with the tab strip absent (navigation disabled) background
+    /// tabs' titles render nowhere, so refreshing them buys nothing.
     pub fn update_titles(&mut self, only_current: bool) -> bool {
+        self.last_title_refresh = Instant::now();
         let template = self.config.title.content.clone();
         let mut repaint = false;
         let range = if only_current {

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -1572,6 +1572,54 @@ pub mod test {
         assert!(!cm.bell(2));
     }
 
+    #[test]
+    fn update_titles_only_current_leaves_other_tabs_dirty() {
+        let mut cm =
+            ContextManager::start_with_capacity(5, VoidListener {}, WindowId::from(0))
+                .unwrap();
+        cm.add_context(false, 0);
+        cm.config.title.content = "{{ columns }}".to_string();
+
+        cm.mark_all_titles_dirty();
+        assert!(cm.contexts[0].current().title_dirty);
+        assert!(cm.contexts[1].current().title_dirty);
+
+        // A current-only walk (tab strip absent) must not silently
+        // clear panes it never re-rendered.
+        assert!(cm.update_titles(true));
+        assert!(!cm.contexts[0].current().title_dirty);
+        assert!(cm.contexts[1].current().title_dirty);
+        let columns = cm.contexts[0].current().dimension.columns.to_string();
+        assert_eq!(cm.contexts[0].current().title.content, columns);
+
+        // Surfacing the stale tab re-renders it via sync_current_route.
+        cm.set_current(1);
+        assert!(!cm.contexts[1].current().title_dirty);
+        let columns = cm.contexts[1].current().dimension.columns.to_string();
+        assert_eq!(cm.contexts[1].current().title.content, columns);
+    }
+
+    #[test]
+    fn on_title_change_renders_displayed_pane_from_event_string() {
+        let mut cm =
+            ContextManager::start_with_capacity(5, VoidListener {}, WindowId::from(0))
+                .unwrap();
+        cm.add_context(false, 0);
+        cm.config.title.content = "{{ title }}".to_string();
+
+        let background_route = cm.contexts[1].current().route_id;
+        cm.contexts[1].current_mut().title_dirty = true;
+        assert!(cm.on_title_change(background_route, Some("hello")));
+        assert_eq!(cm.contexts[1].current().title.content, "hello");
+        assert!(!cm.contexts[1].current().title_dirty);
+
+        // The same title again changes nothing: no repaint requested.
+        assert!(!cm.on_title_change(background_route, Some("hello")));
+
+        // Unknown routes (already-closed panes) are a no-op.
+        assert!(!cm.on_title_change(usize::MAX, Some("x")));
+    }
+
     fn set_tab_title(cm: &mut ContextManager<VoidListener>, index: usize, content: &str) {
         cm.contexts[index].current_mut().title.content = content.to_string();
     }

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -471,11 +471,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         // tab (`tmux new -X` SIGHUPs a shell the user is not even
         // looking at), so the search covers every panel of every tab
         // rather than assuming the focused one.
-        let Some(tab_index) = self
-            .contexts
-            .iter_mut()
-            .position(|grid| grid.get_by_route_id(route_id).is_some())
-        else {
+        let Some(tab_index) = self.tab_index_for_route(route_id) else {
             return self.contexts.is_empty();
         };
 
@@ -750,26 +746,42 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
-    /// A pane rang the bell. Flags its tab so the strip can surface it;
-    /// the focused tab is skipped since the user is already looking at it.
-    /// The ringing pane can live in any tab (background split of a
-    /// background tab included), so every tab is searched.
+    /// Index of the tab containing `route_id`'s pane. Per-route state
+    /// can live ANYWHERE (a background split of a background tab
+    /// included), so the search covers every panel of every tab.
     #[inline]
-    pub fn ring_bell(&mut self, route_id: usize) -> bool {
-        let Some(tab_index) = self
-            .contexts
+    pub fn tab_index_for_route(&mut self, route_id: usize) -> Option<usize> {
+        self.contexts
             .iter_mut()
             .position(|grid| grid.get_by_route_id(route_id).is_some())
-        else {
+    }
+
+    /// Whether `route_id` is the pane its tab currently displays: the
+    /// pane whose title the tab strip shows for that tab. Chrome only
+    /// repaints for these; a hidden split's state changes display
+    /// nothing until it surfaces.
+    #[inline]
+    pub fn is_displayed_pane(&mut self, route_id: usize) -> bool {
+        self.tab_index_for_route(route_id)
+            .is_some_and(|index| self.contexts[index].current().route_id == route_id)
+    }
+
+    /// A pane rang the bell. Flags its tab so the strip can surface it.
+    /// The current tab is skipped only while the window has focus: the
+    /// user is already looking at it then, but a ring in the visible
+    /// tab of an UNFOCUSED window would otherwise leave no trace at
+    /// all. Edge-triggered: a BEL flood marks once and repaints once.
+    #[inline]
+    pub fn ring_bell(&mut self, route_id: usize, window_focused: bool) -> bool {
+        let Some(tab_index) = self.tab_index_for_route(route_id) else {
             return false;
         };
 
-        if tab_index == self.current_index {
+        if window_focused && tab_index == self.current_index {
             return false;
         }
 
-        self.contexts[tab_index].bell = true;
-        true
+        !std::mem::replace(&mut self.contexts[tab_index].bell, true)
     }
 
     #[inline]
@@ -797,6 +809,30 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
+    /// Re-render one pane's title into its `ContextTitle`. The extra
+    /// (foreground program, for `{{program}}` fallbacks and
+    /// color-automation) refreshes even when the rendered content is
+    /// unchanged: it tracks the running program, which changes without
+    /// any title event. Returns whether anything changed.
+    fn refresh_item_title(
+        template: &str,
+        should_update_title_extra: bool,
+        context: &mut Context<T>,
+    ) -> bool {
+        let content = update_title(template, context);
+        let extra = if should_update_title_extra {
+            create_title_extra_from_context(context)
+        } else {
+            None
+        };
+        let title = ContextTitle { content, extra };
+        if title == context.title {
+            return false;
+        }
+        context.title = title;
+        true
+    }
+
     /// Recompute the tab title for a single pane, used when its terminal
     /// title changed (OSC 0/2). The poll below only paces the variables
     /// that have no event to hang off (`{{program}}`, paths), so waiting
@@ -808,32 +844,26 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         let Some(item) = self.get_by_route_id(route_id) else {
             return false;
         };
-
-        let content = update_title(&template, item.context());
-        if content == item.context().title.content {
-            return false;
-        }
-
-        let extra = if should_update_title_extra {
-            create_title_extra_from_context(item.context())
-        } else {
-            None
-        };
-        item.context_mut().title = ContextTitle { content, extra };
-        true
+        Self::refresh_item_title(&template, should_update_title_extra, item.context_mut())
     }
 
     /// Recompute every tab's title on the poll tick. This is what picks up
     /// the variables no PTY event announces (`{{program}}`, paths); OSC
     /// title changes arrive immediately via `update_title_for_route`.
-    /// Returns whether any tab's title changed, so the caller can repaint.
+    /// A `Title` event goes out only for tabs that changed (the handler
+    /// updates the OS titlebar); the repaint rides the returned flag.
     pub fn update_titles(&mut self) -> bool {
+        let template = self.config.title.content.clone();
+        let should_update_title_extra = self.config.should_update_title_extra;
         let mut changed = false;
         for index in 0..self.contexts.len() {
-            let route_id = self.contexts[index].current().route_id;
-            changed |= self.update_title_for_route(route_id);
-
-            let content = self.contexts[index].current().title.content.clone();
+            let context = self.contexts[index].current_mut();
+            if !Self::refresh_item_title(&template, should_update_title_extra, context) {
+                continue;
+            }
+            changed = true;
+            let route_id = context.route_id;
+            let content = context.title.content.clone();
             self.event_proxy
                 .send_event(RioEvent::Title(route_id, content), self.window_id);
         }
@@ -1418,15 +1448,26 @@ pub mod test {
         let background_route = cm.contexts[2].current().route_id;
         let focused_route = cm.contexts[0].current().route_id;
 
-        assert!(cm.ring_bell(background_route));
+        assert!(cm.ring_bell(background_route, true));
         assert!(cm.bell(2));
 
-        // The focused tab is never marked: the user is looking at it.
-        assert!(!cm.ring_bell(focused_route));
+        // Edge-triggered: a BEL flood repaints once, not per byte.
+        assert!(!cm.ring_bell(background_route, true));
+        assert!(cm.bell(2));
+
+        // The current tab of a FOCUSED window is never marked: the
+        // user is looking at it.
+        assert!(!cm.ring_bell(focused_route, true));
         assert!(!cm.bell(0));
 
+        // The current tab of an UNFOCUSED window is marked; nothing
+        // else records the ring.
+        assert!(cm.ring_bell(focused_route, false));
+        assert!(cm.bell(0));
+        cm.contexts[0].bell = false;
+
         // Unknown routes (already-closed panes) are a no-op.
-        assert!(!cm.ring_bell(usize::MAX));
+        assert!(!cm.ring_bell(usize::MAX, true));
 
         // Focusing the tab drops the mark on the next rendered frame.
         cm.set_current(2);

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -482,6 +482,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             self.contexts[tab_index].remove_by_route(route_id, sugarloaf);
             if tab_index == self.current_index {
                 self.current_route = self.contexts[tab_index].current().route_id;
+                self.sync_window_title();
             }
             return false;
         }
@@ -582,19 +583,19 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     #[inline]
     pub fn select_next_split(&mut self) {
         self.contexts[self.current_index].select_next_split();
-        self.current_route = self.current().route_id;
+        self.sync_current_route();
     }
 
     #[inline]
     pub fn select_prev_split(&mut self) {
         self.contexts[self.current_index].select_prev_split();
-        self.current_route = self.current().route_id;
+        self.sync_current_route();
     }
 
     #[inline]
     pub fn switch_to_next_split_or_tab(&mut self) {
         if self.contexts[self.current_index].select_next_split_no_loop() {
-            self.current_route = self.current().route_id;
+            self.sync_current_route();
             return;
         }
         self.switch_to_next();
@@ -603,13 +604,13 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         if let Some(root) = current_tab.root {
             current_tab.current = root;
         }
-        self.current_route = self.current().route_id;
+        self.sync_current_route();
     }
 
     #[inline]
     pub fn switch_to_prev_split_or_tab(&mut self) {
         if self.contexts[self.current_index].select_prev_split_no_loop() {
-            self.current_route = self.current().route_id;
+            self.sync_current_route();
             return;
         }
         self.switch_to_prev();
@@ -619,7 +620,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         if let Some(&last_key) = ordered_keys.last() {
             current_tab.current = last_key;
         }
-        self.current_route = self.current().route_id;
+        self.sync_current_route();
     }
 
     #[inline]
@@ -707,7 +708,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
 
     #[inline]
     pub fn select_route_from_current_grid(&mut self) {
-        self.current_route = self.current().route_id;
+        self.sync_current_route();
     }
 
     #[inline]
@@ -811,24 +812,19 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
-    /// Re-render one pane's title into its `ContextTitle`. The extra
-    /// (foreground program, for `{{program}}` fallbacks and
-    /// color-automation) refreshes even when the rendered content is
-    /// unchanged: it tracks the running program, which changes without
-    /// any title event. Returns whether anything changed.
     /// Re-render one pane's title. The extra tracks the running
     /// program, which changes without any title event, so it refreshes
     /// even when the rendered content is unchanged; the fetched program
     /// is reused for the template render, so a refresh runs the process
-    /// inspection at most once. Returns
-    /// `(content_changed, displayed_changed)`: the strip shows the
-    /// content, falling back to the program only when the content is
-    /// empty, so extra-only churn repaints nothing.
+    /// inspection at most once. Returns whether the DISPLAYED text
+    /// changed: the strip shows the content, falling back to the
+    /// program only when the content is empty, so extra-only churn
+    /// repaints nothing.
     fn refresh_item_title(
         template: &str,
         should_update_title_extra: bool,
         context: &mut Context<T>,
-    ) -> (bool, bool) {
+    ) -> bool {
         let extra = if should_update_title_extra {
             create_title_extra_from_context(context)
         } else {
@@ -842,23 +838,23 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         let content_changed = content != context.title.content;
         let extra_changed = extra != context.title.extra;
         if !content_changed && !extra_changed {
-            return (false, false);
+            return false;
         }
         let displayed_changed = content_changed || content.is_empty();
         context.title = ContextTitle { content, extra };
-        (content_changed, displayed_changed)
+        displayed_changed
     }
 
     /// Recompute the tab title for a single pane, used when its terminal
     /// title changed (OSC 0/2). The poll below only paces the variables
     /// that have no event to hang off (`{{program}}`, paths), so waiting
     /// on it made a title the PTY already told us about show up seconds
-    /// late. Returns `(content_changed, displayed_changed)`.
-    pub fn update_title_for_route(&mut self, route_id: usize) -> (bool, bool) {
+    /// late. Returns whether the displayed text changed.
+    pub fn update_title_for_route(&mut self, route_id: usize) -> bool {
         let template = self.config.title.content.clone();
         let should_update_title_extra = self.config.should_update_title_extra;
         let Some(item) = self.get_by_route_id(route_id) else {
-            return (false, false);
+            return false;
         };
         Self::refresh_item_title(&template, should_update_title_extra, item.context_mut())
     }
@@ -866,40 +862,66 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     /// Recompute every tab's title on the poll tick. This is what picks up
     /// the variables no PTY event announces (`{{program}}`, paths); OSC
     /// title changes arrive immediately via `update_title_for_route`.
-    /// The titles are committed HERE: the only event is a `WindowTitle`
-    /// carrying the current tab's already-rendered content when it
-    /// changed (the native titlebar is the one consumer outside this
-    /// struct), so nothing round-trips back into a second render. The
-    /// chrome repaint rides the returned flag.
+    /// The titles are committed HERE; the chrome repaint rides the
+    /// returned flag, and one unconditional titlebar poke per tick
+    /// makes the native title CONVERGE on the displayed text (the poke
+    /// is payload-less and deduped at the sink, so a tick that changed
+    /// nothing costs one no-op event).
     pub fn update_titles(&mut self) -> bool {
         let template = self.config.title.content.clone();
         let should_update_title_extra = self.config.should_update_title_extra;
         let mut repaint = false;
         for index in 0..self.contexts.len() {
-            let current_index = self.current_index;
             let context = self.contexts[index].current_mut();
-            let (content_changed, displayed_changed) =
+            repaint |=
                 Self::refresh_item_title(&template, should_update_title_extra, context);
-            repaint |= displayed_changed;
-            if content_changed && index == current_index {
-                let content = context.title.content.clone();
-                self.event_proxy
-                    .send_event(RioEvent::WindowTitle(content), self.window_id);
-            }
         }
+        self.sync_window_title();
         repaint
     }
 
-    /// Push the newly displayed pane's rendered title to the native
-    /// titlebar. Runs on every current-tab change: the titlebar only
-    /// otherwise updates when a title CHANGES, so switching to a tab
-    /// with a stable title would leave the previous tab's name up
-    /// forever.
+    /// The title the strip displays for `index`'s tab: the user rename,
+    /// else the rendered content, else the foreground program, else
+    /// "~". The native titlebar reads the same chain, so the two can
+    /// never disagree.
+    pub fn displayed_title_for_tab(&self, index: usize) -> String {
+        if let Some(custom) = self.custom_title(index) {
+            return custom.to_string();
+        }
+        if let Some(title) = self.title(index) {
+            if !title.content.is_empty() {
+                return title.content.clone();
+            }
+            if let Some(ref extra) = title.extra {
+                if !extra.program.is_empty() {
+                    return extra.program.clone();
+                }
+            }
+        }
+        String::from("~")
+    }
+
+    #[inline]
+    pub fn displayed_title_for_current_tab(&self) -> String {
+        self.displayed_title_for_tab(self.current_index)
+    }
+
+    /// Ask the event loop to refresh the native titlebar. Payload-less
+    /// on purpose: the handler re-reads the displayed title at handling
+    /// time, so a queued poke can never overwrite a newer title with a
+    /// stale snapshot, and redundant pokes dedupe at the sink.
     fn sync_window_title(&mut self) {
-        self.event_proxy.send_event(
-            RioEvent::WindowTitle(self.current().title.content.clone()),
-            self.window_id,
-        );
+        self.event_proxy
+            .send_event(RioEvent::SyncWindowTitle, self.window_id);
+    }
+
+    /// Point `current_route` at the pane the user now sees and poke the
+    /// titlebar. Every displayed-pane change (tab switch, split
+    /// selection, split death, new splits) funnels here so the titlebar
+    /// can never be left showing a pane that is not on screen.
+    fn sync_current_route(&mut self) {
+        self.current_route = self.current().route_id;
+        self.sync_window_title();
     }
 
     #[inline]
@@ -938,6 +960,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     pub fn remove_current_grid(&mut self, sugarloaf: &mut Sugarloaf) {
         self.contexts[self.current_index].remove_current(sugarloaf);
         self.current_route = self.contexts[self.current_index].current().route_id;
+        self.sync_window_title();
     }
 
     #[inline]
@@ -969,8 +992,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     pub fn set_current(&mut self, context_id: usize) {
         if context_id < self.contexts.len() {
             self.current_index = context_id;
-            self.current_route = self.current().route_id;
-            self.sync_window_title();
+            self.sync_current_route();
         }
     }
 
@@ -1040,8 +1062,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             self.current_index += 1;
         }
 
-        self.current_route = self.current().route_id;
-        self.sync_window_title();
+        self.sync_current_route();
     }
 
     #[inline]
@@ -1058,8 +1079,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             self.current_index -= 1;
         }
 
-        self.current_route = self.current().route_id;
-        self.sync_window_title();
+        self.sync_current_route();
     }
 
     #[inline]
@@ -1158,6 +1178,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                 }
 
                 self.current_route = new_route_id;
+                self.sync_window_title();
             }
             Err(..) => {
                 tracing::error!("not able to create a new context");
@@ -1221,6 +1242,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                 }
 
                 self.current_route = new_route_id;
+                self.sync_window_title();
             }
             Err(..) => {
                 tracing::error!("not able to create a new context");
@@ -1297,8 +1319,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                     ));
                     if redirect {
                         self.current_index = last_index;
-                        self.current_route = self.current().route_id;
-                        self.sync_window_title();
+                        self.sync_current_route();
                     }
                 }
                 Err(..) => {

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -2,9 +2,7 @@ pub mod renderable;
 pub mod title;
 
 use crate::ansi::CursorShape;
-use crate::context::title::{
-    create_title_extra_from_context, update_title, ContextTitle,
-};
+use crate::context::title::{update_title, ContextTitle};
 use crate::event::sync::FairMutex;
 use crate::event::{Msg, RioEvent};
 pub use crate::layout::{ContextDimension, ContextGrid, ContextGridItem};
@@ -26,7 +24,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 // Global atomic counter for generating unique route IDs
 static ROUTE_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
@@ -59,6 +57,11 @@ pub struct Context<T: EventListener> {
     /// An OSC title change arrived while this pane was hidden: the
     /// render was skipped and must run when the pane surfaces.
     pub title_dirty: bool,
+    /// Display name of the command this pane spawned (the configured
+    /// shell or program), fixed for the pane's lifetime. Fills
+    /// `{{ program }}` and the empty-title strip fallback without ever
+    /// inspecting the foreground process.
+    pub spawned_program: String,
     _io_thread: Option<JoinHandle<(Machine<teletypewriter::Pty, T>, performer::State)>>,
 }
 
@@ -127,11 +130,6 @@ pub struct ContextManagerConfig {
 
 const DEFAULT_CONTEXT_CAPACITY: usize = 28;
 
-/// Floor between two render-time title refreshes: process inspection
-/// stays rate-limited (the point of the old 2s poll) without any
-/// standing timer waking an idle terminal.
-pub const TITLE_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
-
 pub struct ContextManager<T: EventListener> {
     contexts: SmallVec<[ContextGrid<T>; DEFAULT_CONTEXT_CAPACITY]>,
     current_index: usize,
@@ -140,8 +138,30 @@ pub struct ContextManager<T: EventListener> {
     capacity: usize,
     event_proxy: T,
     window_id: WindowId,
-    last_title_refresh: Instant,
     pub config: ContextManagerConfig,
+}
+
+/// Display name for the command a pane spawns: the configured program,
+/// else the user's shell (what the PTY spawn itself falls back to),
+/// reduced to its basename.
+fn spawned_program_name(config: &ContextManagerConfig) -> String {
+    let program = match config.shell.program.as_deref() {
+        Some(program) if !program.is_empty() => program.to_string(),
+        _ => {
+            #[cfg(unix)]
+            {
+                std::env::var("SHELL").unwrap_or_default()
+            }
+            #[cfg(not(unix))]
+            {
+                String::from("powershell")
+            }
+        }
+    };
+    std::path::Path::new(&program)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or(program)
 }
 
 pub fn create_dead_context<T: rio_backend::event::EventListener>(
@@ -176,6 +196,7 @@ pub fn create_dead_context<T: rio_backend::event::EventListener>(
         dimension,
         title: ContextTitle::default(),
         title_dirty: false,
+        spawned_program: String::new(),
         _io_thread: None,
     }
 }
@@ -337,7 +358,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
 
         let messenger = Messenger::new(channel);
 
-        Ok(Context {
+        let mut context = Context {
             route_id,
             #[cfg(not(target_os = "windows"))]
             main_fd,
@@ -350,8 +371,13 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             dimension,
             title: ContextTitle::default(),
             title_dirty: false,
+            spawned_program: spawned_program_name(config),
             _io_thread: io_thread,
-        })
+        };
+        context.title = ContextTitle {
+            content: update_title(&config.title.content, &context, None),
+        };
+        Ok(context)
     }
 
     #[inline]
@@ -427,7 +453,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             capacity: DEFAULT_CONTEXT_CAPACITY,
             event_proxy,
             window_id,
-            last_title_refresh: Instant::now(),
             config: ctx_config,
         })
     }
@@ -465,7 +490,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             capacity,
             event_proxy,
             window_id,
-            last_title_refresh: Instant::now(),
             config,
         })
     }
@@ -728,7 +752,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         self.contexts.len()
     }
 
-    #[inline]
+    #[cfg(test)]
     pub fn title(&self, index: usize) -> Option<&ContextTitle> {
         self.contexts.get(index).map(|grid| &grid.current().title)
     }
@@ -814,31 +838,21 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
-    /// Re-render one pane's title. The extra (foreground program) is
-    /// fetched exactly when its one consumer needs it: the strip falls
-    /// back to the program only for an EMPTY rendered content, so a
-    /// pane with any content pays no process inspection at all (the
-    /// old coupling keyed this on `navigation.color_automation`, which
-    /// nothing consumes). Returns whether the displayed text changed.
+    /// Re-render one pane's title. Returns whether the displayed text
+    /// changed (the empty-content fallback is the pane's static
+    /// spawned program, so displayed text changes exactly when the
+    /// content does).
     fn refresh_item_title(
         template: &str,
         context: &mut Context<T>,
         prefetched_title: Option<&str>,
     ) -> bool {
         let content = update_title(template, context, prefetched_title);
-        let extra = if content.is_empty() {
-            create_title_extra_from_context(context)
-        } else {
-            None
-        };
-        let content_changed = content != context.title.content;
-        let extra_changed = extra != context.title.extra;
-        if !content_changed && !extra_changed {
+        if content == context.title.content {
             return false;
         }
-        let displayed_changed = content_changed || content.is_empty();
-        context.title = ContextTitle { content, extra };
-        displayed_changed
+        context.title = ContextTitle { content };
+        true
     }
 
     /// A pane's title data changed: an OSC 0/2 title (carried in
@@ -866,28 +880,18 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         Self::refresh_item_title(&template, context, raw_title)
     }
 
-    /// Time left before the render-time refresh may run again: `None`
-    /// means due now. The caller schedules a single trailing shot for
-    /// the `Some` case so the last change before an idle period still
-    /// lands (a pure floor would hold it stale until the next render).
-    pub fn title_refresh_due(&self) -> Option<Duration> {
-        TITLE_REFRESH_INTERVAL.checked_sub(self.last_title_refresh.elapsed())
-    }
-
-    /// Recompute tab titles for the variables no PTY event announces
-    /// (`{{program}}`, path fallbacks); OSC title and OSC 7 changes
-    /// arrive immediately via `on_title_change`. Runs opportunistically
-    /// at render time behind `title_refresh_due` (plus one trailing
-    /// shot), never on a standing timer, so an idle terminal does zero
-    /// title work. The chrome repaint rides the returned flag, and one
-    /// unconditional titlebar poke per run makes the native title
-    /// CONVERGE on the displayed text (the poke is payload-less and
-    /// deduped at the sink, so a run that changed nothing costs one
-    /// no-op event). `only_current` restricts the walk to the displayed
-    /// tab: with the tab strip absent (navigation disabled) background
-    /// tabs' titles render nowhere, so refreshing them buys nothing.
+    /// Re-render tab titles from local state: a config reload can
+    /// change the template, and a resize changes `{{columns}}`/
+    /// `{{lines}}`. OSC title and OSC 7 changes arrive via
+    /// `on_title_change` instead; nothing calls this on a timer. The
+    /// chrome repaint rides the returned flag, and one unconditional
+    /// titlebar poke per run makes the native title CONVERGE on the
+    /// displayed text (the poke is payload-less and deduped at the
+    /// sink, so a run that changed nothing costs one no-op event).
+    /// `only_current` restricts the walk to the displayed tab: with
+    /// the tab strip absent (navigation disabled) background tabs'
+    /// titles render nowhere, so refreshing them buys nothing.
     pub fn update_titles(&mut self, only_current: bool) -> bool {
-        self.last_title_refresh = Instant::now();
         let template = self.config.title.content.clone();
         let mut repaint = false;
         let range = if only_current {
@@ -912,14 +916,13 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         if let Some(custom) = self.custom_title(index) {
             return custom.to_string();
         }
-        if let Some(title) = self.title(index) {
-            if !title.content.is_empty() {
-                return title.content.clone();
+        if let Some(grid) = self.contexts.get(index) {
+            let context = grid.current();
+            if !context.title.content.is_empty() {
+                return context.title.content.clone();
             }
-            if let Some(ref extra) = title.extra {
-                if !extra.program.is_empty() {
-                    return extra.program.clone();
-                }
+            if !context.spawned_program.is_empty() {
+                return context.spawned_program.clone();
             }
         }
         String::from("~")

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -150,7 +150,7 @@ fn spawned_program_name(config: &ContextManagerConfig) -> String {
         _ => {
             #[cfg(unix)]
             {
-                std::env::var("SHELL").unwrap_or_default()
+                teletypewriter::default_shell_program()
             }
             #[cfg(not(unix))]
             {
@@ -440,7 +440,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             }
         }
 
-        Ok(ContextManager {
+        let mut manager = ContextManager {
             current_index: 0,
             current_route: 0,
             contexts: smallvec![ContextGrid::new(
@@ -454,7 +454,12 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             event_proxy,
             window_id,
             config: ctx_config,
-        })
+        };
+        // The native titlebar starts as the placeholder; one poke makes
+        // it converge on the displayed title even for shells that never
+        // emit an OSC title or OSC 7.
+        manager.sync_window_title();
+        Ok(manager)
     }
 
     #[cfg(test)]
@@ -517,8 +522,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         if self.contexts[tab_index].len() > 1 {
             self.contexts[tab_index].remove_by_route(route_id, sugarloaf);
             if tab_index == self.current_index {
-                self.current_route = self.contexts[tab_index].current().route_id;
-                self.sync_window_title();
+                self.sync_current_route();
             }
             return false;
         }
@@ -765,9 +769,22 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     }
 
     #[inline]
+    /// A rename changes what `displayed_title_for_tab` returns, so the
+    /// native titlebar gets the same convergence poke every other
+    /// displayed-title mutation sends.
     pub fn set_custom_title(&mut self, index: usize, title: Option<String>) {
         if let Some(grid) = self.contexts.get_mut(index) {
             grid.custom_title = title;
+        }
+        self.sync_window_title();
+    }
+
+    /// Drop every tab's bell mark, used when the indicator is disabled
+    /// by a live config reload: the ring-time gate stops new marks but
+    /// cannot retract ones already set.
+    pub fn clear_all_bells(&mut self) {
+        for grid in self.contexts.iter_mut() {
+            grid.bell = false;
         }
     }
 
@@ -1004,8 +1021,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     #[inline]
     pub fn remove_current_grid(&mut self, sugarloaf: &mut Sugarloaf) {
         self.contexts[self.current_index].remove_current(sugarloaf);
-        self.current_route = self.contexts[self.current_index].current().route_id;
-        self.sync_window_title();
+        self.sync_current_route();
     }
 
     #[inline]

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -789,8 +789,10 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         self.contexts.get(index).is_some_and(|grid| grid.bell)
     }
 
-    /// Clears the focused tab's bell flag. Called every frame so the mark
-    /// drops the moment the tab is shown, whatever brought it to the front.
+    /// Clears the focused tab's bell flag. Called every FOCUSED frame so
+    /// the mark drops the moment the tab is shown to the user, whatever
+    /// brought it to the front; an unfocused window still renders on PTY
+    /// damage, and clearing there would wipe a mark nobody has seen yet.
     #[inline]
     pub fn clear_current_bell(&mut self) -> bool {
         let grid = &mut self.contexts[self.current_index];
@@ -814,35 +816,49 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     /// color-automation) refreshes even when the rendered content is
     /// unchanged: it tracks the running program, which changes without
     /// any title event. Returns whether anything changed.
+    /// Re-render one pane's title. The extra tracks the running
+    /// program, which changes without any title event, so it refreshes
+    /// even when the rendered content is unchanged; the fetched program
+    /// is reused for the template render, so a refresh runs the process
+    /// inspection at most once. Returns
+    /// `(content_changed, displayed_changed)`: the strip shows the
+    /// content, falling back to the program only when the content is
+    /// empty, so extra-only churn repaints nothing.
     fn refresh_item_title(
         template: &str,
         should_update_title_extra: bool,
         context: &mut Context<T>,
-    ) -> bool {
-        let content = update_title(template, context);
+    ) -> (bool, bool) {
         let extra = if should_update_title_extra {
             create_title_extra_from_context(context)
         } else {
             None
         };
-        let title = ContextTitle { content, extra };
-        if title == context.title {
-            return false;
+        let content = update_title(
+            template,
+            context,
+            extra.as_ref().map(|e| e.program.as_str()),
+        );
+        let content_changed = content != context.title.content;
+        let extra_changed = extra != context.title.extra;
+        if !content_changed && !extra_changed {
+            return (false, false);
         }
-        context.title = title;
-        true
+        let displayed_changed = content_changed || content.is_empty();
+        context.title = ContextTitle { content, extra };
+        (content_changed, displayed_changed)
     }
 
     /// Recompute the tab title for a single pane, used when its terminal
     /// title changed (OSC 0/2). The poll below only paces the variables
     /// that have no event to hang off (`{{program}}`, paths), so waiting
     /// on it made a title the PTY already told us about show up seconds
-    /// late. Returns whether the tab's title actually changed.
-    pub fn update_title_for_route(&mut self, route_id: usize) -> bool {
+    /// late. Returns `(content_changed, displayed_changed)`.
+    pub fn update_title_for_route(&mut self, route_id: usize) -> (bool, bool) {
         let template = self.config.title.content.clone();
         let should_update_title_extra = self.config.should_update_title_extra;
         let Some(item) = self.get_by_route_id(route_id) else {
-            return false;
+            return (false, false);
         };
         Self::refresh_item_title(&template, should_update_title_extra, item.context_mut())
     }
@@ -850,24 +866,40 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     /// Recompute every tab's title on the poll tick. This is what picks up
     /// the variables no PTY event announces (`{{program}}`, paths); OSC
     /// title changes arrive immediately via `update_title_for_route`.
-    /// A `Title` event goes out only for tabs that changed (the handler
-    /// updates the OS titlebar); the repaint rides the returned flag.
+    /// The titles are committed HERE: the only event is a `WindowTitle`
+    /// carrying the current tab's already-rendered content when it
+    /// changed (the native titlebar is the one consumer outside this
+    /// struct), so nothing round-trips back into a second render. The
+    /// chrome repaint rides the returned flag.
     pub fn update_titles(&mut self) -> bool {
         let template = self.config.title.content.clone();
         let should_update_title_extra = self.config.should_update_title_extra;
-        let mut changed = false;
+        let mut repaint = false;
         for index in 0..self.contexts.len() {
+            let current_index = self.current_index;
             let context = self.contexts[index].current_mut();
-            if !Self::refresh_item_title(&template, should_update_title_extra, context) {
-                continue;
+            let (content_changed, displayed_changed) =
+                Self::refresh_item_title(&template, should_update_title_extra, context);
+            repaint |= displayed_changed;
+            if content_changed && index == current_index {
+                let content = context.title.content.clone();
+                self.event_proxy
+                    .send_event(RioEvent::WindowTitle(content), self.window_id);
             }
-            changed = true;
-            let route_id = context.route_id;
-            let content = context.title.content.clone();
-            self.event_proxy
-                .send_event(RioEvent::Title(route_id, content), self.window_id);
         }
-        changed
+        repaint
+    }
+
+    /// Push the newly displayed pane's rendered title to the native
+    /// titlebar. Runs on every current-tab change: the titlebar only
+    /// otherwise updates when a title CHANGES, so switching to a tab
+    /// with a stable title would leave the previous tab's name up
+    /// forever.
+    fn sync_window_title(&mut self) {
+        self.event_proxy.send_event(
+            RioEvent::WindowTitle(self.current().title.content.clone()),
+            self.window_id,
+        );
     }
 
     #[inline]
@@ -938,6 +970,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         if context_id < self.contexts.len() {
             self.current_index = context_id;
             self.current_route = self.current().route_id;
+            self.sync_window_title();
         }
     }
 
@@ -1008,6 +1041,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
 
         self.current_route = self.current().route_id;
+        self.sync_window_title();
     }
 
     #[inline]
@@ -1025,6 +1059,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
 
         self.current_route = self.current().route_id;
+        self.sync_window_title();
     }
 
     #[inline]
@@ -1263,6 +1298,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                     if redirect {
                         self.current_index = last_index;
                         self.current_route = self.current().route_id;
+                        self.sync_window_title();
                     }
                 }
                 Err(..) => {
@@ -1451,17 +1487,12 @@ pub mod test {
         assert!(cm.ring_bell(background_route, true));
         assert!(cm.bell(2));
 
-        // Edge-triggered: a BEL flood repaints once, not per byte.
         assert!(!cm.ring_bell(background_route, true));
         assert!(cm.bell(2));
 
-        // The current tab of a FOCUSED window is never marked: the
-        // user is looking at it.
         assert!(!cm.ring_bell(focused_route, true));
         assert!(!cm.bell(0));
 
-        // The current tab of an UNFOCUSED window is marked; nothing
-        // else records the ring.
         assert!(cm.ring_bell(focused_route, false));
         assert!(cm.bell(0));
         cm.contexts[0].bell = false;

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -26,7 +26,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 // Global atomic counter for generating unique route IDs
 static ROUTE_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
@@ -134,7 +134,6 @@ pub struct ContextManager<T: EventListener> {
     event_proxy: T,
     window_id: WindowId,
     pub config: ContextManagerConfig,
-    last_title_update: Option<Instant>,
 }
 
 pub fn create_dead_context<T: rio_backend::event::EventListener>(
@@ -419,7 +418,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             event_proxy,
             window_id,
             config: ctx_config,
-            last_title_update: None,
         })
     }
 
@@ -457,7 +455,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             event_proxy,
             window_id,
             config,
-            last_title_update: None,
         })
     }
 
@@ -800,29 +797,47 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         }
     }
 
-    pub fn update_titles(&mut self) {
-        let interval_time = Duration::from_secs(2);
-        if self
-            .last_title_update
-            .map(|i| i.elapsed() > interval_time)
-            .unwrap_or(true)
-        {
-            self.last_title_update = Some(Instant::now());
-            for grid in self.contexts.iter_mut() {
-                let content = update_title(&self.config.title.content, grid.current());
+    /// Recompute the tab title for a single pane, used when its terminal
+    /// title changed (OSC 0/2). The poll below only paces the variables
+    /// that have no event to hang off (`{{program}}`, paths), so waiting
+    /// on it made a title the PTY already told us about show up seconds
+    /// late. Returns whether the tab's title actually changed.
+    pub fn update_title_for_route(&mut self, route_id: usize) -> bool {
+        let template = self.config.title.content.clone();
+        let should_update_title_extra = self.config.should_update_title_extra;
+        let Some(item) = self.get_by_route_id(route_id) else {
+            return false;
+        };
 
-                self.event_proxy
-                    .send_event(RioEvent::Title(content.to_owned()), self.window_id);
-
-                let extra = if self.config.should_update_title_extra {
-                    create_title_extra_from_context(grid.current())
-                } else {
-                    None
-                };
-
-                grid.current_mut().title = ContextTitle { content, extra };
-            }
+        let content = update_title(&template, item.context());
+        if content == item.context().title.content {
+            return false;
         }
+
+        let extra = if should_update_title_extra {
+            create_title_extra_from_context(item.context())
+        } else {
+            None
+        };
+        item.context_mut().title = ContextTitle { content, extra };
+        true
+    }
+
+    /// Recompute every tab's title on the poll tick. This is what picks up
+    /// the variables no PTY event announces (`{{program}}`, paths); OSC
+    /// title changes arrive immediately via `update_title_for_route`.
+    /// Returns whether any tab's title changed, so the caller can repaint.
+    pub fn update_titles(&mut self) -> bool {
+        let mut changed = false;
+        for index in 0..self.contexts.len() {
+            let route_id = self.contexts[index].current().route_id;
+            changed |= self.update_title_for_route(route_id);
+
+            let content = self.contexts[index].current().title.content.clone();
+            self.event_proxy
+                .send_event(RioEvent::Title(route_id, content), self.window_id);
+        }
+        changed
     }
 
     #[inline]

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -891,6 +891,18 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
     /// `only_current` restricts the walk to the displayed tab: with
     /// the tab strip absent (navigation disabled) background tabs'
     /// titles render nowhere, so refreshing them buys nothing.
+    /// Mark every pane's title stale. For changes that affect panes no
+    /// walk re-renders (a resize changing `{{columns}}`, a config
+    /// reload changing the template), hidden splits and unwalked tabs
+    /// re-render lazily when they surface via `sync_current_route`.
+    pub fn mark_all_titles_dirty(&mut self) {
+        for grid in self.contexts.iter_mut() {
+            for item in grid.contexts_mut().values_mut() {
+                item.context_mut().title_dirty = true;
+            }
+        }
+    }
+
     pub fn update_titles(&mut self, only_current: bool) -> bool {
         let template = self.config.title.content.clone();
         let mut repaint = false;

--- a/frontends/rioterm/src/context/title.rs
+++ b/frontends/rioterm/src/context/title.rs
@@ -90,8 +90,11 @@ pub fn update_title<T: rio_backend::event::EventListener>(
 
     let mut new_template = template.to_owned();
 
-    let re = regex::Regex::new(r"\{\{(.*?)\}\}").unwrap();
-    for (to_replace_str, [variable]) in re.captures_iter(template).map(|c| c.extract()) {
+    // Compiled once: titles are now rendered per OSC title change, not on
+    // a 2s poll, so a per-call `Regex::new` would sit in the hot path.
+    static RE: std::sync::LazyLock<regex::Regex> =
+        std::sync::LazyLock::new(|| regex::Regex::new(r"\{\{(.*?)\}\}").unwrap());
+    for (to_replace_str, [variable]) in RE.captures_iter(template).map(|c| c.extract()) {
         let variables = if to_replace_str.contains("||") {
             variable.split("||").collect()
         } else {

--- a/frontends/rioterm/src/context/title.rs
+++ b/frontends/rioterm/src/context/title.rs
@@ -2,57 +2,24 @@ use crate::context::Context;
 use std::path::Path;
 
 #[derive(PartialEq)]
-pub struct ContextTitleExtra {
-    pub program: String,
-}
-
-#[derive(PartialEq)]
 pub struct ContextTitle {
     pub content: String,
-    pub extra: Option<ContextTitleExtra>,
 }
 
 impl Default for ContextTitle {
     fn default() -> Self {
         Self {
             content: String::from("~"),
-            extra: None,
         }
     }
-}
-
-/// Whether title data can change without an announcing PTY event, so
-/// renders must opportunistically refresh it (rate-limited, never on
-/// a standing timer): `{{program}}` has no event at all, and the path
-/// variables fall back to process inspection for shells without OSC 7
-/// integration. A `{{ title }}`-only template stays purely
-/// event-driven and never runs a render-time refresh.
-pub fn needs_title_refresh(config: &rio_backend::config::Config) -> bool {
-    let template = config.title.content.to_lowercase();
-    ["program", "path", "columns", "lines"]
-        .iter()
-        .any(|variable| template.contains(variable))
-}
-
-pub fn create_title_extra_from_context<T: rio_backend::event::EventListener>(
-    context: &Context<T>,
-) -> Option<ContextTitleExtra> {
-    #[cfg(unix)]
-    let program =
-        teletypewriter::foreground_process_name(*context.main_fd, context.shell_pid);
-
-    #[cfg(not(unix))]
-    let program = String::default();
-
-    Some(ContextTitleExtra { program })
 }
 
 // Possible options:
 
 // - `TITLE`: terminal title via OSC sequences for setting terminal title
-// - `PROGRAM`: (e.g `fish`, `zsh`, `bash`, `vim`, etc...)
-// - `ABSOLUTE_PATH`: (e.g `/Users/rapha/Documents/a/rio`)
-// - `RELATIVE_PATH`: (e.g `~/Documents/a/rio` or `…/a/psone/starpsx`)
+// - `PROGRAM`: the command the pane spawned (e.g `fish`, `zsh`, `bash`)
+// - `ABSOLUTE_PATH`: working directory via OSC 7 (e.g `/Users/rapha/Documents/a/rio`)
+// - `RELATIVE_PATH`: OSC 7 directory, home-relative (e.g `~/Documents/a/rio` or `…/a/psone/starpsx`)
 // - `COLUMNS`: current columns
 // - `LINES`: current lines
 
@@ -95,13 +62,15 @@ fn shorten_path(absolute: &str) -> String {
 }
 
 #[inline]
-/// Render the title template. `prefetched_title` reuses the OSC title
-/// string the caller already holds (a `Title` event carries it), so a
-/// `{{ title }}` render off an event never locks the terminal. Every
-/// terminal-derived value is fetched at most once per render, however
-/// many variables reference it: one terminal lock for title and cwd
-/// together, one lazy process-path inspection shared by the path
-/// fallbacks, one lazy process-name inspection for `{{ program }}`.
+/// Render the title template. Every variable is event-known, so this
+/// NEVER inspects the foreground process: `{{ title }}` is OSC 0/2,
+/// the path variables are OSC 7 (empty for shells without
+/// integration), `{{ program }}` is the name of the command the pane
+/// spawned, and columns/lines are the pane's own dimensions.
+/// `prefetched_title` reuses the OSC title string the caller already
+/// holds (a `Title` event carries it), so a `{{ title }}` render off
+/// an event never locks the terminal; otherwise one lock fetches
+/// title and cwd together.
 pub fn update_title<T: rio_backend::event::EventListener>(
     template: &str,
     context: &Context<T>,
@@ -128,15 +97,6 @@ pub fn update_title<T: rio_backend::event::EventListener>(
         } else {
             (prefetched_title.unwrap_or_default().to_string(), None)
         };
-    #[cfg(unix)]
-    let mut process_path: Option<String> = None;
-    #[cfg(unix)]
-    let mut fetch_process_path = || {
-        teletypewriter::foreground_process_path(*context.main_fd, context.shell_pid)
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default()
-    };
-
     // Compiled once: titles are now rendered per OSC title change, not on
     // a 2s poll, so a per-call `Regex::new` would sit in the hot path.
     static RE: std::sync::LazyLock<regex::Regex> =
@@ -185,81 +145,45 @@ pub fn update_title<T: rio_backend::event::EventListener>(
                     }
                 }
                 "program" => {
-                    #[cfg(unix)]
-                    {
-                        let program = teletypewriter::foreground_process_name(
-                            *context.main_fd,
-                            context.shell_pid,
-                        );
+                    new_template =
+                        new_template.replace(to_replace_str, &context.spawned_program);
+                    matched = true;
+                }
+                "absolute_path" => {
+                    let path = current_directory
+                        .as_ref()
+                        .and_then(|d| d.clone().into_os_string().into_string().ok())
+                        .unwrap_or_default();
 
-                        new_template = new_template.replace(to_replace_str, &program);
+                    let is_only_one = variables.len() == 1;
+                    let is_last = i == variables.len() - 1;
+                    if is_only_one || is_last {
+                        new_template = new_template.replace(to_replace_str, &path);
+                        continue;
+                    }
+
+                    if !path.is_empty() {
+                        new_template = new_template.replace(to_replace_str, &path);
                         matched = true;
                     }
                 }
-                "absolute_path" => {
-                    if let Some(current_directory) = &current_directory {
-                        if let Ok(dir_str) =
-                            current_directory.clone().into_os_string().into_string()
-                        {
-                            new_template = new_template.replace(to_replace_str, &dir_str);
-                            matched = true;
-                            continue;
-                        }
-                    }
-
-                    #[cfg(unix)]
-                    {
-                        let path = process_path
-                            .get_or_insert_with(&mut fetch_process_path)
-                            .clone();
-
-                        // In case it has a fallback and path is empty
-                        // or
-                        // In case is the last then we need to erase variables either way
-                        let is_only_one = variables.len() == 1;
-                        let is_last = i == variables.len() - 1;
-                        if is_only_one || is_last {
-                            new_template = new_template.replace(to_replace_str, &path);
-                            continue;
-                        }
-
-                        if !path.is_empty() {
-                            new_template = new_template.replace(to_replace_str, &path);
-                            matched = true;
-                        }
-                    }
-                }
                 "relative_path" => {
-                    if let Some(current_directory) = &current_directory {
-                        if let Ok(dir_str) =
-                            current_directory.clone().into_os_string().into_string()
-                        {
-                            new_template = new_template
-                                .replace(to_replace_str, &shorten_path(&dir_str));
-                            matched = true;
-                            continue;
-                        }
+                    let path = current_directory
+                        .as_ref()
+                        .and_then(|d| d.clone().into_os_string().into_string().ok())
+                        .map(|d| shorten_path(&d))
+                        .unwrap_or_default();
+
+                    let is_only_one = variables.len() == 1;
+                    let is_last = i == variables.len() - 1;
+                    if is_only_one || is_last {
+                        new_template = new_template.replace(to_replace_str, &path);
+                        continue;
                     }
 
-                    #[cfg(unix)]
-                    {
-                        let path = shorten_path(
-                            &process_path
-                                .get_or_insert_with(&mut fetch_process_path)
-                                .clone(),
-                        );
-
-                        let is_only_one = variables.len() == 1;
-                        let is_last = i == variables.len() - 1;
-                        if is_only_one || is_last {
-                            new_template = new_template.replace(to_replace_str, &path);
-                            continue;
-                        }
-
-                        if !path.is_empty() {
-                            new_template = new_template.replace(to_replace_str, &path);
-                            matched = true;
-                        }
+                    if !path.is_empty() {
+                        new_template = new_template.replace(to_replace_str, &path);
+                        matched = true;
                     }
                 }
                 _ => {}

--- a/frontends/rioterm/src/context/title.rs
+++ b/frontends/rioterm/src/context/title.rs
@@ -21,6 +21,20 @@ impl Default for ContextTitle {
     }
 }
 
+/// Whether title data depends on anything no PTY event announces, so
+/// the 2s poll must run: color automation reads the foreground
+/// program, and the program/path/size template variables change with
+/// no escape sequence attached. OSC 0/2 titles arrive as events.
+pub fn needs_title_poll(config: &rio_backend::config::Config) -> bool {
+    if !config.navigation.color_automation.is_empty() {
+        return true;
+    }
+    let template = config.title.content.to_lowercase();
+    ["program", "path", "columns", "lines"]
+        .iter()
+        .any(|variable| template.contains(variable))
+}
+
 pub fn create_title_extra_from_context<T: rio_backend::event::EventListener>(
     context: &Context<T>,
 ) -> Option<ContextTitleExtra> {

--- a/frontends/rioterm/src/context/title.rs
+++ b/frontends/rioterm/src/context/title.rs
@@ -22,13 +22,11 @@ impl Default for ContextTitle {
 }
 
 /// Whether title data depends on anything no PTY event announces, so
-/// the 2s poll must run: color automation reads the foreground
-/// program, and the program/path/size template variables change with
-/// no escape sequence attached. OSC 0/2 titles arrive as events.
+/// the 2s poll must run: the program/path/size template variables
+/// change with no escape sequence attached. OSC 0/2 titles arrive as
+/// events. (`navigation.color_automation` used to force the poll but
+/// nothing outside config parsing consumes it.)
 pub fn needs_title_poll(config: &rio_backend::config::Config) -> bool {
-    if !config.navigation.color_automation.is_empty() {
-        return true;
-    }
     let template = config.title.content.to_lowercase();
     ["program", "path", "columns", "lines"]
         .iter()
@@ -96,19 +94,47 @@ fn shorten_path(absolute: &str) -> String {
 }
 
 #[inline]
-/// Render the title template. `prefetched_program` reuses a foreground
-/// process name the caller already fetched (the extra needs it too),
-/// so one pane refresh never runs the process inspection twice.
+/// Render the title template. `prefetched_title` reuses the OSC title
+/// string the caller already holds (a `Title` event carries it), so a
+/// `{{ title }}` render off an event never locks the terminal. Every
+/// terminal-derived value is fetched at most once per render, however
+/// many variables reference it: one terminal lock for title and cwd
+/// together, one lazy process-path inspection shared by the path
+/// fallbacks, one lazy process-name inspection for `{{ program }}`.
 pub fn update_title<T: rio_backend::event::EventListener>(
     template: &str,
     context: &Context<T>,
-    prefetched_program: Option<&str>,
+    prefetched_title: Option<&str>,
 ) -> String {
     if template.is_empty() {
         return template.to_string();
     }
 
     let mut new_template = template.to_owned();
+    let lowered = template.to_lowercase();
+    let needs_title = lowered.contains("title");
+    let needs_path = lowered.contains("path");
+    let (terminal_title, current_directory) =
+        if (needs_title && prefetched_title.is_none()) || needs_path {
+            let terminal = context.terminal.lock();
+            (
+                match prefetched_title {
+                    Some(title) => title.to_string(),
+                    None => terminal.title.to_string(),
+                },
+                terminal.current_directory.clone(),
+            )
+        } else {
+            (prefetched_title.unwrap_or_default().to_string(), None)
+        };
+    #[cfg(unix)]
+    let mut process_path: Option<String> = None;
+    #[cfg(unix)]
+    let mut fetch_process_path = || {
+        teletypewriter::foreground_process_path(*context.main_fd, context.shell_pid)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default()
+    };
 
     // Compiled once: titles are now rendered per OSC title change, not on
     // a 2s poll, so a per-call `Regex::new` would sit in the hot path.
@@ -140,11 +166,6 @@ pub fn update_title<T: rio_backend::event::EventListener>(
                     matched = true;
                 }
                 "title" => {
-                    let terminal_title = {
-                        let terminal = context.terminal.lock();
-                        terminal.title.to_string()
-                    };
-
                     // In case it has a fallback and title is empty
                     // or
                     // In case is the last then we need to erase variables either way
@@ -165,41 +186,31 @@ pub fn update_title<T: rio_backend::event::EventListener>(
                 "program" => {
                     #[cfg(unix)]
                     {
-                        let program = match prefetched_program {
-                            Some(program) => program.to_string(),
-                            None => teletypewriter::foreground_process_name(
-                                *context.main_fd,
-                                context.shell_pid,
-                            ),
-                        };
+                        let program = teletypewriter::foreground_process_name(
+                            *context.main_fd,
+                            context.shell_pid,
+                        );
 
                         new_template = new_template.replace(to_replace_str, &program);
                         matched = true;
                     }
                 }
                 "absolute_path" => {
-                    {
-                        let terminal = context.terminal.lock();
-                        if let Some(current_directory) = &terminal.current_directory {
-                            if let Ok(dir_str) =
-                                current_directory.clone().into_os_string().into_string()
-                            {
-                                new_template =
-                                    new_template.replace(to_replace_str, &dir_str);
-                                matched = true;
-                                continue;
-                            }
-                        };
+                    if let Some(current_directory) = &current_directory {
+                        if let Ok(dir_str) =
+                            current_directory.clone().into_os_string().into_string()
+                        {
+                            new_template = new_template.replace(to_replace_str, &dir_str);
+                            matched = true;
+                            continue;
+                        }
                     }
 
                     #[cfg(unix)]
                     {
-                        let path = teletypewriter::foreground_process_path(
-                            *context.main_fd,
-                            context.shell_pid,
-                        )
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_default();
+                        let path = process_path
+                            .get_or_insert_with(&mut fetch_process_path)
+                            .clone();
 
                         // In case it has a fallback and path is empty
                         // or
@@ -218,28 +229,24 @@ pub fn update_title<T: rio_backend::event::EventListener>(
                     }
                 }
                 "relative_path" => {
-                    {
-                        let terminal = context.terminal.lock();
-                        if let Some(current_directory) = &terminal.current_directory {
-                            if let Ok(dir_str) =
-                                current_directory.clone().into_os_string().into_string()
-                            {
-                                new_template = new_template
-                                    .replace(to_replace_str, &shorten_path(&dir_str));
-                                matched = true;
-                                continue;
-                            }
-                        };
+                    if let Some(current_directory) = &current_directory {
+                        if let Ok(dir_str) =
+                            current_directory.clone().into_os_string().into_string()
+                        {
+                            new_template = new_template
+                                .replace(to_replace_str, &shorten_path(&dir_str));
+                            matched = true;
+                            continue;
+                        }
                     }
 
                     #[cfg(unix)]
                     {
-                        let path = teletypewriter::foreground_process_path(
-                            *context.main_fd,
-                            context.shell_pid,
-                        )
-                        .map(|p| shorten_path(&p.to_string_lossy()))
-                        .unwrap_or_default();
+                        let path = shorten_path(
+                            &process_path
+                                .get_or_insert_with(&mut fetch_process_path)
+                                .clone(),
+                        );
 
                         let is_only_one = variables.len() == 1;
                         let is_last = i == variables.len() - 1;

--- a/frontends/rioterm/src/context/title.rs
+++ b/frontends/rioterm/src/context/title.rs
@@ -21,12 +21,13 @@ impl Default for ContextTitle {
     }
 }
 
-/// Whether title data depends on anything no PTY event announces, so
-/// the 2s poll must run: the program/path/size template variables
-/// change with no escape sequence attached. OSC 0/2 titles arrive as
-/// events. (`navigation.color_automation` used to force the poll but
-/// nothing outside config parsing consumes it.)
-pub fn needs_title_poll(config: &rio_backend::config::Config) -> bool {
+/// Whether title data can change without an announcing PTY event, so
+/// renders must opportunistically refresh it (rate-limited, never on
+/// a standing timer): `{{program}}` has no event at all, and the path
+/// variables fall back to process inspection for shells without OSC 7
+/// integration. A `{{ title }}`-only template stays purely
+/// event-driven and never runs a render-time refresh.
+pub fn needs_title_refresh(config: &rio_backend::config::Config) -> bool {
     let template = config.title.content.to_lowercase();
     ["program", "path", "columns", "lines"]
         .iter()

--- a/frontends/rioterm/src/context/title.rs
+++ b/frontends/rioterm/src/context/title.rs
@@ -363,6 +363,48 @@ pub mod test {
     }
 
     #[test]
+    fn test_update_title_program_is_spawned_command() {
+        let context_dimension = ContextDimension::build(
+            1200.0,
+            800.0,
+            TextDimensions {
+                scale: 2.,
+                width: 18.,
+                height: 9.,
+            },
+            rio_backend::sugarloaf::layout::CellMetrics {
+                cell_width: 18,
+                cell_height: 9,
+                cell_baseline: 0,
+                face_width: 18.0,
+                face_height: 9.0,
+                face_y: 0.0,
+            },
+            1.0,
+            14.0,
+            Margin::default(),
+        );
+
+        let mut context =
+            create_mock_context(VoidListener {}, WindowId::from(0), 0, context_dimension);
+        context.spawned_program = "fish".to_string();
+
+        assert_eq!(update_title("{{ program }}", &context, None), "fish");
+        assert_eq!(
+            update_title("{{ title || program }}", &context, None),
+            "fish"
+        );
+
+        // Path variables come from OSC 7 alone: without integration
+        // they render empty instead of inspecting the process.
+        assert_eq!(update_title("{{ relative_path }}", &context, None), "");
+        assert_eq!(update_title("{{ absolute_path }}", &context, None), "");
+
+        // A prefetched OSC title renders without touching the terminal.
+        assert_eq!(update_title("{{ title }}", &context, Some("t")), "t");
+    }
+
+    #[test]
     fn test_shorten_path() {
         // Use a path prefix that can't plausibly be $HOME to keep the test
         // deterministic in build sandboxes that set HOME=/tmp or similar.

--- a/frontends/rioterm/src/context/title.rs
+++ b/frontends/rioterm/src/context/title.rs
@@ -82,9 +82,13 @@ fn shorten_path(absolute: &str) -> String {
 }
 
 #[inline]
+/// Render the title template. `prefetched_program` reuses a foreground
+/// process name the caller already fetched (the extra needs it too),
+/// so one pane refresh never runs the process inspection twice.
 pub fn update_title<T: rio_backend::event::EventListener>(
     template: &str,
     context: &Context<T>,
+    prefetched_program: Option<&str>,
 ) -> String {
     if template.is_empty() {
         return template.to_string();
@@ -147,10 +151,13 @@ pub fn update_title<T: rio_backend::event::EventListener>(
                 "program" => {
                     #[cfg(unix)]
                     {
-                        let program = teletypewriter::foreground_process_name(
-                            *context.main_fd,
-                            context.shell_pid,
-                        );
+                        let program = match prefetched_program {
+                            Some(program) => program.to_string(),
+                            None => teletypewriter::foreground_process_name(
+                                *context.main_fd,
+                                context.shell_pid,
+                            ),
+                        };
 
                         new_template = new_template.replace(to_replace_str, &program);
                         matched = true;
@@ -284,25 +291,40 @@ pub mod test {
             rich_text_id,
             context_dimension,
         );
-        assert_eq!(update_title("", &context), String::from(""));
-        assert_eq!(update_title("{{columns}}", &context), String::from("64"));
-        assert_eq!(update_title("{{COLUMNS}}", &context), String::from("64"));
-        assert_eq!(update_title("{{ COLUMNS }}", &context), String::from("64"));
-        assert_eq!(update_title("{{ columns }}", &context), String::from("64"));
+        assert_eq!(update_title("", &context, None), String::from(""));
         assert_eq!(
-            update_title("hello {{ COLUMNS }} AbC", &context),
+            update_title("{{columns}}", &context, None),
+            String::from("64")
+        );
+        assert_eq!(
+            update_title("{{COLUMNS}}", &context, None),
+            String::from("64")
+        );
+        assert_eq!(
+            update_title("{{ COLUMNS }}", &context, None),
+            String::from("64")
+        );
+        assert_eq!(
+            update_title("{{ columns }}", &context, None),
+            String::from("64")
+        );
+        assert_eq!(
+            update_title("hello {{ COLUMNS }} AbC", &context, None),
             String::from("hello 64 AbC")
         );
         assert_eq!(
-            update_title("hello {{ Lines }} AbC", &context),
+            update_title("hello {{ Lines }} AbC", &context, None),
             String::from("hello 84 AbC")
         );
         assert_eq!(
-            update_title("{{ columns }}x{{lines}}", &context),
+            update_title("{{ columns }}x{{lines}}", &context, None),
             String::from("64x84")
         );
 
-        assert_eq!(update_title("{{ title }}", &context), String::from(""));
+        assert_eq!(
+            update_title("{{ title }}", &context, None),
+            String::from("")
+        );
 
         // #[cfg(unix)]
         // assert_eq!(
@@ -344,17 +366,17 @@ pub mod test {
             rich_text_id,
             context_dimension,
         );
-        assert_eq!(update_title("", &context), String::from(""));
+        assert_eq!(update_title("", &context, None), String::from(""));
         // Title always starts empty
-        assert_eq!(update_title("{{title}}", &context), String::from(""));
+        assert_eq!(update_title("{{title}}", &context, None), String::from(""));
 
         assert_eq!(
-            update_title("{{ title || columns }}", &context),
+            update_title("{{ title || columns }}", &context, None),
             String::from("64")
         );
 
         assert_eq!(
-            update_title("{{ title || title }}", &context),
+            update_title("{{ title || title }}", &context, None),
             String::from("")
         );
 
@@ -365,12 +387,12 @@ pub mod test {
         };
 
         assert_eq!(
-            update_title("{{ title || columns }}", &context),
+            update_title("{{ title || columns }}", &context, None),
             String::from("Something")
         );
 
         assert_eq!(
-            update_title("{{ columns || title }}", &context),
+            update_title("{{ columns || title }}", &context, None),
             String::from("64")
         );
 
@@ -384,12 +406,12 @@ pub mod test {
         };
 
         assert_eq!(
-            update_title("{{ absolute_path || title }}", &context),
+            update_title("{{ absolute_path || title }}", &context, None),
             String::from("/rio-sandbox-test-dir"),
         );
 
         assert_eq!(
-            update_title("{{ relative_path || title }}", &context),
+            update_title("{{ relative_path || title }}", &context, None),
             String::from("/rio-sandbox-test-dir"),
         );
     }

--- a/frontends/rioterm/src/context/title.rs
+++ b/frontends/rioterm/src/context/title.rs
@@ -1,10 +1,12 @@
 use crate::context::Context;
 use std::path::Path;
 
+#[derive(PartialEq)]
 pub struct ContextTitleExtra {
     pub program: String,
 }
 
+#[derive(PartialEq)]
 pub struct ContextTitle {
     pub content: String,
     pub extra: Option<ContextTitleExtra>,

--- a/frontends/rioterm/src/layout/mod.rs
+++ b/frontends/rioterm/src/layout/mod.rs
@@ -114,6 +114,9 @@ pub struct ContextGrid<T: EventListener> {
     pub custom_title: Option<String>,
     // custom_color is the tab's background override (tab color picker).
     pub custom_color: Option<[f32; 4]>,
+    // bell is set when a pane in this tab rang while the tab was in the
+    // background; cleared once the tab is focused again.
+    pub bell: bool,
     scale: f32,
     inner: FxHashMap<NodeId, ContextGridItem<T>>,
     pub root: Option<NodeId>,
@@ -229,6 +232,7 @@ impl<T: rio_backend::event::EventListener> ContextGrid<T> {
             scaled_margin,
             custom_title: None,
             custom_color: None,
+            bell: false,
             scale,
             width,
             height,

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -26,6 +26,10 @@ const TAB_GAP: f32 = 6.0;
 const TAB_INSET_Y: f32 = 7.0;
 const TAB_RADIUS: f32 = 6.0;
 const TITLE_ELLIPSIS: char = '…';
+/// Bell mark for tabs that rang while in the background, and the gap
+/// between it and the tab title.
+const BELL_MARK: &str = "🔔";
+const BELL_GAP: f32 = 4.0;
 const DRAG_THRESHOLD: f32 = 4.0;
 const DRAG_ANIMATION_LENGTH: f32 = 0.15;
 const DRAG_MAX_DT: f32 = 0.05;
@@ -839,13 +843,6 @@ impl Island {
             // fill to carry a custom colour, which moves to the text.
             let single = num_tabs == 1;
 
-            let max_text_width = if single {
-                single_title_budget(window_width, scale_factor, left_margin)
-            } else {
-                (tab_width - TAB_PADDING_X * 2.0).max(0.0)
-            };
-            let title = fit_title_to_width(sugarloaf, &raw_title, max_text_width);
-
             let text_color = if single {
                 match context_manager.custom_color(tab_index) {
                     Some(mut custom) => {
@@ -866,6 +863,24 @@ impl Island {
                 ..DrawOpts::default()
             };
 
+            // The bell mark is its own text run: the UI text layer resolves
+            // a single font per draw from the run's first char, so gluing it
+            // onto the title would shape the whole title in the emoji font.
+            let bell = context_manager.bell(tab_index);
+            let bell_width = if bell {
+                sugarloaf.text_mut().measure(BELL_MARK, &title_opts) + BELL_GAP
+            } else {
+                0.0
+            };
+
+            let max_text_width = if single {
+                single_title_budget(window_width, scale_factor, left_margin) - bell_width
+            } else {
+                tab_width - TAB_PADDING_X * 2.0 - bell_width
+            }
+            .max(0.0);
+            let title = fit_title_to_width(sugarloaf, &raw_title, max_text_width);
+
             // UI text always paints in a final pass above every rect,
             // so the floating tab's opaque background can't occlude
             // titles passing underneath it — skip a title once the
@@ -878,16 +893,20 @@ impl Island {
 
             if !hidden_by_drag {
                 // Measure → centre → draw. Immediate mode, no cached
-                // text_id bookkeeping.
+                // text_id bookkeeping. The bell mark and the title are
+                // centred as one group.
                 let ui = sugarloaf.text_mut();
-                let text_width = ui.measure(&title, &title_opts);
+                let text_width = ui.measure(&title, &title_opts) + bell_width;
                 let text_x = if single {
                     single_title_x(window_width, scale_factor, text_width, left_margin)
                 } else {
                     tab_x + (tab_width - text_width) / 2.0
                 };
                 let text_y = (ISLAND_HEIGHT / 2.0) - (TITLE_FONT_SIZE / 2.);
-                ui.draw(text_x, text_y, &title, &title_opts);
+                if bell {
+                    ui.draw(text_x, text_y, BELL_MARK, &title_opts);
+                }
+                ui.draw(text_x + bell_width, text_y, &title, &title_opts);
             }
 
             // Nothing is drawn behind a lone title.

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -26,9 +26,13 @@ const TAB_GAP: f32 = 6.0;
 const TAB_INSET_Y: f32 = 7.0;
 const TAB_RADIUS: f32 = 6.0;
 const TITLE_ELLIPSIS: char = '…';
-/// Bell mark for tabs that rang while in the background, and the gap
-/// between it and the tab title.
-const BELL_MARK: &str = "🔔";
+/// Bell dot for tabs that rang while in the background, and the gap
+/// between it and the tab title. A dot, not a glyph: the UI text layer
+/// resolves one font per run, so a bell glyph exists only where an
+/// emoji font is installed and resolvable, while a rect renders
+/// identically everywhere (the same reason ghostty's font-free bell
+/// indicator is a border, not a drawn bell).
+const BELL_DOT_SIZE: f32 = 6.0;
 const BELL_GAP: f32 = 4.0;
 const DRAG_THRESHOLD: f32 = 4.0;
 const DRAG_ANIMATION_LENGTH: f32 = 0.15;
@@ -867,11 +871,7 @@ impl Island {
             // a single font per draw from the run's first char, so gluing it
             // onto the title would shape the whole title in the emoji font.
             let bell = context_manager.bell(tab_index);
-            let bell_width = if bell {
-                sugarloaf.text_mut().measure(BELL_MARK, &title_opts) + BELL_GAP
-            } else {
-                0.0
-            };
+            let bell_width = if bell { BELL_DOT_SIZE + BELL_GAP } else { 0.0 };
 
             let max_text_width = if single {
                 single_title_budget(window_width, scale_factor, left_margin) - bell_width
@@ -895,8 +895,8 @@ impl Island {
                 // Measure → centre → draw. Immediate mode, no cached
                 // text_id bookkeeping. The bell mark and the title are
                 // centred as one group.
-                let ui = sugarloaf.text_mut();
-                let text_width = ui.measure(&title, &title_opts) + bell_width;
+                let text_width =
+                    sugarloaf.text_mut().measure(&title, &title_opts) + bell_width;
                 let text_x = if single {
                     single_title_x(window_width, scale_factor, text_width, left_margin)
                 } else {
@@ -904,9 +904,28 @@ impl Island {
                 };
                 let text_y = (ISLAND_HEIGHT / 2.0) - (TITLE_FONT_SIZE / 2.);
                 if bell {
-                    ui.draw(text_x, text_y, BELL_MARK, &title_opts);
+                    // Vertically centred on the strip, in the title's
+                    // own color. Rects paint under the text pass, so a
+                    // dragged floating tab can occlude the dot; its
+                    // title is already skipped in that state.
+                    let dot_y = (ISLAND_HEIGHT - BELL_DOT_SIZE) / 2.0;
+                    sugarloaf.rect(
+                        None,
+                        text_x,
+                        dot_y,
+                        BELL_DOT_SIZE,
+                        BELL_DOT_SIZE,
+                        text_color,
+                        0.0,
+                        0,
+                    );
                 }
-                ui.draw(text_x + bell_width, text_y, &title, &title_opts);
+                sugarloaf.text_mut().draw(
+                    text_x + bell_width,
+                    text_y,
+                    &title,
+                    &title_opts,
+                );
             }
 
             // Nothing is drawn behind a lone title.

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -1461,32 +1461,14 @@ impl Island {
         self.color_picker_tab.is_some()
     }
 
-    /// Get the title text for a specific tab index
+    /// Get the title text for a specific tab index: the one displayed
+    /// chain, shared with the native titlebar.
     fn get_title_for_tab(
         &self,
         context_manager: &ContextManager<EventProxy>,
         tab_index: usize,
     ) -> String {
-        // Custom user-set title takes priority
-        if let Some(custom) = context_manager.custom_title(tab_index) {
-            return custom.to_string();
-        }
-
-        if let Some(context_title) = context_manager.title(tab_index) {
-            if !context_title.content.is_empty() {
-                return context_title.content.clone();
-            }
-
-            // Fallback to program name if title is empty
-            if let Some(ref extra) = context_title.extra {
-                if !extra.program.is_empty() {
-                    return extra.program.clone();
-                }
-            }
-        }
-
-        // Default fallback - show tab number
-        String::from("~")
+        context_manager.displayed_title_for_tab(tab_index)
     }
 }
 

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -29,10 +29,12 @@ const TITLE_ELLIPSIS: char = '…';
 /// Bell dot for tabs that rang while in the background, and the gap
 /// between it and the tab title. A dot, not a glyph: the UI text layer
 /// resolves one font per run, so a bell glyph exists only where an
-/// emoji font is installed and resolvable, while a rect renders
-/// identically everywhere (the same reason ghostty's font-free bell
-/// indicator is a border, not a drawn bell).
+/// emoji font is installed and resolvable, while a dot renders
+/// identically everywhere. Drawn at rect order 1: the tab backgrounds
+/// are submitted at order 0 AFTER the title pass, so a same-order dot
+/// would be painted over and invisible in every multi-tab strip.
 const BELL_DOT_SIZE: f32 = 6.0;
+const BELL_DOT_ORDER: u8 = 1;
 const BELL_GAP: f32 = 4.0;
 const DRAG_THRESHOLD: f32 = 4.0;
 const DRAG_ANIMATION_LENGTH: f32 = 0.15;
@@ -904,12 +906,8 @@ impl Island {
                 };
                 let text_y = (ISLAND_HEIGHT / 2.0) - (TITLE_FONT_SIZE / 2.);
                 if bell {
-                    // Vertically centred on the strip, in the title's
-                    // own color. Rects paint under the text pass, so a
-                    // dragged floating tab can occlude the dot; its
-                    // title is already skipped in that state.
                     let dot_y = (ISLAND_HEIGHT - BELL_DOT_SIZE) / 2.0;
-                    sugarloaf.rect(
+                    sugarloaf.rounded_rect(
                         None,
                         text_x,
                         dot_y,
@@ -917,7 +915,8 @@ impl Island {
                         BELL_DOT_SIZE,
                         text_color,
                         0.0,
-                        0,
+                        BELL_DOT_SIZE / 2.0,
+                        BELL_DOT_ORDER,
                     );
                 }
                 sugarloaf.text_mut().draw(

--- a/frontends/rioterm/src/renderer/island.rs
+++ b/frontends/rioterm/src/renderer/island.rs
@@ -906,7 +906,12 @@ impl Island {
                 };
                 let text_y = (ISLAND_HEIGHT / 2.0) - (TITLE_FONT_SIZE / 2.);
                 if bell {
-                    let dot_y = (ISLAND_HEIGHT - BELL_DOT_SIZE) / 2.0;
+                    // Centered on the title's lowercase body, not the strip:
+                    // the em box hangs from `text_y` with its optical middle
+                    // about two thirds down, so a strip-centered dot rides
+                    // visibly high next to lowercase titles.
+                    let dot_y =
+                        text_y + TITLE_FONT_SIZE * (2.0 / 3.0) - BELL_DOT_SIZE / 2.0;
                     sugarloaf.rounded_rect(
                         None,
                         text_x,

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -505,8 +505,10 @@ impl Router<'_> {
     #[inline]
     pub fn update_titles(&mut self) {
         for route in self.routes.values_mut() {
-            if route.window.is_focused {
-                route.window.screen.context_manager.update_titles();
+            if route.window.is_focused
+                && route.window.screen.context_manager.update_titles()
+            {
+                route.request_overlay_redraw();
             }
         }
     }

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -523,9 +523,13 @@ impl Router<'_> {
     }
 
     #[inline]
+    /// Full title re-render across every window, used on config reload
+    /// (the template may have changed). Panes the walk skips are marked
+    /// dirty and re-render when they surface.
     pub fn update_titles(&mut self) {
         for route in self.routes.values_mut() {
             let only_current = route.window.screen.renderer.island.is_none();
+            route.window.screen.context_manager.mark_all_titles_dirty();
             if route
                 .window
                 .screen

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -528,14 +528,7 @@ impl Router<'_> {
     /// dirty and re-render when they surface.
     pub fn update_titles(&mut self) {
         for route in self.routes.values_mut() {
-            let only_current = route.window.screen.renderer.island.is_none();
-            route.window.screen.context_manager.mark_all_titles_dirty();
-            if route
-                .window
-                .screen
-                .context_manager
-                .update_titles(only_current)
-            {
+            if route.window.screen.refresh_titles() {
                 route.request_overlay_redraw();
             }
         }

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -120,9 +120,29 @@ impl Route<'_> {
         self.window.winit_window.set_subtitle(subtitle);
     }
 
+    /// Set the native window title, deduplicating against the last
+    /// value: every upstream producer may poke redundantly (the whole
+    /// design converges instead of change-detecting), so the OS call
+    /// happens only when the text really changed.
     #[inline]
     pub fn set_window_title(&mut self, title: &str) {
+        if self.window.last_window_title == title {
+            return;
+        }
+        self.window.last_window_title = title.to_string();
         self.window.winit_window.set_title(title);
+    }
+
+    /// Refresh the native titlebar from the displayed pane, through the
+    /// same fallback chain the tab strip renders.
+    #[inline]
+    pub fn sync_window_title(&mut self) {
+        let title = self
+            .window
+            .screen
+            .context_manager
+            .displayed_title_for_current_tab();
+        self.set_window_title(&title);
     }
 
     #[inline]
@@ -505,9 +525,7 @@ impl Router<'_> {
     #[inline]
     pub fn update_titles(&mut self) {
         for route in self.routes.values_mut() {
-            if route.window.is_focused
-                && route.window.screen.context_manager.update_titles()
-            {
+            if route.window.screen.context_manager.update_titles() {
                 route.request_overlay_redraw();
             }
         }
@@ -714,6 +732,13 @@ impl Router<'_> {
 
 pub struct RouteWindow<'a> {
     pub is_focused: bool,
+    /// Whether a real Focused event has ever arrived. A window created
+    /// in the background starts `is_focused: false` and may never get
+    /// a correcting event; render gating must not freeze it before its
+    /// first focus.
+    pub focus_seen: bool,
+    /// Last title pushed to the OS, for `set_window_title` dedup.
+    pub last_window_title: String,
     pub is_occluded: bool,
     pub needs_render_after_occlusion: bool,
     #[cfg(target_os = "windows")]
@@ -905,6 +930,8 @@ impl<'a> RouteWindow<'a> {
             vblank_interval: monitor_vblank_interval,
             render_timestamp: Instant::now(),
             is_focused,
+            focus_seen: false,
+            last_window_title: String::new(),
             is_occluded: false,
             needs_render_after_occlusion: false,
             #[cfg(target_os = "windows")]

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -525,7 +525,13 @@ impl Router<'_> {
     #[inline]
     pub fn update_titles(&mut self) {
         for route in self.routes.values_mut() {
-            if route.window.screen.context_manager.update_titles() {
+            let only_current = route.window.screen.renderer.island.is_none();
+            if route
+                .window
+                .screen
+                .context_manager
+                .update_titles(only_current)
+            {
                 route.request_overlay_redraw();
             }
         }

--- a/frontends/rioterm/src/router/mod.rs
+++ b/frontends/rioterm/src/router/mod.rs
@@ -851,8 +851,9 @@ impl<'a> RouteWindow<'a> {
             window_id: winit_window.id(),
         };
 
-        let screen = Screen::new(properties, config, event_proxy, font_library, open_url)
-            .expect("Screen not created");
+        let mut screen =
+            Screen::new(properties, config, event_proxy, font_library, open_url)
+                .expect("Screen not created");
 
         if config.window.columns.is_some() || config.window.rows.is_some() {
             let (physical_width, physical_height) = compute_window_size_from_grid(
@@ -892,10 +893,18 @@ impl<'a> RouteWindow<'a> {
             Duration::from_micros(frame_time_us)
         };
 
+        // A window can be created without focus (`open -g`, spawned
+        // behind another app) and may never receive a Focused(false)
+        // correcting a hardcoded `true`; a stale-true default makes
+        // focus-gated paths (the bell mark, its clear) treat an
+        // invisible window as watched.
+        let is_focused = winit_window.has_focus();
+        screen.renderer.is_window_focused = is_focused;
+
         Self {
             vblank_interval: monitor_vblank_interval,
             render_timestamp: Instant::now(),
-            is_focused: true,
+            is_focused,
             is_occluded: false,
             needs_render_after_occlusion: false,
             #[cfg(target_os = "windows")]

--- a/frontends/rioterm/src/scheduler.rs
+++ b/frontends/rioterm/src/scheduler.rs
@@ -28,7 +28,6 @@ pub enum Topic {
     ScheduledRenderRoute,
     UpdateConfig,
     CursorBlinking,
-    UpdateTitles,
     SelectionScrolling,
 }
 

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -628,6 +628,16 @@ impl Screen<'_> {
     }
 
     #[inline]
+    /// Re-render titles after a grid reflow (window resize, font-size
+    /// or scale change, split open/close): `{{columns}}`/`{{lines}}`
+    /// have no PTY event, so the reflow itself is their trigger. Panes
+    /// the walk skips are marked dirty and re-render on surfacing.
+    pub fn refresh_titles(&mut self) -> bool {
+        let only_current = self.renderer.island.is_none();
+        self.context_manager.mark_all_titles_dirty();
+        self.context_manager.update_titles(only_current)
+    }
+
     pub fn change_font_size(&mut self, action: FontSizeAction) {
         let dim = &mut self.context_manager.current_mut().dimension;
         let changed = match action {
@@ -645,6 +655,7 @@ impl Screen<'_> {
 
         self.mark_dirty();
         self.resize_all_contexts();
+        self.refresh_titles();
         // Reflowed cursor displacement is layout, not travel.
         self.renderer.trail_cursor.snap();
     }
@@ -739,6 +750,7 @@ impl Screen<'_> {
 
         self.context_manager
             .resize_all_grids(width, height, &mut self.sugarloaf);
+        self.refresh_titles();
         self.mark_dirty();
         // Rescaled cursor displacement is layout, not travel.
         self.renderer.trail_cursor.snap();
@@ -1618,6 +1630,7 @@ impl Screen<'_> {
             &mut self.sugarloaf,
         );
 
+        self.refresh_titles();
         self.mark_dirty();
     }
 
@@ -1626,6 +1639,7 @@ impl Screen<'_> {
         self.context_manager
             .split(rich_text_id, false, &mut self.sugarloaf);
 
+        self.refresh_titles();
         self.mark_dirty();
     }
 
@@ -1634,6 +1648,7 @@ impl Screen<'_> {
         self.context_manager
             .split(rich_text_id, true, &mut self.sugarloaf);
 
+        self.refresh_titles();
         self.mark_dirty();
     }
 
@@ -1723,6 +1738,7 @@ impl Screen<'_> {
             self.clear_selection();
             self.context_manager
                 .remove_current_grid(&mut self.sugarloaf);
+            self.refresh_titles();
             self.mark_dirty();
         } else {
             self.close_tab(clipboard);

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -256,9 +256,6 @@ impl Screen<'_> {
             #[cfg(not(target_os = "windows"))]
             use_fork: config.use_fork,
             is_native,
-            // When navigation does not contain any color rule
-            // does not make sense fetch for foreground process names/path
-            should_update_title_extra: !config.navigation.color_automation.is_empty(),
             split_color: config.colors.split,
             split_active_color: config.colors.split_active,
             panel: config.panel,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3017,23 +3017,7 @@ impl Screen<'_> {
         // Right-click or Control + left-click → toggle color picker for that tab
         if is_right_click || self.modifiers.state().control_key() {
             // Get current displayed title for the rename input
-            let current_title = self
-                .context_manager
-                .title(clicked_tab)
-                .and_then(|t| {
-                    if !t.content.is_empty() {
-                        Some(t.content.clone())
-                    } else {
-                        t.extra.as_ref().and_then(|e| {
-                            if !e.program.is_empty() {
-                                Some(e.program.clone())
-                            } else {
-                                None
-                            }
-                        })
-                    }
-                })
-                .unwrap_or_else(|| String::from("~"));
+            let current_title = self.context_manager.displayed_title_for_tab(clicked_tab);
             if let Some(ref mut island) = self.renderer.island {
                 island.toggle_color_picker(
                     clicked_tab,

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3877,6 +3877,7 @@ impl Screen<'_> {
 
     pub(crate) fn render(&mut self) -> Option<crate::context::renderable::WindowUpdate> {
         self.update_close_button_hover(self.mouse.x, self.mouse.y);
+        self.context_manager.clear_current_bell();
 
         let is_search_active = self.search_active();
         if is_search_active {

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3877,10 +3877,6 @@ impl Screen<'_> {
 
     pub(crate) fn render(&mut self) -> Option<crate::context::renderable::WindowUpdate> {
         self.update_close_button_hover(self.mouse.x, self.mouse.y);
-        // The bell mark drops the first time its tab is SHOWN to the
-        // user, whatever brought it to the front; an unfocused window
-        // still renders on PTY damage, and clearing there would wipe a
-        // mark nobody has seen yet.
         if self.renderer.is_window_focused {
             self.context_manager.clear_current_bell();
         }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -603,6 +603,7 @@ impl Screen<'_> {
 
         // Update keyboard config in context manager
         self.context_manager.config.keyboard = config.keyboard.clone();
+        self.context_manager.config.title = config.title.clone();
 
         // Re-evaluate the opaque flag — toggling `window.opacity` /
         // `window.blur` at runtime should flip the compositor mode.

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3877,7 +3877,13 @@ impl Screen<'_> {
 
     pub(crate) fn render(&mut self) -> Option<crate::context::renderable::WindowUpdate> {
         self.update_close_button_hover(self.mouse.x, self.mouse.y);
-        self.context_manager.clear_current_bell();
+        // The bell mark drops the first time its tab is SHOWN to the
+        // user, whatever brought it to the front; an unfocused window
+        // still renders on PTY damage, and clearing there would wipe a
+        // mark nobody has seen yet.
+        if self.renderer.is_window_focused {
+            self.context_manager.clear_current_bell();
+        }
 
         let is_search_active = self.search_active();
         if is_search_active {

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -188,7 +188,7 @@ impl Listener {
                     },
                 );
             }
-            RioEvent::Bell => {
+            RioEvent::Bell(_) => {
                 self.delegate.action(self.surface_id, Action::RingBell);
             }
             RioEvent::CursorBlinkingChange | RioEvent::CursorBlinkingChangeOnRoute(_) => {

--- a/librio/src/lib.rs
+++ b/librio/src/lib.rs
@@ -170,7 +170,7 @@ impl Listener {
             | RioEvent::RenderRoute(_) => {
                 self.delegate.wakeup(self.surface_id);
             }
-            RioEvent::Title(title) => {
+            RioEvent::Title(_, title) => {
                 self.delegate.action(
                     self.surface_id,
                     Action::SetTitle {

--- a/rio-backend/src/config/bell.rs
+++ b/rio-backend/src/config/bell.rs
@@ -1,15 +1,20 @@
+use crate::config::defaults::default_bool_true;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Bell {
     #[serde(default = "default_audio_bell")]
     pub audio: bool,
+    /// Mark background tabs that rang the bell with a 🔔 in the tab strip.
+    #[serde(default = "default_bool_true", rename = "tab-indicator")]
+    pub tab_indicator: bool,
 }
 
 impl Default for Bell {
     fn default() -> Self {
         Bell {
             audio: default_audio_bell(),
+            tab_indicator: default_bool_true(),
         }
     }
 }

--- a/rio-backend/src/config/bell.rs
+++ b/rio-backend/src/config/bell.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct Bell {
     #[serde(default = "default_audio_bell")]
     pub audio: bool,
-    /// Mark background tabs that rang the bell with a 🔔 in the tab strip.
+    /// Mark background tabs that rang the bell with a dot in the tab strip.
     #[serde(default = "default_bool_true", rename = "tab-indicator")]
     pub tab_indicator: bool,
 }

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -3474,7 +3474,14 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
     fn set_current_directory(&mut self, path: std::path::PathBuf) {
         trace!("Setting working directory {:?}", path);
+        if self.current_directory.as_deref() == Some(path.as_path()) {
+            return;
+        }
         self.current_directory = Some(path);
+        self.event_proxy.send_event(
+            RioEvent::CurrentDirectoryChanged(self.route_id),
+            self.window_id,
+        );
     }
 
     fn set_semantic_prompt(
@@ -7889,6 +7896,43 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, RioEvent::Title(route, t) if *route == 7 && t == "my title")),
             "set_title should emit RioEvent::Title carrying its route id"
+        );
+    }
+
+    #[test]
+    fn set_current_directory_emits_event_once_per_change() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(10, 10),
+            CursorShape::Block,
+            TestListener {
+                events: events.clone(),
+            },
+            WindowId::from(0),
+            7,
+            10,
+        );
+
+        Handler::set_current_directory(&mut term, "/tmp/a".into());
+        Handler::set_current_directory(&mut term, "/tmp/a".into());
+
+        let count = events
+            .borrow()
+            .iter()
+            .filter(
+                |e| matches!(e, RioEvent::CurrentDirectoryChanged(route) if *route == 7),
+            )
+            .count();
+        assert_eq!(
+            count, 1,
+            "a repeated OSC 7 for the same directory must not re-emit"
+        );
+        assert_eq!(
+            term.current_directory.as_deref(),
+            Some(std::path::Path::new("/tmp/a"))
         );
     }
 

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -7902,6 +7902,48 @@ mod tests {
     }
 
     #[test]
+    fn bell_emits_bell_event_for_its_route() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        #[derive(Clone)]
+        struct TestListener {
+            events: Rc<RefCell<Vec<RioEvent>>>,
+        }
+
+        impl EventListener for TestListener {
+            fn send_event(&self, event: RioEvent, _id: WindowId) {
+                self.events.borrow_mut().push(event);
+            }
+        }
+
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(10, 10),
+            CursorShape::Block,
+            TestListener {
+                events: events.clone(),
+            },
+            WindowId::from(0),
+            7,
+            10,
+        );
+
+        // Drive a real BEL byte through the parser rather than calling the
+        // handler directly, so the C0 dispatch stays covered too.
+        let mut parser = crate::performer::handler::Processor::default();
+        parser.advance(&mut term, b"\x07");
+
+        assert!(
+            events
+                .borrow()
+                .iter()
+                .any(|e| matches!(e, RioEvent::Bell(route) if *route == 7)),
+            "BEL should emit RioEvent::Bell carrying its route id"
+        );
+    }
+
+    #[test]
     fn test_keyboard_mode_syncs_with_mode() {
         let size = CrosswordsSize::new(10, 10);
         let window_id = WindowId::from(0);

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -5817,6 +5817,20 @@ mod tests {
     use crate::crosswords::CrosswordsSize;
     use crate::event::VoidListener;
 
+    /// Event-capturing listener for tests that assert on emitted
+    /// `RioEvent`s. One definition; four tests used to carry
+    /// byte-identical local copies.
+    #[derive(Clone)]
+    struct TestListener {
+        events: std::rc::Rc<std::cell::RefCell<Vec<RioEvent>>>,
+    }
+
+    impl EventListener for TestListener {
+        fn send_event(&self, event: RioEvent, _id: WindowId) {
+            self.events.borrow_mut().push(event);
+        }
+    }
+
     fn make_crosswords() -> Crosswords<VoidListener> {
         let size = CrosswordsSize::new(4, 4);
         let window_id = crate::event::WindowId::from(0);
@@ -7810,18 +7824,6 @@ mod tests {
         use std::cell::RefCell;
         use std::rc::Rc;
 
-        // Create a custom event listener that captures PtyWrite events
-        #[derive(Clone)]
-        struct TestListener {
-            events: Rc<RefCell<Vec<RioEvent>>>,
-        }
-
-        impl EventListener for TestListener {
-            fn send_event(&self, event: RioEvent, _id: WindowId) {
-                self.events.borrow_mut().push(event);
-            }
-        }
-
         let size = CrosswordsSize::new(10, 10);
         let window_id = WindowId::from(0);
         let events = Rc::new(RefCell::new(Vec::new()));
@@ -7866,17 +7868,6 @@ mod tests {
         use std::cell::RefCell;
         use std::rc::Rc;
 
-        #[derive(Clone)]
-        struct TestListener {
-            events: Rc<RefCell<Vec<RioEvent>>>,
-        }
-
-        impl EventListener for TestListener {
-            fn send_event(&self, event: RioEvent, _id: WindowId) {
-                self.events.borrow_mut().push(event);
-            }
-        }
-
         let events = Rc::new(RefCell::new(Vec::new()));
         let mut term = Crosswords::new(
             CrosswordsSize::new(10, 10),
@@ -7905,17 +7896,6 @@ mod tests {
     fn bell_emits_bell_event_for_its_route() {
         use std::cell::RefCell;
         use std::rc::Rc;
-
-        #[derive(Clone)]
-        struct TestListener {
-            events: Rc<RefCell<Vec<RioEvent>>>,
-        }
-
-        impl EventListener for TestListener {
-            fn send_event(&self, event: RioEvent, _id: WindowId) {
-                self.events.borrow_mut().push(event);
-            }
-        }
 
         let events = Rc::new(RefCell::new(Vec::new()));
         let mut term = Crosswords::new(
@@ -10426,17 +10406,6 @@ mod tests {
         use crate::performer::handler::Processor;
         use std::cell::RefCell;
         use std::rc::Rc;
-
-        #[derive(Clone)]
-        struct TestListener {
-            events: Rc<RefCell<Vec<RioEvent>>>,
-        }
-
-        impl EventListener for TestListener {
-            fn send_event(&self, event: RioEvent, _id: WindowId) {
-                self.events.borrow_mut().push(event);
-            }
-        }
 
         let events = Rc::new(RefCell::new(Vec::new()));
         let mut term = Crosswords::new(

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -3460,8 +3460,10 @@ impl<U: EventListener> Handler for Crosswords<U> {
         let title = title.unwrap_or_default();
         if title != self.title {
             self.title = title;
-            self.event_proxy
-                .send_event(RioEvent::Title(self.title.clone()), self.window_id);
+            self.event_proxy.send_event(
+                RioEvent::Title(self.route_id, self.title.clone()),
+                self.window_id,
+            );
         }
     }
 
@@ -7883,7 +7885,7 @@ mod tests {
                 events: events.clone(),
             },
             WindowId::from(0),
-            0,
+            7,
             10,
         );
 
@@ -7894,8 +7896,8 @@ mod tests {
             events
                 .borrow()
                 .iter()
-                .any(|e| matches!(e, RioEvent::Title(t) if t == "my title")),
-            "set_title should emit RioEvent::Title"
+                .any(|e| matches!(e, RioEvent::Title(route, t) if *route == 7 && t == "my title")),
+            "set_title should emit RioEvent::Title carrying its route id"
         );
     }
 

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -3350,7 +3350,13 @@ impl<U: EventListener> Handler for Crosswords<U> {
         self.inactive_keyboard_mode_stack = [0; KEYBOARD_MODE_STACK_MAX_DEPTH];
         self.keyboard_mode_idx = 0;
         self.inactive_keyboard_mode_idx = 0;
-        self.title = String::from("");
+        if !self.title.is_empty() {
+            self.title = String::from("");
+            self.event_proxy.send_event(
+                RioEvent::Title(self.route_id, String::new()),
+                self.window_id,
+            );
+        }
         self.selection = None;
         self.vi_mode_cursor = Default::default();
         self.keyboard_mode_stack = Default::default();
@@ -7897,6 +7903,47 @@ mod tests {
                 .any(|e| matches!(e, RioEvent::Title(route, t) if *route == 7 && t == "my title")),
             "set_title should emit RioEvent::Title carrying its route id"
         );
+    }
+
+    #[test]
+    fn reset_emits_empty_title_event_once() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let mut term = Crosswords::new(
+            CrosswordsSize::new(10, 10),
+            CursorShape::Block,
+            TestListener {
+                events: events.clone(),
+            },
+            WindowId::from(0),
+            7,
+            10,
+        );
+
+        Handler::set_title(&mut term, Some("vim - foo.rs".to_string()));
+        events.borrow_mut().clear();
+
+        // RIS must announce the cleared title like any other change,
+        // or the strip and titlebar keep the pre-reset text forever.
+        Handler::reset_state(&mut term);
+        let count = events
+            .borrow()
+            .iter()
+            .filter(
+                |e| matches!(e, RioEvent::Title(route, t) if *route == 7 && t.is_empty()),
+            )
+            .count();
+        assert_eq!(count, 1);
+
+        // A reset with no title set stays silent.
+        events.borrow_mut().clear();
+        Handler::reset_state(&mut term);
+        assert!(events
+            .borrow()
+            .iter()
+            .all(|e| !matches!(e, RioEvent::Title(..))));
     }
 
     #[test]

--- a/rio-vt/src/crosswords/mod.rs
+++ b/rio-vt/src/crosswords/mod.rs
@@ -4272,7 +4272,8 @@ impl<U: EventListener> Handler for Crosswords<U> {
 
     #[inline]
     fn bell(&mut self) {
-        self.event_proxy.send_event(RioEvent::Bell, self.window_id);
+        self.event_proxy
+            .send_event(RioEvent::Bell(self.route_id), self.window_id);
     }
 
     #[inline]

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -247,8 +247,8 @@ pub enum RioEvent {
     /// Progress bar report from OSC 9;4 sequence
     ProgressReport(ProgressReport),
 
-    /// Terminal bell ring.
-    Bell,
+    /// Terminal bell ring, from the PTY identified by `route_id`.
+    Bell(usize),
 
     /// Desktop notification from OSC 9 or OSC 777.
     DesktopNotification {
@@ -340,7 +340,7 @@ impl Debug for RioEvent {
                 write!(f, "GlyphProtocolQuery route {route_id} cp {cp:#x}")
             }
             RioEvent::Scroll(scroll) => write!(f, "Scroll {scroll:?}"),
-            RioEvent::Bell => write!(f, "Bell"),
+            RioEvent::Bell(route_id) => write!(f, "Bell route {route_id}"),
             RioEvent::DesktopNotification { title, body } => {
                 write!(f, "DesktopNotification({title}, {body})")
             }

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -190,8 +190,8 @@ pub enum RioEvent {
     /// Grid has changed possibly requiring a mouse cursor shape change.
     MouseCursorDirty,
 
-    /// Window title change.
-    Title(String),
+    /// Terminal title change from the PTY identified by `route_id`.
+    Title(usize, String),
 
     /// Window title change.
     TitleWithSubtitle(String, String),
@@ -306,7 +306,9 @@ impl Debug for RioEvent {
             RioEvent::PtyWrite(route_id, text) => {
                 write!(f, "PtyWrite(route={route_id}, {text})")
             }
-            RioEvent::Title(title) => write!(f, "Title({title})"),
+            RioEvent::Title(route_id, title) => {
+                write!(f, "Title route {route_id} ({title})")
+            }
             RioEvent::TitleWithSubtitle(title, subtitle) => {
                 write!(f, "TitleWithSubtitle({title}, {subtitle})")
             }

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -287,9 +287,6 @@ pub enum RioEvent {
     /// Selection scroll tick — auto-scroll while dragging outside viewport.
     SelectionScrollTick,
 
-    /// Update window titles.
-    UpdateTitles,
-
     /// Update terminal screen colors.
     ///
     /// The first usize is the route_id, the second is the color index to change.
@@ -389,7 +386,6 @@ impl Debug for RioEvent {
                 write!(f, "BlinkCursor {timeout} {route_id}")
             }
             RioEvent::SelectionScrollTick => write!(f, "SelectionScrollTick"),
-            RioEvent::UpdateTitles => write!(f, "UpdateTitles"),
             RioEvent::Noop => write!(f, "Noop"),
             RioEvent::Copy(_) => write!(f, "Copy"),
             RioEvent::Paste => write!(f, "Paste"),

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -193,11 +193,12 @@ pub enum RioEvent {
     /// Terminal title change from the PTY identified by `route_id`.
     Title(usize, String),
 
-    /// Set the native window title to an ALREADY-RENDERED string, with
-    /// no re-render or template work in the handler. Emitted when the
-    /// displayed pane changes (tab switch, tab close) or when the poll
-    /// sees the current tab's rendered title change.
-    WindowTitle(String),
+    /// Ask the event loop to refresh the native titlebar from the
+    /// currently displayed pane. Payload-less on purpose: the handler
+    /// re-reads the displayed title at handling time, so a queued poke
+    /// can never overwrite a newer title with a stale snapshot, and
+    /// redundant pokes dedupe at the sink.
+    SyncWindowTitle,
 
     /// Window title change.
     TitleWithSubtitle(String, String),
@@ -315,9 +316,7 @@ impl Debug for RioEvent {
             RioEvent::Title(route_id, title) => {
                 write!(f, "Title route {route_id} ({title})")
             }
-            RioEvent::WindowTitle(title) => {
-                write!(f, "WindowTitle({title})")
-            }
+            RioEvent::SyncWindowTitle => write!(f, "SyncWindowTitle"),
             RioEvent::TitleWithSubtitle(title, subtitle) => {
                 write!(f, "TitleWithSubtitle({title}, {subtitle})")
             }

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -193,6 +193,11 @@ pub enum RioEvent {
     /// Terminal title change from the PTY identified by `route_id`.
     Title(usize, String),
 
+    /// Working directory change (OSC 7) from the PTY identified by
+    /// `route_id`. Payload-less: the handler re-reads the terminal's
+    /// stored directory, which the emitter already committed.
+    CurrentDirectoryChanged(usize),
+
     /// Ask the event loop to refresh the native titlebar from the
     /// currently displayed pane. Payload-less on purpose: the handler
     /// re-reads the displayed title at handling time, so a queued poke
@@ -315,6 +320,9 @@ impl Debug for RioEvent {
             }
             RioEvent::Title(route_id, title) => {
                 write!(f, "Title route {route_id} ({title})")
+            }
+            RioEvent::CurrentDirectoryChanged(route_id) => {
+                write!(f, "CurrentDirectoryChanged route {route_id}")
             }
             RioEvent::SyncWindowTitle => write!(f, "SyncWindowTitle"),
             RioEvent::TitleWithSubtitle(title, subtitle) => {

--- a/rio-vt/src/event/mod.rs
+++ b/rio-vt/src/event/mod.rs
@@ -193,6 +193,12 @@ pub enum RioEvent {
     /// Terminal title change from the PTY identified by `route_id`.
     Title(usize, String),
 
+    /// Set the native window title to an ALREADY-RENDERED string, with
+    /// no re-render or template work in the handler. Emitted when the
+    /// displayed pane changes (tab switch, tab close) or when the poll
+    /// sees the current tab's rendered title change.
+    WindowTitle(String),
+
     /// Window title change.
     TitleWithSubtitle(String, String),
 
@@ -308,6 +314,9 @@ impl Debug for RioEvent {
             }
             RioEvent::Title(route_id, title) => {
                 write!(f, "Title route {route_id} ({title})")
+            }
+            RioEvent::WindowTitle(title) => {
+                write!(f, "WindowTitle({title})")
             }
             RioEvent::TitleWithSubtitle(title, subtitle) => {
                 write!(f, "TitleWithSubtitle({title}, {subtitle})")

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -730,6 +730,15 @@ pub fn create_pty_with_spawn(
 ///
 /// It returns two [`Pty`] along with respective process name [`String`] and process id (`libc::pid_`)
 ///
+/// The shell a spawn falls back to when none is configured: `$SHELL`,
+/// else the passwd entry. Public so per-shell decisions made before
+/// spawning (title program name) match what actually spawns.
+pub fn default_shell_program() -> String {
+    ShellUser::from_env()
+        .map(|user| user.shell)
+        .unwrap_or_default()
+}
+
 pub fn create_pty_with_fork(
     shell: Option<&str>,
     args: &[String],


### PR DESCRIPTION
Supersedes #1881. Carries @aymanbagabas's three commits verbatim (bell tab indicator, immediate tab titles, BEL parser test), with review fixes layered on top.

A `BEL` from a background tab now flags its tab in the strip, and OSC 0/2 title changes reach the tab strip immediately as events. See #1881 for the full design write-up. Gated behind `bell.tab-indicator` (default `true`).

Titles are now purely event-driven: the standing 2s poll is gone and title rendering never inspects the foreground process. `{{ title }}` comes from OSC 0/2 events, the path variables come from OSC 7 events (empty for shells without that integration), `{{ program }}` is the name of the command the pane spawned, and `{{ columns }}`/`{{ lines }}` re-render on resize. An idle terminal does zero title work and no timer ever wakes the process.
