### PR TITLE
rioterm: use vi-cursor color while in Vi mode

### DIFF
--- a/frontends/rioterm/src/context/renderable.rs
+++ b/frontends/rioterm/src/context/renderable.rs
@@ -103,6 +103,9 @@ pub struct RenderableContent {
     pub atlas_placements: Vec<AtlasPlacement>,
     /// `true` when the terminal has cursor blink enabled this frame.
     pub blinking_cursor: bool,
+    /// `true` when the terminal was in Vi mode at snapshot time, so
+    /// the cursor is drawn with the `vi-cursor` color.
+    pub is_vi_mode: bool,
     /// Kitty graphics state captured under the snapshot lock. Owned
     /// here so the kitty overlay path doesn't need to lock again.
     pub kitty_virtual_placements: FxHashMap<(u32, u32), VirtualPlacement>,
@@ -137,6 +140,7 @@ impl RenderableContent {
             lines_evicted: 0,
             atlas_placements: Vec::new(),
             blinking_cursor: false,
+            is_vi_mode: false,
             kitty_virtual_placements: FxHashMap::default(),
             kitty_images: FxHashMap::default(),
             kitty_placements: Vec::new(),

--- a/frontends/rioterm/src/renderer/mod.rs
+++ b/frontends/rioterm/src/renderer/mod.rs
@@ -22,6 +22,7 @@ use rio_backend::event::TerminalDamage;
 use crate::context::renderable::{PendingUpdate, RenderableContent};
 use crate::context::ContextManager;
 use crate::crosswords::style::{Style as CellStyle, StyleFlags};
+use crate::crosswords::Mode;
 use rio_backend::config::colors::term::TermColors;
 use rio_backend::config::colors::{
     term::{List, DIM_FACTOR},
@@ -405,6 +406,18 @@ impl Renderer {
         }
     }
 
+    /// Cursor color for a panel. In Vi mode the configured `vi-cursor`
+    /// color is used; otherwise OSC 12 wins over the theme `cursor`.
+    /// `List::fill_named` skips the Cursor slot, so the named colors
+    /// are read directly instead of going through `Renderer::color`.
+    #[inline]
+    pub fn cursor_color(&self, term_colors: &TermColors, is_vi_mode: bool) -> ColorArray {
+        if is_vi_mode {
+            return self.named_colors.vi_cursor;
+        }
+        term_colors[NamedColor::Cursor as usize].unwrap_or(self.named_colors.cursor)
+    }
+
     #[inline]
     pub fn set_vi_mode(&mut self, is_vi_mode_enabled: bool) {
         self.is_vi_mode_enabled = is_vi_mode_enabled;
@@ -523,6 +536,8 @@ impl Renderer {
                 context.renderable_content.lines_evicted = terminal.lines_evicted();
                 context.renderable_content.blinking_cursor = terminal.blinking_cursor;
                 context.renderable_content.cursor.state = terminal.cursor();
+                context.renderable_content.is_vi_mode =
+                    terminal.mode().contains(Mode::VI);
                 if terminal.graphics.kitty_graphics_dirty {
                     context.renderable_content.kitty_virtual_placements =
                         terminal.graphics.kitty_virtual_placements.clone();
@@ -1462,5 +1477,49 @@ mod grid_cell_bg_tests {
             rio_grid::cell_bg(Square::from_char('x'), style, &renderer, &colors),
             [0, 0, 0, 0]
         );
+    }
+}
+
+#[cfg(test)]
+mod cursor_color_tests {
+    use super::*;
+
+    const CURSOR: ColorArray = [1.0, 0.4, 0.0, 1.0];
+    const VI_CURSOR: ColorArray = [1.0, 1.0, 0.0, 1.0];
+    const OSC_12: ColorArray = [0.0, 0.5, 1.0, 1.0];
+
+    fn renderer() -> Renderer {
+        Renderer::new(&Config {
+            colors: Colors {
+                cursor: CURSOR,
+                vi_cursor: VI_CURSOR,
+                ..Colors::default()
+            },
+            ..Config::default()
+        })
+    }
+
+    #[test]
+    fn uses_cursor_color_outside_vi_mode() {
+        let r = renderer();
+        assert_eq!(r.cursor_color(&TermColors::default(), false), CURSOR);
+    }
+
+    /// The reported bug: `vi-cursor` was parsed but the cursor kept
+    /// the `cursor` color after entering Vi mode.
+    #[test]
+    fn uses_vi_cursor_color_in_vi_mode() {
+        let r = renderer();
+        assert_eq!(r.cursor_color(&TermColors::default(), true), VI_CURSOR);
+    }
+
+    #[test]
+    fn osc_12_overrides_cursor_color_only_outside_vi_mode() {
+        let r = renderer();
+        let mut colors = TermColors::default();
+        colors[NamedColor::Cursor as usize] = Some(OSC_12);
+
+        assert_eq!(r.cursor_color(&colors, false), OSC_12);
+        assert_eq!(r.cursor_color(&colors, true), VI_CURSOR);
     }
 }

--- a/frontends/rioterm/src/screen/mod.rs
+++ b/frontends/rioterm/src/screen/mod.rs
@@ -3966,7 +3966,11 @@ impl Screen<'_> {
                     current.route_id,
                 );
 
-                let cursor_color = self.renderer.named_colors.cursor;
+                let cursor_color = if current.renderable_content.is_vi_mode {
+                    self.renderer.named_colors.vi_cursor
+                } else {
+                    self.renderer.named_colors.cursor
+                };
                 self.renderer.trail_cursor.draw(
                     &mut self.sugarloaf,
                     scale_factor,
@@ -4037,8 +4041,8 @@ impl Screen<'_> {
                 /// configured shape so the user can tell IME is
                 /// taking input.
                 cursor_preedit: bool,
-                /// Resolved cursor color: OSC 12 wins, then config /
-                /// theme `cursor`.
+                /// Resolved cursor color: `vi-cursor` in Vi mode,
+                /// otherwise OSC 12 wins, then config / theme `cursor`.
                 /// `state.colors.cursor → config.cursor_color`
                 /// resolution. Per-panel
                 /// because each terminal can issue its own OSC 12.
@@ -4192,14 +4196,11 @@ impl Screen<'_> {
                     None
                 };
                 let cursor_preedit = preedit_line.is_some();
-                // OSC 12 wins; otherwise fall back to the named-color
-                // theme value. `Renderer::color`'s fallback (the
-                // indexed-color List) is not populated for the Cursor
-                // slot — `List::fill_named` skips it — so we read
-                // `named_colors.cursor` directly.
-                let cursor_color = term_colors
-                    [rio_backend::config::colors::NamedColor::Cursor as usize]
-                    .unwrap_or(self.renderer.named_colors.cursor);
+                // `vi-cursor` in Vi mode; otherwise OSC 12, then the
+                // theme `cursor`.
+                let cursor_color = self
+                    .renderer
+                    .cursor_color(&term_colors, ctx.renderable_content.is_vi_mode);
                 panels.push(PanelFrame {
                     route_id: ctx.route_id,
                     layout_rect: item.layout_rect,


### PR DESCRIPTION
The `vi-cursor` color from `[colors]` was parsed but never read, so the cursor kept the `cursor` color (or the OSC 12 color) after entering Vi mode. Each context now records whether its terminal is in Vi mode when the frame is snapshotted, and the cursor and trail cursor use `vi-cursor` while it is on. I added unit tests for the color choice (they fail on main) and ran `cargo test -p rioterm`, `cargo fmt --check` and `cargo clippy -p rioterm --all-targets -- -D warnings`.

Fixes #1904
