### PR TITLE
terminfo: advertise 256 colors on xterm-rio, not just rio

### DIFF
--- a/misc/rio.terminfo
+++ b/misc/rio.terminfo
@@ -1,8 +1,5 @@
 xterm-rio,
     use=rio+base,
-
-rio,
-    use=xterm-rio,
     rs1=\Ec\E]104\007,
     ccc,
     colors#0x100, pairs#0x7FFF,
@@ -14,6 +11,9 @@ rio,
     setaf=\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5
           ;%p1%d%;m,
     setb@, setf@,
+
+rio,
+    use=xterm-rio,
 
 rio+base,
     OTbs, am, bce, km, mir, msgr, xenl, AX, XT,


### PR DESCRIPTION
## Problem

`misc/rio.terminfo` puts the 256-color capabilities (`colors#0x100`, `pairs#0x7FFF`, `ccc`, `initc`, `oc`, the 256-color `setaf`/`setab`, `setb@`/`setf@`, and the palette-resetting `rs1`) only on the `rio` entry. `xterm-rio` is just `use=rio+base`, and `rio+base` declares `colors#8` with 8-color-only `setaf`/`setab`.

rioterm prefers `TERM=xterm-rio` whenever that entry is installed (`frontends/rioterm/src/main.rs`), so every real session gets the 8-color entry:

```
$ infocmp xterm-rio | grep colors
colors#8
```

Programs that trust terminfo degrade accordingly:

- zsh emits "default foreground" (`\e[39m`) for colors 8..255 because it can't express them via `setaf`. zsh-autosuggestions' default `fg=8` ghost text renders in the normal text color instead of grey.
- tmux caps rendering at 8 colors.
- vim/neovim see `t_Co=8`.
- ncurses apps use the 8-color sequences.

Every other modern terminal's primary entry (`xterm-ghostty`, `alacritty`, `xterm-256color`) advertises 256.

## Fix

Move the 256-color block onto `xterm-rio` and leave `rio` as a plain `use=xterm-rio` alias. Both names now resolve to identical capabilities.

## Verification

```
$ tic -x -o /tmp/ti misc/rio.terminfo
$ TERMINFO=/tmp/ti infocmp -d rio xterm-rio     # no differences
$ TERMINFO=/tmp/ti TERM=xterm-rio zsh -c 'echoti colors; print -P "%F{8}x%f" | cat -v'
256
^[[90mx^[[39m       # was: 8 / ^[[39mx^[[39m
```

`tic -xe xterm-rio,rio` (the Makefile invocation) compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQ7Dj9bymq2j1RohfqxT2g
