### PR TITLE
Automatic shell integration for zsh, fish and PowerShell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,6 +4042,7 @@ name = "rioterm"
 version = "0.5.27"
 dependencies = [
  "ahash",
+ "base64",
  "bitflags 2.13.1",
  "cfg_aliases",
  "clap",

--- a/frontends/rioterm/Cargo.toml
+++ b/frontends/rioterm/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 global-hotkey = "0.8.0"
+base64 = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "registry"] }
 wgpu = { workspace = true }

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -109,6 +109,8 @@ pub struct ContextManagerConfig {
     pub shell: Shell,
     #[cfg(not(target_os = "windows"))]
     pub use_fork: bool,
+    #[cfg(not(target_os = "windows"))]
+    pub shell_integration: bool,
     pub working_dir: Option<String>,
     pub spawn_performer: bool,
     pub cwd: bool,
@@ -253,11 +255,17 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         let pty;
         #[cfg(not(target_os = "windows"))]
         {
+            let integration_env: Vec<(String, String)> = if config.shell_integration {
+                crate::shell_integration::spawn_env(config.shell.program.as_deref())
+            } else {
+                Vec::new()
+            };
             if config.use_fork {
                 tracing::info!("rio -> teletypewriter: create_pty_with_fork");
                 pty = match create_pty_with_fork(
                     config.shell.program.as_deref(),
                     &config.shell.args,
+                    &integration_env,
                     cols,
                     rows,
                     initial_winsize.width,
@@ -275,7 +283,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                     config.shell.program.as_deref(),
                     config.shell.args.clone(),
                     &config.working_dir,
-                    None,
+                    (!integration_env.is_empty()).then_some(integration_env),
                     cols,
                     rows,
                     initial_winsize.width,
@@ -1073,6 +1081,8 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             spawn_performer: true,
             #[cfg(not(target_os = "windows"))]
             use_fork: config.use_fork,
+            #[cfg(not(target_os = "windows"))]
+            shell_integration: config.shell_integration,
             is_native: config.navigation.is_native(),
             // When navigation is collapsed and does not contain any color rule
             // does not make sense fetch for foreground process names

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -265,7 +265,7 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             None
         };
         let (shell_program, shell_args) = match &rewritten_command {
-            Some((program, args)) => (Some(program.as_str()), args.clone()),
+            Some((program, args)) => (program.as_deref(), args.clone()),
             None => (config.shell.program.as_deref(), config.shell.args.clone()),
         };
 

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -251,22 +251,20 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         terminal.blinking_cursor = cursor_state.1;
         let terminal: Arc<FairMutex<Crosswords<T>>> = Arc::new(FairMutex::new(terminal));
 
-        let integration_env: Vec<(String, String)> = if config.shell_integration {
-            crate::shell_integration::spawn_env(config.shell.program.as_deref())
-        } else {
-            Vec::new()
-        };
-        let rewritten_command = if config.shell_integration {
-            crate::shell_integration::powershell_command(
+        let integration = if config.shell_integration {
+            crate::shell_integration::prepare(
                 config.shell.program.as_deref(),
                 &config.shell.args,
             )
         } else {
-            None
+            crate::shell_integration::SpawnIntegration::default()
         };
-        let (shell_program, shell_args) = match &rewritten_command {
-            Some((program, args)) => (program.as_deref(), args.clone()),
-            None => (config.shell.program.as_deref(), config.shell.args.clone()),
+        let (shell_program, shell_args) = match &integration.command {
+            Some((program, args)) => (program.as_deref(), args.as_slice()),
+            None => (
+                config.shell.program.as_deref(),
+                config.shell.args.as_slice(),
+            ),
         };
 
         let pty;
@@ -276,8 +274,8 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                 tracing::info!("rio -> teletypewriter: create_pty_with_fork");
                 pty = match create_pty_with_fork(
                     shell_program,
-                    &shell_args,
-                    &integration_env,
+                    shell_args,
+                    &integration.env,
                     cols,
                     rows,
                     initial_winsize.width,
@@ -293,9 +291,9 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
                 tracing::info!("rio -> teletypewriter: create_pty_with_spawn");
                 pty = match create_pty_with_spawn(
                     shell_program,
-                    shell_args.clone(),
+                    shell_args.to_vec(),
                     &config.working_dir,
-                    (!integration_env.is_empty()).then_some(integration_env),
+                    (!integration.env.is_empty()).then(|| integration.env.clone()),
                     cols,
                     rows,
                     initial_winsize.width,
@@ -319,9 +317,9 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         {
             pty = match create_pty(
                 shell_program,
-                shell_args,
+                shell_args.to_vec(),
                 &config.working_dir,
-                (!integration_env.is_empty()).then_some(integration_env),
+                (!integration.env.is_empty()).then(|| integration.env.clone()),
                 cols,
                 rows,
             ) {

--- a/frontends/rioterm/src/context/mod.rs
+++ b/frontends/rioterm/src/context/mod.rs
@@ -109,7 +109,6 @@ pub struct ContextManagerConfig {
     pub shell: Shell,
     #[cfg(not(target_os = "windows"))]
     pub use_fork: bool,
-    #[cfg(not(target_os = "windows"))]
     pub shell_integration: bool,
     pub working_dir: Option<String>,
     pub spawn_performer: bool,
@@ -252,19 +251,32 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         terminal.blinking_cursor = cursor_state.1;
         let terminal: Arc<FairMutex<Crosswords<T>>> = Arc::new(FairMutex::new(terminal));
 
+        let integration_env: Vec<(String, String)> = if config.shell_integration {
+            crate::shell_integration::spawn_env(config.shell.program.as_deref())
+        } else {
+            Vec::new()
+        };
+        let rewritten_command = if config.shell_integration {
+            crate::shell_integration::powershell_command(
+                config.shell.program.as_deref(),
+                &config.shell.args,
+            )
+        } else {
+            None
+        };
+        let (shell_program, shell_args) = match &rewritten_command {
+            Some((program, args)) => (Some(program.as_str()), args.clone()),
+            None => (config.shell.program.as_deref(), config.shell.args.clone()),
+        };
+
         let pty;
         #[cfg(not(target_os = "windows"))]
         {
-            let integration_env: Vec<(String, String)> = if config.shell_integration {
-                crate::shell_integration::spawn_env(config.shell.program.as_deref())
-            } else {
-                Vec::new()
-            };
             if config.use_fork {
                 tracing::info!("rio -> teletypewriter: create_pty_with_fork");
                 pty = match create_pty_with_fork(
-                    config.shell.program.as_deref(),
-                    &config.shell.args,
+                    shell_program,
+                    &shell_args,
                     &integration_env,
                     cols,
                     rows,
@@ -280,8 +292,8 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             } else {
                 tracing::info!("rio -> teletypewriter: create_pty_with_spawn");
                 pty = match create_pty_with_spawn(
-                    config.shell.program.as_deref(),
-                    config.shell.args.clone(),
+                    shell_program,
+                    shell_args.clone(),
                     &config.working_dir,
                     (!integration_env.is_empty()).then_some(integration_env),
                     cols,
@@ -306,10 +318,10 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
         #[cfg(target_os = "windows")]
         {
             pty = match create_pty(
-                config.shell.program.as_deref(),
-                config.shell.args.clone(),
+                shell_program,
+                shell_args,
                 &config.working_dir,
-                None,
+                (!integration_env.is_empty()).then_some(integration_env),
                 cols,
                 rows,
             ) {
@@ -1081,7 +1093,6 @@ impl<T: EventListener + Clone + std::marker::Send + 'static> ContextManager<T> {
             spawn_performer: true,
             #[cfg(not(target_os = "windows"))]
             use_fork: config.use_fork,
-            #[cfg(not(target_os = "windows"))]
             shell_integration: config.shell_integration,
             is_native: config.navigation.is_native(),
             // When navigation is collapsed and does not contain any color rule

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -22,6 +22,8 @@ mod renderer;
 mod router;
 mod scheduler;
 mod screen;
+#[cfg(not(target_os = "windows"))]
+mod shell_integration;
 mod watcher;
 
 use clap::Parser;

--- a/frontends/rioterm/src/main.rs
+++ b/frontends/rioterm/src/main.rs
@@ -22,7 +22,6 @@ mod renderer;
 mod router;
 mod scheduler;
 mod screen;
-#[cfg(not(target_os = "windows"))]
 mod shell_integration;
 mod watcher;
 

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -255,6 +255,8 @@ impl Screen<'_> {
             spawn_performer: true,
             #[cfg(not(target_os = "windows"))]
             use_fork: config.use_fork,
+            #[cfg(not(target_os = "windows"))]
+            shell_integration: config.shell_integration,
             is_native,
             // When navigation does not contain any color rule
             // does not make sense fetch for foreground process names/path

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -255,7 +255,6 @@ impl Screen<'_> {
             spawn_performer: true,
             #[cfg(not(target_os = "windows"))]
             use_fork: config.use_fork,
-            #[cfg(not(target_os = "windows"))]
             shell_integration: config.shell_integration,
             is_native,
             // When navigation does not contain any color rule

--- a/frontends/rioterm/src/shell_integration/mod.rs
+++ b/frontends/rioterm/src/shell_integration/mod.rs
@@ -10,10 +10,14 @@
 //! runs) and an `XDG_DATA_DIRS` prepend for fish, whose
 //! `vendor_conf.d` loads from there. PowerShell has no environment
 //! hook, so a bare spawn (no configured args) is rewritten to
-//! `-NoExit -Command . '<script>'`, which runs after the user's
-//! profile. Shells with neither hook (bash needs `--posix` argv
-//! surgery, cmd.exe only has a machine-wide registry key) are left
-//! untouched.
+//! `-NoExit -EncodedCommand <script>` carrying the script inline,
+//! which runs after the user's profile and is exempt from execution
+//! policy (the default Windows client policy blocks script FILES, so
+//! a dot-sourced file would error in every pane). Shells with neither
+//! hook (bash needs `--posix` argv surgery, cmd.exe only has a
+//! machine-wide registry key) are left untouched, and every
+//! integrated pane exports `RIO_SHELL_INTEGRATION` pointing at the
+//! script directory so any shell can source the integration manually.
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -45,30 +49,42 @@ fn shell_display_name(program: &str) -> String {
     name.strip_suffix(".exe").unwrap_or(&name).to_string()
 }
 
-/// Extra environment for the pane about to spawn `shell_program`.
-/// Empty when the shell has no environment-only integration hook or
-/// the scripts could not be written.
+/// Extra environment for the pane about to spawn `shell_program`:
+/// the per-shell loading hook plus `RIO_SHELL_INTEGRATION`, which
+/// points every pane (any shell) at the script directory as the
+/// documented manual-sourcing hook. Empty when the scripts could not
+/// be written.
 pub fn spawn_env(shell_program: Option<&str>) -> Vec<(String, String)> {
     let shell_name = shell_display_name(&resolved_shell(shell_program));
     let Some(dir) = integration_dir() else {
         return Vec::new();
     };
-    env_pairs(
+    let mut envs = env_pairs(
         &shell_name,
         dir,
         std::env::var("ZDOTDIR").ok(),
         std::env::var("XDG_DATA_DIRS").ok(),
-    )
+    );
+    envs.push((
+        "RIO_SHELL_INTEGRATION".to_string(),
+        dir.to_string_lossy().to_string(),
+    ));
+    envs
 }
 
 /// Rewrites a PowerShell spawn (powershell.exe or pwsh, any platform)
 /// so the shell loads rio's integration script AFTER the user's
 /// profile ran. Only a bare spawn is rewritten: configured args change
-/// what `-Command` would mean, so they win over integration.
+/// what the command line means, so they win over integration. The
+/// returned program keeps an unconfigured shell unconfigured on unix,
+/// so the platform's default-shell handling (macOS `login(1)`) still
+/// wraps the spawn and only the args ride through it; Windows names
+/// the platform default explicitly because its PTY drops args when no
+/// program is given.
 pub fn powershell_command(
     shell_program: Option<&str>,
     args: &[String],
-) -> Option<(String, Vec<String>)> {
+) -> Option<(Option<String>, Vec<String>)> {
     if !args.is_empty() {
         return None;
     }
@@ -77,18 +93,32 @@ pub fn powershell_command(
     if name != "powershell" && name != "pwsh" {
         return None;
     }
-    let script = integration_dir()?.join("powershell").join("rio.ps1");
-    Some((program, powershell_args(&script)))
+    #[cfg(target_os = "windows")]
+    let program = Some(program);
+    #[cfg(not(target_os = "windows"))]
+    let program = shell_program.map(str::to_string);
+    Some((program, powershell_args()))
 }
 
-/// `-NoExit -Command . '<script>'`, with the path single-quoted so
-/// spaces survive and embedded quotes doubled per PowerShell quoting.
-fn powershell_args(script: &Path) -> Vec<String> {
-    let script = script.to_string_lossy().replace('\'', "''");
+/// `-NoExit -EncodedCommand <base64 of the UTF-16LE script>`: the
+/// script travels inline, so no file is dot-sourced (script FILES are
+/// what the default Windows execution policy blocks) and no quoting
+/// can break.
+fn powershell_args() -> Vec<String> {
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    static ENCODED: OnceLock<String> = OnceLock::new();
+    let encoded = ENCODED.get_or_init(|| {
+        let utf16le: Vec<u8> = POWERSHELL_INTEGRATION
+            .encode_utf16()
+            .flat_map(|unit| unit.to_le_bytes())
+            .collect();
+        B64.encode(utf16le)
+    });
     vec![
         "-NoExit".to_string(),
-        "-Command".to_string(),
-        format!(". '{script}'"),
+        "-EncodedCommand".to_string(),
+        encoded.clone(),
     ]
 }
 
@@ -142,6 +172,7 @@ fn integration_dir() -> Option<&'static Path> {
             tracing::warn!("shell integration scripts not written: {err}");
             return None;
         }
+        prune_stale(&base);
         Some(base)
     })
     .as_deref()
@@ -164,6 +195,31 @@ fn materialize(base: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(&powershell)?;
     write_if_changed(&powershell.join("rio.ps1"), POWERSHELL_INTEGRATION)?;
     Ok(())
+}
+
+/// Best-effort removal of other rio versions' script directories, so
+/// the cache holds one copy the way a packaged resources dir would.
+/// The `.zshenv` guards its source with `-r`, so a pane spawned by a
+/// concurrently running older rio degrades to no integration rather
+/// than an error banner.
+fn prune_stale(base: &Path) {
+    let Some(parent) = base.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path != base
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("shell-integration-"))
+        {
+            let _ = std::fs::remove_dir_all(&path);
+        }
+    }
 }
 
 fn write_if_changed(path: &Path, content: &str) -> std::io::Result<()> {
@@ -240,11 +296,53 @@ mod test {
     }
 
     #[test]
-    fn powershell_invocation_quotes_the_script_path() {
-        let args = powershell_args(Path::new("/tmp/o'brien/rio.ps1"));
+    fn powershell_invocation_carries_the_script_inline() {
+        use base64::engine::general_purpose::STANDARD as B64;
+        use base64::Engine as _;
+
+        let args = powershell_args();
         assert_eq!(args[0], "-NoExit");
-        assert_eq!(args[1], "-Command");
-        assert_eq!(args[2], ". '/tmp/o''brien/rio.ps1'");
+        assert_eq!(args[1], "-EncodedCommand");
+
+        // The payload decodes back to the exact script, UTF-16LE.
+        let bytes = B64.decode(&args[2]).unwrap();
+        let units: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect();
+        assert_eq!(String::from_utf16(&units).unwrap(), POWERSHELL_INTEGRATION);
+    }
+
+    #[test]
+    fn powershell_command_scope() {
+        // Configured args always win over integration.
+        assert!(powershell_command(Some("pwsh"), &["-NoLogo".into()]).is_none());
+        // Non-PowerShell shells are untouched.
+        assert!(powershell_command(Some("zsh"), &[]).is_none());
+
+        let (program, args) = powershell_command(Some("pwsh"), &[]).unwrap();
+        assert_eq!(program.as_deref(), Some("pwsh"));
+        assert_eq!(args[1], "-EncodedCommand");
+    }
+
+    #[test]
+    fn prune_removes_only_stale_siblings() {
+        let parent = std::env::temp_dir()
+            .join(format!("rio-si-prune-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&parent);
+        let current = parent.join("shell-integration-9.9.9");
+        let stale = parent.join("shell-integration-0.0.1");
+        let unrelated = parent.join("something-else");
+        std::fs::create_dir_all(&current).unwrap();
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::create_dir_all(&unrelated).unwrap();
+
+        prune_stale(&current);
+        assert!(current.exists());
+        assert!(!stale.exists());
+        assert!(unrelated.exists());
+
+        let _ = std::fs::remove_dir_all(&parent);
     }
 
     #[test]

--- a/frontends/rioterm/src/shell_integration/mod.rs
+++ b/frontends/rioterm/src/shell_integration/mod.rs
@@ -1,0 +1,195 @@
+//! Automatic shell integration.
+//!
+//! Rio embeds small per-shell scripts that report the working
+//! directory to the terminal (OSC 7, `kitty-shell-cwd://` flavor) on
+//! every prompt and directory change. At spawn time the scripts are
+//! written under the user's cache directory (once per rio version)
+//! and the child's environment is pointed at them: `ZDOTDIR` for zsh
+//! (the user's value is preserved in `RIO_ZSH_ZDOTDIR` and restored
+//! before any of their configuration runs) and an `XDG_DATA_DIRS`
+//! prepend for fish, whose `vendor_conf.d` loads from there. Shells
+//! without an environment-only hook (bash needs its argv rewritten)
+//! are left untouched.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+const ZSH_ZSHENV: &str = include_str!("zshenv.zsh");
+const ZSH_INTEGRATION: &str = include_str!("rio-integration.zsh");
+const FISH_INTEGRATION: &str = include_str!("rio.fish");
+
+/// Extra environment for the pane about to spawn `shell_program`
+/// (falling back to `$SHELL`, mirroring the PTY spawn itself). Empty
+/// when the shell has no environment-only integration hook or the
+/// scripts could not be written.
+pub fn spawn_env(shell_program: Option<&str>) -> Vec<(String, String)> {
+    let program = match shell_program {
+        Some(program) if !program.is_empty() => program.to_string(),
+        _ => std::env::var("SHELL").unwrap_or_default(),
+    };
+    let shell_name = Path::new(&program)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let Some(dir) = integration_dir() else {
+        return Vec::new();
+    };
+    env_pairs(
+        &shell_name,
+        dir,
+        std::env::var("ZDOTDIR").ok(),
+        std::env::var("XDG_DATA_DIRS").ok(),
+    )
+}
+
+/// The environment that makes `shell_name` load the scripts under
+/// `dir`. Pure so the mapping is testable without touching the real
+/// process environment or cache directory.
+fn env_pairs(
+    shell_name: &str,
+    dir: &Path,
+    current_zdotdir: Option<String>,
+    current_xdg_data_dirs: Option<String>,
+) -> Vec<(String, String)> {
+    match shell_name {
+        "zsh" => {
+            let mut envs = Vec::new();
+            if let Some(old) = current_zdotdir {
+                envs.push(("RIO_ZSH_ZDOTDIR".to_string(), old));
+            }
+            envs.push((
+                "ZDOTDIR".to_string(),
+                dir.join("zsh").to_string_lossy().to_string(),
+            ));
+            envs
+        }
+        "fish" => {
+            let data_dir = dir.join("data").to_string_lossy().to_string();
+            let dirs = match current_xdg_data_dirs {
+                Some(existing) if !existing.is_empty() => {
+                    format!("{data_dir}:{existing}")
+                }
+                // The XDG spec default applies when the variable is
+                // unset; spell it out so prepending does not hide it.
+                _ => format!("{data_dir}:/usr/local/share:/usr/share"),
+            };
+            vec![("XDG_DATA_DIRS".to_string(), dirs)]
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// The on-disk script directory, materialized once per process. Keyed
+/// by rio's version so upgrades rewrite stale scripts and downgrades
+/// never read newer ones.
+fn integration_dir() -> Option<&'static Path> {
+    static DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let base = dirs::cache_dir()?
+            .join("rio")
+            .join(format!("shell-integration-{}", env!("CARGO_PKG_VERSION")));
+        if let Err(err) = materialize(&base) {
+            tracing::warn!("shell integration scripts not written: {err}");
+            return None;
+        }
+        Some(base)
+    })
+    .as_deref()
+}
+
+/// Write the embedded scripts under `base`. Rewrites only files whose
+/// content differs, so concurrent rio processes racing here write the
+/// same bytes and the result is valid either way.
+fn materialize(base: &Path) -> std::io::Result<()> {
+    let zsh = base.join("zsh");
+    std::fs::create_dir_all(&zsh)?;
+    write_if_changed(&zsh.join(".zshenv"), ZSH_ZSHENV)?;
+    write_if_changed(&zsh.join("rio-integration.zsh"), ZSH_INTEGRATION)?;
+
+    let fish = base.join("data").join("fish").join("vendor_conf.d");
+    std::fs::create_dir_all(&fish)?;
+    write_if_changed(&fish.join("rio.fish"), FISH_INTEGRATION)?;
+    Ok(())
+}
+
+fn write_if_changed(path: &Path, content: &str) -> std::io::Result<()> {
+    if std::fs::read_to_string(path)
+        .map(|current| current == content)
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+    std::fs::write(path, content)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn env_pairs_per_shell() {
+        let dir = Path::new("/cache/rio/shell-integration-1.0.0");
+
+        let zsh = env_pairs("zsh", dir, None, None);
+        assert_eq!(
+            zsh,
+            vec![(
+                "ZDOTDIR".to_string(),
+                "/cache/rio/shell-integration-1.0.0/zsh".to_string()
+            )]
+        );
+
+        // A user ZDOTDIR is preserved for the .zshenv chain to restore.
+        let zsh = env_pairs("zsh", dir, Some("/home/u/.config/zsh".into()), None);
+        assert_eq!(
+            zsh[0],
+            (
+                "RIO_ZSH_ZDOTDIR".to_string(),
+                "/home/u/.config/zsh".to_string()
+            )
+        );
+        assert_eq!(zsh[1].0, "ZDOTDIR");
+
+        let fish = env_pairs("fish", dir, None, Some("/usr/share".into()));
+        assert_eq!(
+            fish,
+            vec![(
+                "XDG_DATA_DIRS".to_string(),
+                "/cache/rio/shell-integration-1.0.0/data:/usr/share".to_string()
+            )]
+        );
+
+        // Unset XDG_DATA_DIRS keeps the spec default visible.
+        let fish = env_pairs("fish", dir, None, None);
+        assert!(fish[0].1.ends_with(":/usr/local/share:/usr/share"));
+
+        // Shells without an environment-only hook are untouched.
+        assert!(env_pairs("bash", dir, None, None).is_empty());
+        assert!(env_pairs("nu", dir, None, None).is_empty());
+        assert!(env_pairs("", dir, None, None).is_empty());
+    }
+
+    #[test]
+    fn materialize_writes_scripts_idempotently() {
+        let base = std::env::temp_dir()
+            .join(format!("rio-shell-integration-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+
+        materialize(&base).unwrap();
+        let zshenv = base.join("zsh").join(".zshenv");
+        let fish = base
+            .join("data")
+            .join("fish")
+            .join("vendor_conf.d")
+            .join("rio.fish");
+        assert_eq!(std::fs::read_to_string(&zshenv).unwrap(), ZSH_ZSHENV);
+        assert!(base.join("zsh").join("rio-integration.zsh").exists());
+        assert_eq!(std::fs::read_to_string(&fish).unwrap(), FISH_INTEGRATION);
+
+        // A second run over existing content is a no-op, not an error.
+        materialize(&base).unwrap();
+        assert_eq!(std::fs::read_to_string(&zshenv).unwrap(), ZSH_ZSHENV);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}

--- a/frontends/rioterm/src/shell_integration/mod.rs
+++ b/frontends/rioterm/src/shell_integration/mod.rs
@@ -183,15 +183,13 @@ mod test {
     #[test]
     fn env_pairs_per_shell() {
         let dir = Path::new("/cache/rio/shell-integration-1.0.0");
+        // The join separator differs per platform; compare against the
+        // same join the implementation performs.
+        let zsh_dir = dir.join("zsh").to_string_lossy().to_string();
+        let data_dir = dir.join("data").to_string_lossy().to_string();
 
         let zsh = env_pairs("zsh", dir, None, None);
-        assert_eq!(
-            zsh,
-            vec![(
-                "ZDOTDIR".to_string(),
-                "/cache/rio/shell-integration-1.0.0/zsh".to_string()
-            )]
-        );
+        assert_eq!(zsh, vec![("ZDOTDIR".to_string(), zsh_dir.clone())]);
 
         // A user ZDOTDIR is preserved for the .zshenv chain to restore.
         let zsh = env_pairs("zsh", dir, Some("/home/u/.config/zsh".into()), None);
@@ -202,14 +200,14 @@ mod test {
                 "/home/u/.config/zsh".to_string()
             )
         );
-        assert_eq!(zsh[1].0, "ZDOTDIR");
+        assert_eq!(zsh[1], ("ZDOTDIR".to_string(), zsh_dir));
 
         let fish = env_pairs("fish", dir, None, Some("/usr/share".into()));
         assert_eq!(
             fish,
             vec![(
                 "XDG_DATA_DIRS".to_string(),
-                "/cache/rio/shell-integration-1.0.0/data:/usr/share".to_string()
+                format!("{data_dir}:/usr/share")
             )]
         );
 

--- a/frontends/rioterm/src/shell_integration/mod.rs
+++ b/frontends/rioterm/src/shell_integration/mod.rs
@@ -332,8 +332,8 @@ mod test {
     #[cfg(unix)]
     #[test]
     fn zsh_integration_emits_a_cwd_report() {
-        let base = std::env::temp_dir()
-            .join(format!("rio-si-zsh-test-{}", std::process::id()));
+        let base =
+            std::env::temp_dir().join(format!("rio-si-zsh-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&base);
         materialize(&base).unwrap();
         // An empty restored ZDOTDIR keeps the developer's own zsh

--- a/frontends/rioterm/src/shell_integration/mod.rs
+++ b/frontends/rioterm/src/shell_integration/mod.rs
@@ -8,16 +8,22 @@
 //! environment alone: `ZDOTDIR` for zsh (the user's value is preserved
 //! in `RIO_ZSH_ZDOTDIR` and restored before any of their configuration
 //! runs) and an `XDG_DATA_DIRS` prepend for fish, whose
-//! `vendor_conf.d` loads from there. PowerShell has no environment
-//! hook, so a bare spawn (no configured args) is rewritten to
-//! `-NoExit -EncodedCommand <script>` carrying the script inline,
-//! which runs after the user's profile and is exempt from execution
-//! policy (the default Windows client policy blocks script FILES, so
-//! a dot-sourced file would error in every pane). Shells with neither
-//! hook (bash needs `--posix` argv surgery, cmd.exe only has a
-//! machine-wide registry key) are left untouched, and every
+//! `vendor_conf.d` loads from there (the script restores the original
+//! value so the prepend never leaks to child processes). PowerShell
+//! has no environment hook, so a bare spawn (no configured args) is
+//! rewritten to `-NoExit -EncodedCommand <script>` carrying the script
+//! inline, which runs after the user's profile and is exempt from
+//! execution policy (the default Windows client policy blocks script
+//! FILES, so a dot-sourced file would error in every pane). Shells
+//! with neither hook (bash needs `--posix` argv surgery, cmd.exe only
+//! has a machine-wide registry key) are left untouched, and every
 //! integrated pane exports `RIO_SHELL_INTEGRATION` pointing at the
 //! script directory so any shell can source the integration manually.
+//!
+//! Old versions' script directories are deliberately left in place: a
+//! concurrently running older rio still spawns shells whose `ZDOTDIR`
+//! points into its own directory, and deleting it would make zsh skip
+//! the user's entire configuration.
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -27,13 +33,47 @@ const ZSH_INTEGRATION: &str = include_str!("rio-integration.zsh");
 const FISH_INTEGRATION: &str = include_str!("rio.fish");
 const POWERSHELL_INTEGRATION: &str = include_str!("rio.ps1");
 
+/// Everything shell integration wants applied to one spawn: extra
+/// environment, and for PowerShell a replacement `(program, args)`
+/// command (the program stays `None` when the shell was unconfigured,
+/// so platform default-shell handling such as macOS `login(1)` still
+/// wraps the spawn).
+#[derive(Default)]
+pub struct SpawnIntegration {
+    pub env: Vec<(String, String)>,
+    pub command: Option<(Option<String>, Vec<String>)>,
+}
+
+/// Resolve the shell once and derive both integration halves from it.
+/// Empty when the scripts could not be written.
+pub fn prepare(shell_program: Option<&str>, args: &[String]) -> SpawnIntegration {
+    let program = resolved_shell(shell_program);
+    let shell_name = shell_display_name(&program);
+    let Some(dir) = integration_dir() else {
+        return SpawnIntegration::default();
+    };
+    let mut env = env_pairs(
+        &shell_name,
+        dir,
+        std::env::var("ZDOTDIR").ok(),
+        std::env::var("XDG_DATA_DIRS").ok(),
+    );
+    env.push((
+        "RIO_SHELL_INTEGRATION".to_string(),
+        dir.to_string_lossy().to_string(),
+    ));
+    let command = powershell_command(&shell_name, shell_program, &program, args);
+    SpawnIntegration { env, command }
+}
+
 /// The program the PTY will spawn: the configured one, else the same
-/// platform default the spawn itself falls back to.
+/// resolution the spawn itself performs (`$SHELL`, then the passwd
+/// entry, on unix; `powershell` on Windows).
 fn resolved_shell(shell_program: Option<&str>) -> String {
     match shell_program {
         Some(program) if !program.is_empty() => program.to_string(),
         #[cfg(not(target_os = "windows"))]
-        _ => std::env::var("SHELL").unwrap_or_default(),
+        _ => teletypewriter::default_shell_program(),
         #[cfg(target_os = "windows")]
         _ => String::from("powershell"),
     }
@@ -47,79 +87,6 @@ fn shell_display_name(program: &str) -> String {
     let name = program.rsplit(['/', '\\']).next().unwrap_or(program);
     let name = name.to_ascii_lowercase();
     name.strip_suffix(".exe").unwrap_or(&name).to_string()
-}
-
-/// Extra environment for the pane about to spawn `shell_program`:
-/// the per-shell loading hook plus `RIO_SHELL_INTEGRATION`, which
-/// points every pane (any shell) at the script directory as the
-/// documented manual-sourcing hook. Empty when the scripts could not
-/// be written.
-pub fn spawn_env(shell_program: Option<&str>) -> Vec<(String, String)> {
-    let shell_name = shell_display_name(&resolved_shell(shell_program));
-    let Some(dir) = integration_dir() else {
-        return Vec::new();
-    };
-    let mut envs = env_pairs(
-        &shell_name,
-        dir,
-        std::env::var("ZDOTDIR").ok(),
-        std::env::var("XDG_DATA_DIRS").ok(),
-    );
-    envs.push((
-        "RIO_SHELL_INTEGRATION".to_string(),
-        dir.to_string_lossy().to_string(),
-    ));
-    envs
-}
-
-/// Rewrites a PowerShell spawn (powershell.exe or pwsh, any platform)
-/// so the shell loads rio's integration script AFTER the user's
-/// profile ran. Only a bare spawn is rewritten: configured args change
-/// what the command line means, so they win over integration. The
-/// returned program keeps an unconfigured shell unconfigured on unix,
-/// so the platform's default-shell handling (macOS `login(1)`) still
-/// wraps the spawn and only the args ride through it; Windows names
-/// the platform default explicitly because its PTY drops args when no
-/// program is given.
-pub fn powershell_command(
-    shell_program: Option<&str>,
-    args: &[String],
-) -> Option<(Option<String>, Vec<String>)> {
-    if !args.is_empty() {
-        return None;
-    }
-    let program = resolved_shell(shell_program);
-    let name = shell_display_name(&program);
-    if name != "powershell" && name != "pwsh" {
-        return None;
-    }
-    #[cfg(target_os = "windows")]
-    let program = Some(program);
-    #[cfg(not(target_os = "windows"))]
-    let program = shell_program.map(str::to_string);
-    Some((program, powershell_args()))
-}
-
-/// `-NoExit -EncodedCommand <base64 of the UTF-16LE script>`: the
-/// script travels inline, so no file is dot-sourced (script FILES are
-/// what the default Windows execution policy blocks) and no quoting
-/// can break.
-fn powershell_args() -> Vec<String> {
-    use base64::engine::general_purpose::STANDARD as B64;
-    use base64::Engine as _;
-    static ENCODED: OnceLock<String> = OnceLock::new();
-    let encoded = ENCODED.get_or_init(|| {
-        let utf16le: Vec<u8> = POWERSHELL_INTEGRATION
-            .encode_utf16()
-            .flat_map(|unit| unit.to_le_bytes())
-            .collect();
-        B64.encode(utf16le)
-    });
-    vec![
-        "-NoExit".to_string(),
-        "-EncodedCommand".to_string(),
-        encoded.clone(),
-    ]
 }
 
 /// The environment that makes `shell_name` load the scripts under
@@ -145,22 +112,84 @@ fn env_pairs(
         }
         "fish" => {
             let data_dir = dir.join("data").to_string_lossy().to_string();
-            let dirs = match current_xdg_data_dirs {
+            // The original value rides along (empty means "was unset")
+            // so the script can RESTORE it after loading: without the
+            // restore, every process the pane ever starts inherits the
+            // rio-version-specific prepend.
+            let (restore, dirs) = match current_xdg_data_dirs {
                 Some(existing) if !existing.is_empty() => {
-                    format!("{data_dir}:{existing}")
+                    let dirs = format!("{data_dir}:{existing}");
+                    (existing, dirs)
                 }
                 // The XDG spec default applies when the variable is
                 // unset; spell it out so prepending does not hide it.
-                _ => format!("{data_dir}:/usr/local/share:/usr/share"),
+                _ => (
+                    String::new(),
+                    format!("{data_dir}:/usr/local/share:/usr/share"),
+                ),
             };
-            vec![("XDG_DATA_DIRS".to_string(), dirs)]
+            vec![
+                ("RIO_FISH_XDG_DATA_DIRS".to_string(), restore),
+                ("XDG_DATA_DIRS".to_string(), dirs),
+            ]
         }
         _ => Vec::new(),
     }
 }
 
+/// Rewrites a PowerShell spawn (powershell.exe or pwsh, any platform)
+/// so the shell loads rio's integration script AFTER the user's
+/// profile ran. Only a bare spawn is rewritten: configured args change
+/// what the command line means, so they win over integration. The
+/// returned program keeps an unconfigured shell unconfigured on unix,
+/// so the platform's default-shell handling (macOS `login(1)`) still
+/// wraps the spawn and only the args ride through it; Windows names
+/// the platform default explicitly because its PTY drops args when no
+/// program is given.
+fn powershell_command(
+    shell_name: &str,
+    configured_program: Option<&str>,
+    resolved_program: &str,
+    args: &[String],
+) -> Option<(Option<String>, Vec<String>)> {
+    if shell_name != "powershell" && shell_name != "pwsh" {
+        return None;
+    }
+    if !args.is_empty() {
+        tracing::info!("shell integration skipped: PowerShell spawn has configured args");
+        return None;
+    }
+    #[cfg(target_os = "windows")]
+    let program = Some(resolved_program.to_string());
+    #[cfg(not(target_os = "windows"))]
+    let program = {
+        let _ = resolved_program;
+        configured_program.map(str::to_string)
+    };
+    Some((program, powershell_args()))
+}
+
+/// `-NoExit -EncodedCommand <base64 of the UTF-16LE script>`: the
+/// script travels inline, so no file is dot-sourced (script FILES are
+/// what the default Windows execution policy blocks) and no quoting
+/// can break. Encoded per call: this runs once per PowerShell pane,
+/// where microseconds of base64 vanish next to the process spawn.
+fn powershell_args() -> Vec<String> {
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    let utf16le: Vec<u8> = POWERSHELL_INTEGRATION
+        .encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect();
+    vec![
+        "-NoExit".to_string(),
+        "-EncodedCommand".to_string(),
+        B64.encode(utf16le),
+    ]
+}
+
 /// The on-disk script directory, materialized once per process. Keyed
-/// by rio's version so upgrades rewrite stale scripts and downgrades
+/// by rio's version so upgrades write fresh scripts and downgrades
 /// never read newer ones.
 fn integration_dir() -> Option<&'static Path> {
     static DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
@@ -172,7 +201,6 @@ fn integration_dir() -> Option<&'static Path> {
             tracing::warn!("shell integration scripts not written: {err}");
             return None;
         }
-        prune_stale(&base);
         Some(base)
     })
     .as_deref()
@@ -195,31 +223,6 @@ fn materialize(base: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(&powershell)?;
     write_if_changed(&powershell.join("rio.ps1"), POWERSHELL_INTEGRATION)?;
     Ok(())
-}
-
-/// Best-effort removal of other rio versions' script directories, so
-/// the cache holds one copy the way a packaged resources dir would.
-/// The `.zshenv` guards its source with `-r`, so a pane spawned by a
-/// concurrently running older rio degrades to no integration rather
-/// than an error banner.
-fn prune_stale(base: &Path) {
-    let Some(parent) = base.parent() else {
-        return;
-    };
-    let Ok(entries) = std::fs::read_dir(parent) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path != base
-            && path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.starts_with("shell-integration-"))
-        {
-            let _ = std::fs::remove_dir_all(&path);
-        }
-    }
 }
 
 fn write_if_changed(path: &Path, content: &str) -> std::io::Result<()> {
@@ -258,18 +261,30 @@ mod test {
         );
         assert_eq!(zsh[1], ("ZDOTDIR".to_string(), zsh_dir));
 
+        // A user XDG_DATA_DIRS is preserved for rio.fish to restore.
         let fish = env_pairs("fish", dir, None, Some("/usr/share".into()));
         assert_eq!(
             fish,
-            vec![(
-                "XDG_DATA_DIRS".to_string(),
-                format!("{data_dir}:/usr/share")
-            )]
+            vec![
+                (
+                    "RIO_FISH_XDG_DATA_DIRS".to_string(),
+                    "/usr/share".to_string()
+                ),
+                (
+                    "XDG_DATA_DIRS".to_string(),
+                    format!("{data_dir}:/usr/share")
+                ),
+            ]
         );
 
-        // Unset XDG_DATA_DIRS keeps the spec default visible.
+        // Unset XDG_DATA_DIRS keeps the spec default visible, and the
+        // empty restore value tells the script to unset it again.
         let fish = env_pairs("fish", dir, None, None);
-        assert!(fish[0].1.ends_with(":/usr/local/share:/usr/share"));
+        assert_eq!(
+            fish[0],
+            ("RIO_FISH_XDG_DATA_DIRS".to_string(), String::new())
+        );
+        assert!(fish[1].1.ends_with(":/usr/local/share:/usr/share"));
 
         // Shells without an environment-only hook are untouched.
         assert!(env_pairs("bash", dir, None, None).is_empty());
@@ -316,11 +331,15 @@ mod test {
     #[test]
     fn powershell_command_scope() {
         // Configured args always win over integration.
-        assert!(powershell_command(Some("pwsh"), &["-NoLogo".into()]).is_none());
+        assert!(
+            powershell_command("pwsh", Some("pwsh"), "pwsh", &["-NoLogo".into()])
+                .is_none()
+        );
         // Non-PowerShell shells are untouched.
-        assert!(powershell_command(Some("zsh"), &[]).is_none());
+        assert!(powershell_command("zsh", Some("zsh"), "zsh", &[]).is_none());
 
-        let (program, args) = powershell_command(Some("pwsh"), &[]).unwrap();
+        let (program, args) =
+            powershell_command("pwsh", Some("pwsh"), "pwsh", &[]).unwrap();
         assert_eq!(program.as_deref(), Some("pwsh"));
         assert_eq!(args[1], "-EncodedCommand");
     }
@@ -360,12 +379,13 @@ mod test {
     }
 
     /// Same, for fish, via its `vendor_conf.d` loading from
-    /// `XDG_DATA_DIRS`. Skips silently where fish is not installed
-    /// (no CI runner ships it today, so this mainly guards local
-    /// changes to the fish script).
+    /// `XDG_DATA_DIRS`, which the script must then RESTORE so the
+    /// prepend never leaks to child processes. Skips silently where
+    /// fish is not installed (no CI runner ships it today, so this
+    /// mainly guards local changes to the fish script).
     #[cfg(unix)]
     #[test]
-    fn fish_integration_emits_a_cwd_report() {
+    fn fish_integration_emits_a_cwd_report_and_restores_env() {
         let base =
             std::env::temp_dir().join(format!("rio-si-fish-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&base);
@@ -376,8 +396,9 @@ mod test {
         std::fs::create_dir_all(&config_home).unwrap();
 
         let Ok(output) = std::process::Command::new("fish")
-            .args(["-ic", ":"])
+            .args(["-ic", "echo RIO_XDG=$XDG_DATA_DIRS"])
             .env("XDG_DATA_DIRS", base.join("data"))
+            .env("RIO_FISH_XDG_DATA_DIRS", "/usr/share")
             .env("XDG_CONFIG_HOME", &config_home)
             .output()
         else {
@@ -389,28 +410,12 @@ mod test {
             "no OSC 7 in fish output; stdout: {stdout:?}, stderr: {:?}",
             String::from_utf8_lossy(&output.stderr)
         );
+        assert!(
+            stdout.contains("RIO_XDG=/usr/share"),
+            "XDG_DATA_DIRS not restored; stdout: {stdout:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
-    }
-
-    #[test]
-    fn prune_removes_only_stale_siblings() {
-        let parent = std::env::temp_dir()
-            .join(format!("rio-si-prune-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&parent);
-        let current = parent.join("shell-integration-9.9.9");
-        let stale = parent.join("shell-integration-0.0.1");
-        let unrelated = parent.join("something-else");
-        std::fs::create_dir_all(&current).unwrap();
-        std::fs::create_dir_all(&stale).unwrap();
-        std::fs::create_dir_all(&unrelated).unwrap();
-
-        prune_stale(&current);
-        assert!(current.exists());
-        assert!(!stale.exists());
-        assert!(unrelated.exists());
-
-        let _ = std::fs::remove_dir_all(&parent);
     }
 
     #[test]
@@ -429,6 +434,7 @@ mod test {
         assert_eq!(std::fs::read_to_string(&zshenv).unwrap(), ZSH_ZSHENV);
         assert!(base.join("zsh").join("rio-integration.zsh").exists());
         assert_eq!(std::fs::read_to_string(&fish).unwrap(), FISH_INTEGRATION);
+        assert!(base.join("powershell").join("rio.ps1").exists());
 
         // A second run over existing content is a no-op, not an error.
         materialize(&base).unwrap();

--- a/frontends/rioterm/src/shell_integration/mod.rs
+++ b/frontends/rioterm/src/shell_integration/mod.rs
@@ -4,12 +4,16 @@
 //! directory to the terminal (OSC 7, `kitty-shell-cwd://` flavor) on
 //! every prompt and directory change. At spawn time the scripts are
 //! written under the user's cache directory (once per rio version)
-//! and the child's environment is pointed at them: `ZDOTDIR` for zsh
-//! (the user's value is preserved in `RIO_ZSH_ZDOTDIR` and restored
-//! before any of their configuration runs) and an `XDG_DATA_DIRS`
-//! prepend for fish, whose `vendor_conf.d` loads from there. Shells
-//! without an environment-only hook (bash needs its argv rewritten)
-//! are left untouched.
+//! and the child is pointed at them. zsh and fish load through the
+//! environment alone: `ZDOTDIR` for zsh (the user's value is preserved
+//! in `RIO_ZSH_ZDOTDIR` and restored before any of their configuration
+//! runs) and an `XDG_DATA_DIRS` prepend for fish, whose
+//! `vendor_conf.d` loads from there. PowerShell has no environment
+//! hook, so a bare spawn (no configured args) is rewritten to
+//! `-NoExit -Command . '<script>'`, which runs after the user's
+//! profile. Shells with neither hook (bash needs `--posix` argv
+//! surgery, cmd.exe only has a machine-wide registry key) are left
+//! untouched.
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -17,20 +21,35 @@ use std::sync::OnceLock;
 const ZSH_ZSHENV: &str = include_str!("zshenv.zsh");
 const ZSH_INTEGRATION: &str = include_str!("rio-integration.zsh");
 const FISH_INTEGRATION: &str = include_str!("rio.fish");
+const POWERSHELL_INTEGRATION: &str = include_str!("rio.ps1");
 
-/// Extra environment for the pane about to spawn `shell_program`
-/// (falling back to `$SHELL`, mirroring the PTY spawn itself). Empty
-/// when the shell has no environment-only integration hook or the
-/// scripts could not be written.
-pub fn spawn_env(shell_program: Option<&str>) -> Vec<(String, String)> {
-    let program = match shell_program {
+/// The program the PTY will spawn: the configured one, else the same
+/// platform default the spawn itself falls back to.
+fn resolved_shell(shell_program: Option<&str>) -> String {
+    match shell_program {
         Some(program) if !program.is_empty() => program.to_string(),
+        #[cfg(not(target_os = "windows"))]
         _ => std::env::var("SHELL").unwrap_or_default(),
-    };
-    let shell_name = Path::new(&program)
-        .file_name()
-        .map(|name| name.to_string_lossy().to_string())
-        .unwrap_or_default();
+        #[cfg(target_os = "windows")]
+        _ => String::from("powershell"),
+    }
+}
+
+/// The shell's identity from its program path: basename with both
+/// separator flavors (a Windows path can carry `\`), lowercased,
+/// `.exe` dropped, so `C:\W\pwsh.exe` and `/usr/bin/pwsh` compare
+/// equal.
+fn shell_display_name(program: &str) -> String {
+    let name = program.rsplit(['/', '\\']).next().unwrap_or(program);
+    let name = name.to_ascii_lowercase();
+    name.strip_suffix(".exe").unwrap_or(&name).to_string()
+}
+
+/// Extra environment for the pane about to spawn `shell_program`.
+/// Empty when the shell has no environment-only integration hook or
+/// the scripts could not be written.
+pub fn spawn_env(shell_program: Option<&str>) -> Vec<(String, String)> {
+    let shell_name = shell_display_name(&resolved_shell(shell_program));
     let Some(dir) = integration_dir() else {
         return Vec::new();
     };
@@ -40,6 +59,37 @@ pub fn spawn_env(shell_program: Option<&str>) -> Vec<(String, String)> {
         std::env::var("ZDOTDIR").ok(),
         std::env::var("XDG_DATA_DIRS").ok(),
     )
+}
+
+/// Rewrites a PowerShell spawn (powershell.exe or pwsh, any platform)
+/// so the shell loads rio's integration script AFTER the user's
+/// profile ran. Only a bare spawn is rewritten: configured args change
+/// what `-Command` would mean, so they win over integration.
+pub fn powershell_command(
+    shell_program: Option<&str>,
+    args: &[String],
+) -> Option<(String, Vec<String>)> {
+    if !args.is_empty() {
+        return None;
+    }
+    let program = resolved_shell(shell_program);
+    let name = shell_display_name(&program);
+    if name != "powershell" && name != "pwsh" {
+        return None;
+    }
+    let script = integration_dir()?.join("powershell").join("rio.ps1");
+    Some((program, powershell_args(&script)))
+}
+
+/// `-NoExit -Command . '<script>'`, with the path single-quoted so
+/// spaces survive and embedded quotes doubled per PowerShell quoting.
+fn powershell_args(script: &Path) -> Vec<String> {
+    let script = script.to_string_lossy().replace('\'', "''");
+    vec![
+        "-NoExit".to_string(),
+        "-Command".to_string(),
+        format!(". '{script}'"),
+    ]
 }
 
 /// The environment that makes `shell_name` load the scripts under
@@ -109,6 +159,10 @@ fn materialize(base: &Path) -> std::io::Result<()> {
     let fish = base.join("data").join("fish").join("vendor_conf.d");
     std::fs::create_dir_all(&fish)?;
     write_if_changed(&fish.join("rio.fish"), FISH_INTEGRATION)?;
+
+    let powershell = base.join("powershell");
+    std::fs::create_dir_all(&powershell)?;
+    write_if_changed(&powershell.join("rio.ps1"), POWERSHELL_INTEGRATION)?;
     Ok(())
 }
 
@@ -165,8 +219,34 @@ mod test {
 
         // Shells without an environment-only hook are untouched.
         assert!(env_pairs("bash", dir, None, None).is_empty());
+        assert!(env_pairs("powershell", dir, None, None).is_empty());
         assert!(env_pairs("nu", dir, None, None).is_empty());
         assert!(env_pairs("", dir, None, None).is_empty());
+    }
+
+    #[test]
+    fn shell_names_normalize_across_platforms() {
+        assert_eq!(shell_display_name("/usr/local/bin/fish"), "fish");
+        assert_eq!(shell_display_name("zsh"), "zsh");
+        assert_eq!(
+            shell_display_name("C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+            "pwsh"
+        );
+        assert_eq!(
+            shell_display_name(
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+            ),
+            "powershell"
+        );
+        assert_eq!(shell_display_name("PWSH.EXE"), "pwsh");
+    }
+
+    #[test]
+    fn powershell_invocation_quotes_the_script_path() {
+        let args = powershell_args(Path::new("/tmp/o'brien/rio.ps1"));
+        assert_eq!(args[0], "-NoExit");
+        assert_eq!(args[1], "-Command");
+        assert_eq!(args[2], ". '/tmp/o''brien/rio.ps1'");
     }
 
     #[test]

--- a/frontends/rioterm/src/shell_integration/mod.rs
+++ b/frontends/rioterm/src/shell_integration/mod.rs
@@ -359,6 +359,40 @@ mod test {
         let _ = std::fs::remove_dir_all(&base);
     }
 
+    /// Same, for fish, via its `vendor_conf.d` loading from
+    /// `XDG_DATA_DIRS`. Skips silently where fish is not installed
+    /// (no CI runner ships it today, so this mainly guards local
+    /// changes to the fish script).
+    #[cfg(unix)]
+    #[test]
+    fn fish_integration_emits_a_cwd_report() {
+        let base =
+            std::env::temp_dir().join(format!("rio-si-fish-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        materialize(&base).unwrap();
+        // An empty config home keeps the developer's own fish config
+        // out of the test.
+        let config_home = base.join("empty-config-home");
+        std::fs::create_dir_all(&config_home).unwrap();
+
+        let Ok(output) = std::process::Command::new("fish")
+            .args(["-ic", ":"])
+            .env("XDG_DATA_DIRS", base.join("data"))
+            .env("XDG_CONFIG_HOME", &config_home)
+            .output()
+        else {
+            return;
+        };
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("\x1b]7;kitty-shell-cwd://"),
+            "no OSC 7 in fish output; stdout: {stdout:?}, stderr: {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
     #[test]
     fn prune_removes_only_stale_siblings() {
         let parent = std::env::temp_dir()

--- a/frontends/rioterm/src/shell_integration/mod.rs
+++ b/frontends/rioterm/src/shell_integration/mod.rs
@@ -325,6 +325,40 @@ mod test {
         assert_eq!(args[1], "-EncodedCommand");
     }
 
+    /// Runs a real zsh against the materialized scripts: the pane
+    /// setup (ZDOTDIR redirect plus preserved user ZDOTDIR) must end
+    /// with the integration loaded and one cwd report emitted. Skips
+    /// silently where zsh is not installed.
+    #[cfg(unix)]
+    #[test]
+    fn zsh_integration_emits_a_cwd_report() {
+        let base = std::env::temp_dir()
+            .join(format!("rio-si-zsh-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        materialize(&base).unwrap();
+        // An empty restored ZDOTDIR keeps the developer's own zsh
+        // config out of the test.
+        let user_zdotdir = base.join("empty-user-config");
+        std::fs::create_dir_all(&user_zdotdir).unwrap();
+
+        let Ok(output) = std::process::Command::new("zsh")
+            .args(["-ic", ":"])
+            .env("ZDOTDIR", base.join("zsh"))
+            .env("RIO_ZSH_ZDOTDIR", &user_zdotdir)
+            .output()
+        else {
+            return;
+        };
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("\x1b]7;kitty-shell-cwd://"),
+            "no OSC 7 in zsh output; stdout: {stdout:?}, stderr: {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
     #[test]
     fn prune_removes_only_stale_siblings() {
         let parent = std::env::temp_dir()

--- a/frontends/rioterm/src/shell_integration/rio-integration.zsh
+++ b/frontends/rioterm/src/shell_integration/rio-integration.zsh
@@ -1,0 +1,16 @@
+# Reports the working directory to rio (OSC 7) on every prompt and
+# directory change, which powers the title path variables and opening
+# new tabs in the current directory. Loading twice is a no-op.
+if [[ -n "${_rio_integration+x}" ]]; then
+    return 0
+fi
+builtin typeset -g _rio_integration=1
+
+_rio_report_pwd() {
+    builtin printf '\e]7;kitty-shell-cwd://%s%s\a' "${HOST-}" "$PWD"
+}
+
+builtin autoload -Uz add-zsh-hook
+add-zsh-hook chpwd _rio_report_pwd
+add-zsh-hook precmd _rio_report_pwd
+_rio_report_pwd

--- a/frontends/rioterm/src/shell_integration/rio.fish
+++ b/frontends/rioterm/src/shell_integration/rio.fish
@@ -1,0 +1,10 @@
+# Reports the working directory to rio (OSC 7) on every prompt and
+# directory change, which powers the title path variables and opening
+# new tabs in the current directory.
+status is-interactive; or exit
+
+function __rio_report_pwd --on-variable PWD --on-event fish_prompt \
+        --description 'Report the working directory to rio (OSC 7)'
+    printf '\e]7;kitty-shell-cwd://%s%s\a' $hostname $PWD
+end
+__rio_report_pwd

--- a/frontends/rioterm/src/shell_integration/rio.fish
+++ b/frontends/rioterm/src/shell_integration/rio.fish
@@ -1,6 +1,19 @@
 # Reports the working directory to rio (OSC 7) on every prompt and
 # directory change, which powers the title path variables and opening
 # new tabs in the current directory.
+
+# Rio prepended its script directory to XDG_DATA_DIRS so this file
+# loads; restore the original value (empty means it was unset) so the
+# prepend never leaks to child processes.
+if set -q RIO_FISH_XDG_DATA_DIRS
+    if test -n "$RIO_FISH_XDG_DATA_DIRS"
+        set -gx XDG_DATA_DIRS "$RIO_FISH_XDG_DATA_DIRS"
+    else
+        set -e XDG_DATA_DIRS
+    end
+    set -e RIO_FISH_XDG_DATA_DIRS
+end
+
 status is-interactive; or exit
 
 function __rio_report_pwd --on-variable PWD --on-event fish_prompt \

--- a/frontends/rioterm/src/shell_integration/rio.ps1
+++ b/frontends/rioterm/src/shell_integration/rio.ps1
@@ -10,6 +10,11 @@ $Global:__RioShellIntegration = $true
 $Global:__RioOriginalPrompt = $Function:Prompt
 
 function Global:Prompt {
+    # Preserve the state the user's prompt inspects: $LASTEXITCODE is
+    # restored directly, and since $? is not assignable, a deliberately
+    # failing statement re-arms it when the last command failed.
+    $Global:__RioLastSuccess = $?
+    $Global:__RioLastExitCode = $Global:LASTEXITCODE
     $location = $ExecutionContext.SessionState.Path.CurrentLocation
     if ($location.Provider.Name -eq 'FileSystem') {
         $path = $location.ProviderPath
@@ -18,5 +23,11 @@ function Global:Prompt {
             [Console]::Write("$([char]27)]7;kitty-shell-cwd://$path$([char]7)")
         }
     }
-    & $Global:__RioOriginalPrompt
+    $Global:LASTEXITCODE = $Global:__RioLastExitCode
+    if ($Global:__RioLastSuccess) {
+        & $Global:__RioOriginalPrompt
+    } else {
+        Microsoft.PowerShell.Utility\Write-Error '' -ErrorAction SilentlyContinue
+        & $Global:__RioOriginalPrompt
+    }
 }

--- a/frontends/rioterm/src/shell_integration/rio.ps1
+++ b/frontends/rioterm/src/shell_integration/rio.ps1
@@ -1,0 +1,16 @@
+# Reports the working directory to rio (OSC 7) from the prompt, which
+# powers the title path variables and opening new tabs in the current
+# directory. Loading twice is a no-op.
+if ($Global:__RioShellIntegration) { return }
+$Global:__RioShellIntegration = $true
+
+$Global:__RioOriginalPrompt = $Function:Prompt
+
+function Global:Prompt {
+    $location = $ExecutionContext.SessionState.Path.CurrentLocation
+    if ($location.Provider.Name -eq 'FileSystem') {
+        $uri = ([System.Uri]$location.ProviderPath).AbsoluteUri
+        [Console]::Write("$([char]27)]7;$uri$([char]7)")
+    }
+    & $Global:__RioOriginalPrompt
+}

--- a/frontends/rioterm/src/shell_integration/rio.ps1
+++ b/frontends/rioterm/src/shell_integration/rio.ps1
@@ -1,6 +1,9 @@
-# Reports the working directory to rio (OSC 7) from the prompt, which
-# powers the title path variables and opening new tabs in the current
-# directory. Loading twice is a no-op.
+# Reports the working directory to rio (OSC 7, kitty-shell-cwd flavor:
+# the path travels verbatim, so spaces, `#` and `%` need no encoding),
+# which powers the title path variables and opening new tabs in the
+# current directory. UNC paths are skipped: the verbatim flavor has no
+# host field to mark them as belonging to another machine. Loading
+# twice is a no-op.
 if ($Global:__RioShellIntegration) { return }
 $Global:__RioShellIntegration = $true
 
@@ -9,8 +12,11 @@ $Global:__RioOriginalPrompt = $Function:Prompt
 function Global:Prompt {
     $location = $ExecutionContext.SessionState.Path.CurrentLocation
     if ($location.Provider.Name -eq 'FileSystem') {
-        $uri = ([System.Uri]$location.ProviderPath).AbsoluteUri
-        [Console]::Write("$([char]27)]7;$uri$([char]7)")
+        $path = $location.ProviderPath
+        if (-not $path.StartsWith('\\')) {
+            if (-not $path.StartsWith('/')) { $path = "/$path" }
+            [Console]::Write("$([char]27)]7;kitty-shell-cwd://$path$([char]7)")
+        }
     }
     & $Global:__RioOriginalPrompt
 }

--- a/frontends/rioterm/src/shell_integration/zshenv.zsh
+++ b/frontends/rioterm/src/shell_integration/zshenv.zsh
@@ -15,9 +15,9 @@ fi
 builtin unset _rio_user_zshenv
 
 if [[ -o interactive ]]; then
-    builtin typeset _rio_integration="${${(%):-%x}:A:h}/rio-integration.zsh"
-    if [[ -r "$_rio_integration" ]]; then
-        builtin source -- "$_rio_integration"
+    builtin typeset _rio_integration_file="${${(%):-%x}:A:h}/rio-integration.zsh"
+    if [[ -r "$_rio_integration_file" ]]; then
+        builtin source -- "$_rio_integration_file"
     fi
-    builtin unset _rio_integration
+    builtin unset _rio_integration_file
 fi

--- a/frontends/rioterm/src/shell_integration/zshenv.zsh
+++ b/frontends/rioterm/src/shell_integration/zshenv.zsh
@@ -15,5 +15,9 @@ fi
 builtin unset _rio_user_zshenv
 
 if [[ -o interactive ]]; then
-    builtin source -- "${${(%):-%x}:A:h}/rio-integration.zsh"
+    builtin typeset _rio_integration="${${(%):-%x}:A:h}/rio-integration.zsh"
+    if [[ -r "$_rio_integration" ]]; then
+        builtin source -- "$_rio_integration"
+    fi
+    builtin unset _rio_integration
 fi

--- a/frontends/rioterm/src/shell_integration/zshenv.zsh
+++ b/frontends/rioterm/src/shell_integration/zshenv.zsh
@@ -1,0 +1,19 @@
+# Sourced by zsh because rio pointed ZDOTDIR here. Restores the user's
+# ZDOTDIR, chains their real .zshenv, then loads the integration for
+# interactive shells, so their own configuration always runs first.
+if [[ -n "${RIO_ZSH_ZDOTDIR+x}" ]]; then
+    builtin export ZDOTDIR="$RIO_ZSH_ZDOTDIR"
+    builtin unset RIO_ZSH_ZDOTDIR
+else
+    builtin unset ZDOTDIR
+fi
+
+builtin typeset _rio_user_zshenv="${ZDOTDIR:-$HOME}/.zshenv"
+if [[ -r "$_rio_user_zshenv" && ! -d "$_rio_user_zshenv" ]]; then
+    builtin source -- "$_rio_user_zshenv"
+fi
+builtin unset _rio_user_zshenv
+
+if [[ -o interactive ]]; then
+    builtin source -- "${${(%):-%x}:A:h}/rio-integration.zsh"
+fi

--- a/rio-backend/src/config/mod.rs
+++ b/rio-backend/src/config/mod.rs
@@ -110,6 +110,11 @@ pub struct Config {
     pub platform: Platform,
     #[serde(default = "default_use_fork", rename = "use-fork")]
     pub use_fork: bool,
+    /// Inject rio's shell integration into spawned zsh and fish
+    /// shells, so the working directory reaches the terminal (OSC 7)
+    /// with no user setup.
+    #[serde(default = "default_bool_true", rename = "shell-integration")]
+    pub shell_integration: bool,
     #[serde(default = "Keyboard::default")]
     pub keyboard: Keyboard,
     #[serde(default = "Title::default")]
@@ -678,6 +683,7 @@ impl Default for Config {
             platform: Platform::default(),
             theme: String::default(),
             use_fork: default_use_fork(),
+            shell_integration: true,
             window: Window::default(),
             working_dir: default_working_dir(),
             ignore_selection_fg_color: false,

--- a/rio-vt/src/performer/handler.rs
+++ b/rio-vt/src/performer/handler.rs
@@ -1141,8 +1141,10 @@ impl<U: Handler> Perform for Performer<'_, U> {
 
             // Inform current directory.
             b"7" => {
-                if params.len() >= 2 {
-                    if let Some(path) = osc::parse_current_directory(params[1]) {
+                // Rejoined: the kitty-shell-cwd flavor is verbatim, so a
+                // `;` in the directory arrives as extra params.
+                if let Some(payload) = osc::join_params(params, 1) {
+                    if let Some(path) = osc::parse_current_directory(payload.as_bytes()) {
                         self.handler.set_current_directory(path.into());
                     }
                 }
@@ -1154,22 +1156,27 @@ impl<U: Handler> Perform for Performer<'_, U> {
                     .set_hyperlink(osc::parse_hyperlink(params[1], params[2]));
             }
 
-            // OSC 9;4 progress; OSC 9;9 working directory;
-            // OSC 9 desktop notification fallback.
-            b"9" => {
-                if let Some(report) = osc::parse_progress_report(params) {
-                    self.handler.set_progress_report(report);
-                } else if let Some(path) = osc::parse_conemu_working_directory(params) {
-                    self.handler.set_current_directory(path.into());
-                } else if params.len() >= 2 {
-                    let body = std::str::from_utf8(params[1])
-                        .unwrap_or_default()
-                        .to_string();
-                    self.handler.desktop_notification(String::new(), body);
-                } else {
-                    unhandled(params);
+            // OSC 9 dispatches on its sub-command: 9;4 progress and 9;9
+            // working directory are consumed even when their payload is
+            // invalid (a malformed known sub-command must not pop a
+            // bogus notification); anything else is a notification.
+            b"9" => match params.get(1).copied() {
+                Some(b"4") => {
+                    if let Some(report) = osc::parse_progress_report(params) {
+                        self.handler.set_progress_report(report);
+                    }
                 }
-            }
+                Some(b"9") => {
+                    if let Some(path) = osc::parse_conemu_working_directory(params) {
+                        self.handler.set_current_directory(path.into());
+                    }
+                }
+                Some(body) => {
+                    let body = std::str::from_utf8(body).unwrap_or_default().to_string();
+                    self.handler.desktop_notification(String::new(), body);
+                }
+                None => unhandled(params),
+            },
 
             // OSC 133 - semantic prompt zones (shell integration).
             b"133" => {

--- a/rio-vt/src/performer/handler.rs
+++ b/rio-vt/src/performer/handler.rs
@@ -1154,10 +1154,13 @@ impl<U: Handler> Perform for Performer<'_, U> {
                     .set_hyperlink(osc::parse_hyperlink(params[1], params[2]));
             }
 
-            // OSC 9;4 progress; OSC 9 desktop notification fallback.
+            // OSC 9;4 progress; OSC 9;9 working directory;
+            // OSC 9 desktop notification fallback.
             b"9" => {
                 if let Some(report) = osc::parse_progress_report(params) {
                     self.handler.set_progress_report(report);
+                } else if let Some(path) = osc::parse_conemu_working_directory(params) {
+                    self.handler.set_current_directory(path.into());
                 } else if params.len() >= 2 {
                     let body = std::str::from_utf8(params[1])
                         .unwrap_or_default()

--- a/rio-vt/src/performer/osc.rs
+++ b/rio-vt/src/performer/osc.rs
@@ -267,17 +267,18 @@ fn host_is_local(host: &str) -> bool {
     }
 
     match local_hostname() {
-        Some(local) => host.eq_ignore_ascii_case(local),
+        Some(local) => host.eq_ignore_ascii_case(&local),
         // With no hostname to compare against, take the shell at its word
         // rather than dropping the directory outright.
         None => true,
     }
 }
 
-/// This machine's hostname, looked up once.
-fn local_hostname() -> Option<&'static str> {
-    static HOSTNAME: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
-    HOSTNAME.get_or_init(read_hostname).as_deref()
+/// This machine's hostname, read per check: one syscall, where a
+/// process-lifetime cache would keep rejecting a shell's cwd reports
+/// after the hostname changes mid-session (macOS mDNS renames).
+fn local_hostname() -> Option<String> {
+    read_hostname()
 }
 
 #[cfg(unix)]

--- a/rio-vt/src/performer/osc.rs
+++ b/rio-vt/src/performer/osc.rs
@@ -195,15 +195,25 @@ pub(super) fn parse_palette_entries(params: &[&[u8]]) -> Option<Vec<PaletteEntry
     Some(out)
 }
 
-/// The only URL scheme rio-vt ever parses.
+/// The URL schemes rio-vt ever parses, both OSC 7 working-directory
+/// carriers: RFC 8089 file URLs and the `kitty-shell-cwd` scheme
+/// (a raw, unencoded path) that kitty defined and several shell
+/// integrations emit.
 const FILE_SCHEME: &str = "file://";
+const KITTY_SHELL_CWD_SCHEME: &str = "kitty-shell-cwd://";
 
-/// OSC 7: working directory as a `file://` URL.
-///
-/// The payload is `file://<host>/<path>`, with a percent-encoded path. Parsed
-/// by hand rather than with a URL crate: this is the only URL the terminal core
-/// looks at, and a general parser costs an IDNA/Unicode stack just to reach
-/// `.path()`.
+/// Strip `scheme` from the front of `s`, case-insensitively.
+fn strip_scheme<'a>(s: &'a str, scheme: &str) -> Option<&'a str> {
+    s.get(..scheme.len())
+        .filter(|prefix| prefix.eq_ignore_ascii_case(scheme))
+        .map(|_| &s[scheme.len()..])
+}
+
+/// OSC 7: working directory as a `file://` URL (percent-encoded path)
+/// or a `kitty-shell-cwd://` payload (raw path, no encoding). Parsed
+/// by hand rather than with a URL crate: these are the only URLs the
+/// terminal core looks at, and a general parser costs an IDNA/Unicode
+/// stack just to reach `.path()`.
 ///
 /// Anything on the other end of the PTY can send this, including a shell on the
 /// far side of an ssh session, so a directory that belongs to another machine is
@@ -211,11 +221,10 @@ const FILE_SCHEME: &str = "file://";
 pub(super) fn parse_current_directory(param: &[u8]) -> Option<String> {
     let s = simd_utf8::from_utf8_fast(param).ok()?;
 
-    // Schemes are case-insensitive.
-    let after_scheme = s
-        .get(..FILE_SCHEME.len())
-        .filter(|scheme| scheme.eq_ignore_ascii_case(FILE_SCHEME))
-        .map(|_| &s[FILE_SCHEME.len()..])?;
+    let (after_scheme, percent_encoded) = match strip_scheme(s, FILE_SCHEME) {
+        Some(rest) => (rest, true),
+        None => (strip_scheme(s, KITTY_SHELL_CWD_SCHEME)?, false),
+    };
 
     // The path begins at the host's trailing slash. A payload with no path at
     // all leaves nothing to report.
@@ -226,6 +235,12 @@ pub(super) fn parse_current_directory(param: &[u8]) -> Option<String> {
     if !host_is_local(host) {
         tracing::warn!("ignoring OSC 7 for non-local host {host:?}");
         return None;
+    }
+
+    if !percent_encoded {
+        // The kitty flavor is the path verbatim: `?`, `#` and `%` are
+        // path bytes, not URL syntax.
+        return Some(path.to_string());
     }
 
     // A query or fragment is not part of the path.
@@ -511,6 +526,43 @@ mod tests {
 
         // No path component at all.
         assert_eq!(cwd("file://localhost"), None);
+        assert_eq!(cwd("kitty-shell-cwd://localhost"), None);
+    }
+
+    #[test]
+    fn current_directory_accepts_kitty_shell_cwd() {
+        assert_eq!(
+            cwd("kitty-shell-cwd:///home/user"),
+            Some("/home/user".into())
+        );
+        assert_eq!(
+            cwd("kitty-shell-cwd://localhost/home/user"),
+            Some("/home/user".into())
+        );
+        // Scheme is case-insensitive, like file://.
+        assert_eq!(
+            cwd("KITTY-SHELL-CWD:///home/user"),
+            Some("/home/user".into())
+        );
+    }
+
+    #[test]
+    fn kitty_shell_cwd_is_verbatim() {
+        // Raw spaces pass through, and percent sequences are path
+        // bytes rather than encodings.
+        assert_eq!(cwd("kitty-shell-cwd:///tmp/a b"), Some("/tmp/a b".into()));
+        assert_eq!(
+            cwd("kitty-shell-cwd:///tmp/50%25 off?really"),
+            Some("/tmp/50%25 off?really".into())
+        );
+    }
+
+    #[test]
+    fn kitty_shell_cwd_rejects_remote_hosts() {
+        assert_eq!(
+            cwd("kitty-shell-cwd://other-machine.example/home/user"),
+            None
+        );
     }
 
     #[cfg(not(windows))]

--- a/rio-vt/src/performer/osc.rs
+++ b/rio-vt/src/performer/osc.rs
@@ -557,6 +557,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn kitty_shell_cwd_rejects_remote_hosts() {
         assert_eq!(

--- a/rio-vt/src/performer/osc.rs
+++ b/rio-vt/src/performer/osc.rs
@@ -578,6 +578,7 @@ mod tests {
         assert_eq!(parse(&[b"9", b"9", b"\"\""]), None);
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn current_directory_accepts_kitty_shell_cwd() {
         assert_eq!(
@@ -595,6 +596,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn kitty_shell_cwd_is_verbatim() {
         // Raw spaces pass through, and percent sequences are path
@@ -603,6 +605,22 @@ mod tests {
         assert_eq!(
             cwd("kitty-shell-cwd:///tmp/50%25 off?really"),
             Some("/tmp/50%25 off?really".into())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn kitty_shell_cwd_strips_windows_leading_slash() {
+        // The PowerShell integration emits `/C:\...`; the drive letter
+        // must come back without the URL-shaped leading slash, and the
+        // path stays verbatim (spaces, `#`, `%` untouched).
+        assert_eq!(
+            cwd("kitty-shell-cwd:///C:\\Users\\a b"),
+            Some("C:\\Users\\a b".into())
+        );
+        assert_eq!(
+            cwd("kitty-shell-cwd://localhost/C:\\projects\\c#"),
+            Some("C:\\projects\\c#".into())
         );
     }
 

--- a/rio-vt/src/performer/osc.rs
+++ b/rio-vt/src/performer/osc.rs
@@ -383,6 +383,32 @@ pub(super) fn parse_progress_report(params: &[&[u8]]) -> Option<ProgressReport> 
     Some(ProgressReport { state, progress })
 }
 
+/// OSC 9;9: ConEmu/Windows-Terminal working directory report, the
+/// Windows counterpart of OSC 7. Format: `9;9;<path>`, with the path
+/// optionally wrapped in double quotes. The path is verbatim (no URL
+/// encoding), and a `;` inside it comes through as extra params, so
+/// everything after `9;9;` is rejoined.
+pub(super) fn parse_conemu_working_directory(params: &[&[u8]]) -> Option<String> {
+    if params.len() < 3 || params[1] != b"9" {
+        return None;
+    }
+    let mut path = String::new();
+    for (i, param) in params[2..].iter().enumerate() {
+        if i > 0 {
+            path.push(';');
+        }
+        path.push_str(simd_utf8::from_utf8_fast(param).ok()?);
+    }
+    let path = path
+        .strip_prefix('"')
+        .and_then(|p| p.strip_suffix('"'))
+        .unwrap_or(&path);
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.to_string())
+}
+
 /// OSC 10/11/12: dynamic color set/query, applied to consecutive named
 /// colors starting at `dynamic_code - 10`.
 pub(super) fn parse_dynamic_colors(params: &[&[u8]]) -> Option<Vec<DynamicColorEntry>> {
@@ -527,6 +553,28 @@ mod tests {
         // No path component at all.
         assert_eq!(cwd("file://localhost"), None);
         assert_eq!(cwd("kitty-shell-cwd://localhost"), None);
+    }
+
+    #[test]
+    fn conemu_working_directory() {
+        let parse = parse_conemu_working_directory;
+        assert_eq!(
+            parse(&[b"9", b"9", b"C:\\Users\\rapha"]),
+            Some("C:\\Users\\rapha".into())
+        );
+        // Windows Terminal profiles commonly quote the path.
+        assert_eq!(
+            parse(&[b"9", b"9", b"\"C:\\Program Files\""]),
+            Some("C:\\Program Files".into())
+        );
+        // A `;` in the path arrives as extra params and is rejoined.
+        assert_eq!(parse(&[b"9", b"9", b"C:\\a", b"b"]), Some("C:\\a;b".into()));
+
+        // Progress reports and notifications are not directories.
+        assert_eq!(parse(&[b"9", b"4", b"1", b"50"]), None);
+        assert_eq!(parse(&[b"9", b"hello"]), None);
+        assert_eq!(parse(&[b"9", b"9", b""]), None);
+        assert_eq!(parse(&[b"9", b"9", b"\"\""]), None);
     }
 
     #[test]

--- a/rio-vt/src/performer/osc.rs
+++ b/rio-vt/src/performer/osc.rs
@@ -384,30 +384,56 @@ pub(super) fn parse_progress_report(params: &[&[u8]]) -> Option<ProgressReport> 
     Some(ProgressReport { state, progress })
 }
 
+/// Rejoin `params[from..]` with the `;` the OSC parser split on, so a
+/// payload defined as verbatim text survives a `;` inside it.
+pub(super) fn join_params(params: &[&[u8]], from: usize) -> Option<String> {
+    Some(
+        params
+            .get(from..)?
+            .iter()
+            .map(|param| simd_utf8::from_utf8_fast(param).ok())
+            .collect::<Option<Vec<_>>>()?
+            .join(";"),
+    )
+}
+
 /// OSC 9;9: ConEmu/Windows-Terminal working directory report, the
 /// Windows counterpart of OSC 7. Format: `9;9;<path>`, with the path
-/// optionally wrapped in double quotes. The path is verbatim (no URL
-/// encoding), and a `;` inside it comes through as extra params, so
-/// everything after `9;9;` is rejoined.
+/// optionally wrapped in double quotes and travelling verbatim (no URL
+/// encoding), so everything after `9;9;` is rejoined.
+///
+/// The sequence carries no host field, so unlike OSC 7 a remote shell
+/// cannot be told apart from a local one (ConEmu and Windows Terminal
+/// accept the same). Requiring an absolute path at least drops
+/// free-text payloads and relative garbage.
 pub(super) fn parse_conemu_working_directory(params: &[&[u8]]) -> Option<String> {
     if params.len() < 3 || params[1] != b"9" {
         return None;
     }
-    let mut path = String::new();
-    for (i, param) in params[2..].iter().enumerate() {
-        if i > 0 {
-            path.push(';');
-        }
-        path.push_str(simd_utf8::from_utf8_fast(param).ok()?);
-    }
+    let path = join_params(params, 2)?;
     let path = path
         .strip_prefix('"')
         .and_then(|p| p.strip_suffix('"'))
         .unwrap_or(&path);
-    if path.is_empty() {
+    if !is_absolute_path(path) {
         return None;
     }
     Some(path.to_string())
+}
+
+/// Whether `path` is absolute in either flavor a cwd report can carry:
+/// a POSIX `/` root or a Windows drive-letter root. UNC (`\\server`)
+/// is refused: it names another machine, which the host-checked OSC 7
+/// flavors refuse too.
+fn is_absolute_path(path: &str) -> bool {
+    if path.starts_with('/') {
+        return true;
+    }
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
 }
 
 /// OSC 10/11/12: dynamic color set/query, applied to consecutive named
@@ -576,6 +602,26 @@ mod tests {
         assert_eq!(parse(&[b"9", b"hello"]), None);
         assert_eq!(parse(&[b"9", b"9", b""]), None);
         assert_eq!(parse(&[b"9", b"9", b"\"\""]), None);
+
+        // Only absolute paths: free text and relative paths are not a
+        // cwd, and UNC names another machine like a remote OSC 7 host.
+        assert_eq!(parse(&[b"9", b"9", b"Meeting at 5"]), None);
+        assert_eq!(parse(&[b"9", b"9", b"..\\up"]), None);
+        assert_eq!(parse(&[b"9", b"9", b"\\\\server\\share"]), None);
+        assert_eq!(
+            parse(&[b"9", b"9", b"/home/user"]),
+            Some("/home/user".into())
+        );
+    }
+
+    #[test]
+    fn join_params_restores_split_semicolons() {
+        assert_eq!(
+            join_params(&[b"7", b"kitty-shell-cwd://h/tmp/a", b"b"], 1),
+            Some("kitty-shell-cwd://h/tmp/a;b".into())
+        );
+        assert_eq!(join_params(&[b"7", b"x"], 1), Some("x".into()));
+        assert_eq!(join_params(&[b"7"], 1), Some(String::new()));
     }
 
     #[cfg(not(windows))]
@@ -594,6 +640,14 @@ mod tests {
             cwd("KITTY-SHELL-CWD:///home/user"),
             Some("/home/user".into())
         );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn kitty_shell_cwd_keeps_semicolons_after_rejoin() {
+        // The handler rejoins split params before calling the parser.
+        let payload = join_params(&[b"7", b"kitty-shell-cwd:///tmp/a", b"b"], 1).unwrap();
+        assert_eq!(cwd(&payload), Some("/tmp/a;b".into()));
     }
 
     #[cfg(not(windows))]

--- a/rio-vt/src/performer/osc.rs
+++ b/rio-vt/src/performer/osc.rs
@@ -237,6 +237,11 @@ pub(super) fn parse_current_directory(param: &[u8]) -> Option<String> {
         return None;
     }
 
+    // Windows paths arrive as `/C:/...` in both flavors; drop the
+    // leading slash.
+    #[cfg(windows)]
+    let path = path.strip_prefix('/').unwrap_or(path);
+
     if !percent_encoded {
         // The kitty flavor is the path verbatim: `?`, `#` and `%` are
         // path bytes, not URL syntax.
@@ -245,10 +250,6 @@ pub(super) fn parse_current_directory(param: &[u8]) -> Option<String> {
 
     // A query or fragment is not part of the path.
     let path = &path[..path.find(['?', '#']).unwrap_or(path.len())];
-
-    // Windows paths arrive as `/C:/...`; drop the leading slash.
-    #[cfg(windows)]
-    let path = path.strip_prefix('/').unwrap_or(path);
 
     percent_decode(path)
 }

--- a/teletypewriter/examples/spawn.rs
+++ b/teletypewriter/examples/spawn.rs
@@ -8,7 +8,7 @@ fn main() -> std::io::Result<()> {
     use std::io::BufReader;
     use teletypewriter::{create_pty_with_fork, ProcessReadWrite, Pty};
 
-    let mut process: Pty = create_pty_with_fork(Some("bash"), &[], 80, 25, 0, 0)?;
+    let mut process: Pty = create_pty_with_fork(Some("bash"), &[], &[], 80, 25, 0, 0)?;
 
     process.writer().write_all(b"1").unwrap();
     process.writer().write_all(b"2").unwrap();

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -61,6 +61,22 @@ extern "C" {
     fn ptsname(fd: *mut libc::c_int) -> *mut libc::c_char;
 }
 
+/// Export `envs` in the forked child before exec. Runs post-fork, so
+/// keep it to setenv: the allocations match what `default_shell_command`
+/// already does on this path.
+fn set_child_envs(envs: &[(String, String)]) {
+    for (key, value) in envs {
+        let (Ok(key), Ok(value)) =
+            (CString::new(key.as_str()), CString::new(value.as_str()))
+        else {
+            continue;
+        };
+        unsafe {
+            libc::setenv(key.as_ptr(), value.as_ptr(), 1);
+        }
+    }
+}
+
 fn default_shell_command(shell: &str, args: &[String]) {
     // Ignored signal dispositions survive exec (unlike caught
     // handlers), so the shell inherits whatever the launcher left
@@ -733,6 +749,7 @@ pub fn create_pty_with_spawn(
 pub fn create_pty_with_fork(
     shell: Option<&str>,
     args: &[String],
+    envs: &[(String, String)],
     columns: u16,
     rows: u16,
     width: u16,
@@ -771,6 +788,7 @@ pub fn create_pty_with_fork(
         )
     } {
         0 => {
+            set_child_envs(envs);
             default_shell_command(shell_program, args);
             Err(Error::other(format!(
                 "forkpty has reach unreachable with {shell_program}"

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -619,6 +619,14 @@ pub fn create_pty_with_spawn(
                 "--env=TERM=rio".to_string(),
             ];
 
+            // Only `--env=` crosses the sandbox boundary: variables set
+            // on flatpak-spawn itself never reach the host process.
+            if let Some(env) = &env {
+                for (key, value) in env {
+                    with_args.push(format!("--env={key}={value}"));
+                }
+            }
+
             if let Some(directory) = working_directory {
                 with_args.push(format!(
                     "--directory={}",

--- a/teletypewriter/src/unix/mod.rs
+++ b/teletypewriter/src/unix/mod.rs
@@ -453,14 +453,13 @@ impl ShellUser {
 ///
 /// Build the argv passed to login(1) on macOS.
 ///
-/// A custom command (non empty args) goes straight into login's argv:
-/// login execvp's it, so args pass through as single words with no
-/// intermediate shell that could word split them.
-///
-/// A bare shell becomes a login shell through a bash intermediate that
-/// execs it with `-l`, which prepends the dash to argv[0]. bash runs
-/// with `--noprofile --norc` so user startup files cannot interfere
-/// with the exec.
+/// The shell always becomes a login shell through a bash intermediate
+/// that execs it with `-l`, which prepends the dash to argv[0]. The
+/// shell program rides as `$0` and any args as `"$@"`, so no quoting
+/// or word splitting can touch them (this also keeps login semantics
+/// when integration or the user adds args to the default shell). bash
+/// runs with `--noprofile --norc` so user startup files cannot
+/// interfere with the exec.
 #[cfg(any(target_os = "macos", test))]
 fn login_argv(
     hushlogin: bool,
@@ -480,17 +479,13 @@ fn login_argv(
     argv.push("-flp".to_string());
     argv.push(username.to_string());
 
-    if args.is_empty() {
-        let quoted = shell_program.replace('\'', "'\\''");
-        argv.push("/bin/bash".to_string());
-        argv.push("--noprofile".to_string());
-        argv.push("--norc".to_string());
-        argv.push("-c".to_string());
-        argv.push(format!("exec -l '{quoted}'"));
-    } else {
-        argv.push(shell_program.to_string());
-        argv.extend(args.iter().cloned());
-    }
+    argv.push("/bin/bash".to_string());
+    argv.push("--noprofile".to_string());
+    argv.push("--norc".to_string());
+    argv.push("-c".to_string());
+    argv.push(r#"exec -l "$0" "$@""#.to_string());
+    argv.push(shell_program.to_string());
+    argv.extend(args.iter().cloned());
 
     argv
 }
@@ -746,6 +741,16 @@ pub fn create_pty_with_spawn(
 ///
 /// It returns two [`Pty`] along with respective process name [`String`] and process id (`libc::pid_`)
 ///
+/// The shell a spawn falls back to when none is configured: `$SHELL`,
+/// else the passwd entry. Public so per-shell decisions made before
+/// spawning (title program name, shell integration) match what
+/// actually spawns.
+pub fn default_shell_program() -> String {
+    ShellUser::from_env()
+        .map(|user| user.shell)
+        .unwrap_or_default()
+}
+
 pub fn create_pty_with_fork(
     shell: Option<&str>,
     args: &[String],
@@ -1142,7 +1147,8 @@ mod login_argv_tests {
                 "--noprofile",
                 "--norc",
                 "-c",
-                "exec -l '/bin/zsh'",
+                r#"exec -l "$0" "$@""#,
+                "/bin/zsh",
             ]
         );
     }
@@ -1155,7 +1161,7 @@ mod login_argv_tests {
     }
 
     #[test]
-    fn custom_command_goes_directly_to_login() {
+    fn args_ride_as_positional_words_and_keep_login() {
         let args = vec!["-c".to_string(), "echo hello world; sleep 1".to_string()];
         let argv = login_argv(false, "rapha", "/bin/bash", &args);
         assert_eq!(
@@ -1164,6 +1170,11 @@ mod login_argv_tests {
                 "-flp",
                 "rapha",
                 "/bin/bash",
+                "--noprofile",
+                "--norc",
+                "-c",
+                r#"exec -l "$0" "$@""#,
+                "/bin/bash",
                 "-c",
                 "echo hello world; sleep 1",
             ]
@@ -1171,9 +1182,11 @@ mod login_argv_tests {
     }
 
     #[test]
-    fn quotes_in_shell_path_are_escaped() {
+    fn shell_path_needs_no_quoting() {
+        // The program travels as `$0`, never inside the -c string, so
+        // quotes and spaces in the path cannot break the exec.
         let argv = login_argv(false, "rapha", "/tmp/it's a shell", &[]);
-        assert_eq!(argv.last().unwrap(), "exec -l '/tmp/it'\\''s a shell'");
+        assert_eq!(argv.last().unwrap(), "/tmp/it's a shell");
     }
 }
 

--- a/teletypewriter/src/windows/conpty.rs
+++ b/teletypewriter/src/windows/conpty.rs
@@ -107,7 +107,9 @@ unsafe impl Send for Conpty {}
 
 /// Builds a `CREATE_UNICODE_ENVIRONMENT` block from the current process
 /// environment plus `extra_env` (which overrides inherited variables of the
-/// same name): NUL-terminated `KEY=VALUE` UTF-16 entries, with a trailing NUL.
+/// same name): NUL-terminated `KEY=VALUE` UTF-16 entries, with a trailing
+/// NUL. Sorted case-insensitively by name, which the CreateProcess
+/// documentation requires of Unicode environment blocks.
 fn environment_block(extra_env: Vec<(String, String)>) -> Vec<u16> {
     let mut vars: Vec<(std::ffi::OsString, std::ffi::OsString)> =
         std::env::vars_os().collect();
@@ -116,6 +118,11 @@ fn environment_block(extra_env: Vec<(String, String)>) -> Vec<u16> {
         vars.retain(|(existing, _)| !existing.eq_ignore_ascii_case(&key));
         vars.push((key, value.into()));
     }
+    vars.sort_by(|(a, _), (b, _)| {
+        a.to_string_lossy()
+            .to_uppercase()
+            .cmp(&b.to_string_lossy().to_uppercase())
+    });
 
     let mut block = Vec::new();
     for (key, value) in vars {


### PR DESCRIPTION
Rio's title path variables and cwd inheritance rely on the shell reporting its working directory, but until now that required the user to configure their shell. This PR makes it work out of the box on every platform:

- Rio embeds small integration scripts and injects them automatically at spawn. zsh and fish load through the environment alone: `ZDOTDIR` for zsh (the user's value is preserved and restored before any of their configuration runs, and their real `.zshenv` is chained first) and an `XDG_DATA_DIRS` prepend for fish (`vendor_conf.d`). The scripts emit OSC 7 on every prompt and directory change and are original to rio.
- PowerShell (powershell.exe and pwsh, on Windows and unix) has no environment hook, so a bare spawn is rewritten to `-NoExit -Command . '<script>'`, running after the user's profile, the same mechanism VS Code uses for automatic injection. Configured shell args win over integration and skip the rewrite. The script wraps the prompt function and emits the cwd as a `file://` URI, so spaces and UNC paths are handled by the existing parser rules (remote UNC hosts are refused).
- Scripts are written under the cache directory once per rio version, so upgrades refresh them and installs need no packaging changes.
- The OSC 7 parser now also accepts the `kitty-shell-cwd://` scheme (a raw, unencoded path), so existing kitty-style shell integrations work with rio unchanged.
- New: `OSC 9;9` (ConEmu/Windows Terminal working directory) is parsed as a cwd report. Previously it fell into the desktop-notification fallback and produced a bogus notification; now any existing Windows Terminal `$PROFILE` works with rio as-is.
- `create_pty_with_fork` gained an env parameter so the fork spawn path (`use-fork = true`) injects the same environment as the spawn path; the Windows ConPTY path already supported env blocks and needed no teletypewriter change.
- New config option `shell-integration` (default `true`) disables the injection entirely.

Out of scope: bash needs `--posix` plus `ENV` argv surgery, cmd.exe only offers a machine-wide registry AutoRun (too invasive; clink users can source a snippet), nushell's vendor autoload story is still settling across versions, and WSL needs `WSLENV` plumbing. All are documented paths for a follow-up.

Tests: parser acceptance/verbatim/host-rejection for `kitty-shell-cwd://`, `OSC 9;9` parsing (quoted paths, `;` rejoin, non-collision with progress reports), per-shell env mapping, cross-platform shell-name normalization, PowerShell path quoting, and idempotent script materialization.
