### PR TITLE
terminfo: 256 colors and truecolor caps on xterm-rio

### DIFF
--- a/misc/rio.terminfo
+++ b/misc/rio.terminfo
@@ -1,8 +1,4 @@
 xterm-rio,
-    use=rio+base,
-
-rio,
-    use=xterm-rio,
     rs1=\Ec\E]104\007,
     ccc,
     colors#0x100, pairs#0x7FFF,
@@ -14,6 +10,13 @@ rio,
     setaf=\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5
           ;%p1%d%;m,
     setb@, setf@,
+    Tc,
+    setrgbb=\E[48\:2\:%p1%d\:%p2%d\:%p3%dm,
+    setrgbf=\E[38\:2\:%p1%d\:%p2%d\:%p3%dm,
+    use=rio+base,
+
+rio,
+    use=xterm-rio,
 
 rio+base,
     OTbs, am, bce, km, mir, msgr, xenl, AX, XT,


### PR DESCRIPTION
Supersedes #1924 (thanks @Brumor, authorship preserved).

`xterm-rio` inherited only `rio+base` (colors#8, 8-color setaf/setab) while the 256-color block lived on `rio`. Since rioterm prefers `xterm-rio` when installed, real sessions got 8 colors: zsh %F{8} emitted default-foreground, tmux capped at 8, vim t_Co was 8.

Changes on top of #1924:

- Move the 256-color overrides and `setb@`/`setf@` cancels above the `use=rio+base` reference. ncurses tic resolves either order, but terminfo(5) override/cancel semantics are positional, so a strict SVr4 tic (Solaris/AIX) would let the base's colors#8 win.
- Add truecolor caps `Tc`, `setrgbf`, `setrgbb` (same values as ghostty/kitty). Rio sets COLORTERM=truecolor and parses SGR 38;2, but without these, tmux over ssh (no COLORTERM forwarding) quantizes to 256 colors. The ncurses `RGB` boolean is deliberately omitted since it changes color-pair semantics.

Verified with `tic -xe xterm-rio,rio`: the only capability delta vs #1924 is the three truecolor caps, `infocmp -d rio xterm-rio` reports no differences, and `tput -T xterm-rio colors` reports 256.